### PR TITLE
no scan to prevent thread issues on jruby

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1327,7 +1327,7 @@ to_field 'callnum_facet_hsim' do |record, accumulator|
     translation_map = Traject::TranslationMap.new('call_number')
     cn = holding.call_number.normalized_lc
     first_letter = cn[0, 1].upcase
-    letters = cn.split(/[^A-Z]+/).first
+    letters = cn[/^[A-Z]+/]
 
     next unless first_letter && translation_map[first_letter]
 


### PR DESCRIPTION
Fixes #118 .

I'm not seeing issues with other `splits` at the moment just this one. Ran indexing locally to confirm.