### PR TITLE
Uses trim_punctuation_custom for title display fields.

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -80,13 +80,25 @@ to_field 'vern_title_variant_search', extract_marc('210ab:222ab:242abnp:243adfgk
 to_field 'title_related_search', extract_marc('505t:700fgklmnoprst:710dfgklmnoprst:711fgklnpst:730adfgklmnoprst:740anp:760st:762st:765st:767st:770st:772st:773st:774st:775st:776st:777st:780st:785st:786st:787st:796fgklmnoprst:797dfgklmnoprst:798fgklnpst:799adfgklmnoprst')
 to_field 'vern_title_related_search', extract_marc('505t:700fgklmnoprst:710dfgklmnoprst:711fgklnpst:730adfgklmnoprst:740anp:760st:762st:765st:767st:770st:772st:773st:774st:775st:776st:777st:780st:785st:786st:787st:796fgklmnoprst:797dfgklmnoprst:798fgklnpst:799adfgklmnoprst', alternate_script: :only)
 # Title Display Fields
-to_field 'title_245a_display', extract_marc('245a', alternate_script: false, trim_punctuation: true)
-to_field 'vern_title_245a_display', extract_marc('245a', alternate_script: :only, trim_punctuation: true)
-to_field 'title_245c_display', extract_marc('245c', alternate_script: false, trim_punctuation: true)
-to_field 'vern_title_245c_display', extract_marc('245c', alternate_script: :only, trim_punctuation: true)
-to_field 'title_display', extract_marc('245abdefghijklmnopqrstuvwxyz', alternate_script: false, trim_punctuation: true)
-to_field 'vern_title_display', extract_marc('245abdefghijklmnopqrstuvwxyz', alternate_script: :only, trim_punctuation: true)
-to_field 'title_full_display', extract_marc("245#{ALPHABET}", first: true, alternate_script: false)
+to_field 'title_245a_display', extract_marc('245a', alternate_script: false) do |record, accumulator|
+  accumulator.map!(&method(:trim_punctuation_custom))
+end
+to_field 'vern_title_245a_display', extract_marc('245a', alternate_script: :only) do |record, accumulator|
+  accumulator.map!(&method(:trim_punctuation_custom))
+end
+to_field 'title_245c_display', extract_marc('245c', alternate_script: false) do |record, accumulator|
+  accumulator.map!(&method(:trim_punctuation_custom))
+end
+to_field 'vern_title_245c_display', extract_marc('245c', alternate_script: :only) do |record, accumulator|
+  accumulator.map!(&method(:trim_punctuation_custom))
+end
+to_field 'title_display', extract_marc('245abdefghijklmnopqrstuvwxyz', alternate_script: false) do |record, accumulator|
+  accumulator.map!(&method(:trim_punctuation_custom))
+end
+to_field 'vern_title_display', extract_marc('245abdefghijklmnopqrstuvwxyz', alternate_script: :only) do |record, accumulator|
+  accumulator.map!(&method(:trim_punctuation_custom))
+end
+to_field 'title_full_display', extract_marc("245#{ALPHABET}", first: true, alternate_script: :false)
 to_field 'vern_title_full_display', extract_marc("245#{ALPHABET}", alternate_script: :only)
 to_field 'title_uniform_display', extract_marc(%w(130 240).map { |c| "#{c}#{ALPHABET}" }.join(':'), first: true, alternate_script: false)
 # # ? no longer will use title_uniform_display due to author-title searching needs ? 2010-11

--- a/spec/lib/traject/config/title_spec.rb
+++ b/spec/lib/traject/config/title_spec.rb
@@ -320,7 +320,6 @@ RSpec.describe 'Title spec' do
       expect(select_by_id('245pNotn')[field]).to eq ['245 p but no n. subfield b Student handbook']
       expect(select_by_id('245nAndp')[field]).to eq ['245 n and p: A, The humanities and social sciences']
       expect(select_by_id('245multpn')[field]).to eq ['245 multiple p, n first p subfield first n subfield second p subfield second n subfield']
-      pending 'legacy test has punctuation at end here, but claims to trim punctuation'
       expect(select_by_id('245nNotp')[field]).to eq ['245 n but no p Part one.']
     end
     context 'trailing punctuation' do


### PR DESCRIPTION
Per solrmarc-sw config, trailing periods should be preceded by four or more letters.