### PR TITLE
Skips records that are missing item_display field

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1839,8 +1839,6 @@ to_field 'building_facet', extract_marc('596a', translation_map: 'library_on_ord
   accumulator.replace library_map.translate_array(accumulator)
 end
 
-# item_display = customDeleteRecordIfFieldEmpty, getItemDisplay
-
 to_field 'item_display' do |record, accumulator|
   record.each_by_tag('999') do |item_999|
     holding = SirsiHolding.new(
@@ -1869,6 +1867,12 @@ to_field 'item_display' do |record, accumulator|
       holding.call_number_type
     ].join(' -|- ')
   end
+end
+
+##
+# Skip records for missing `item_display` field
+each_record do |record, context|
+  context.skip!('No item_display field') if context.output_hash['item_display'].nil?
 end
 
 to_field 'on_order_library_ssim', extract_marc('596a', translation_map: 'library_on_order_map')

--- a/spec/integration/skips_spec.rb
+++ b/spec/integration/skips_spec.rb
@@ -1,0 +1,19 @@
+describe 'Skips records' do
+  let(:indexer) do
+    Traject::Indexer.new.tap do |i|
+      i.settings(
+        'solr.url' => 'http://127.0.0.1:8983/solr/fake',
+        'reader_class_name' => 'MARC::Reader',
+        'writer_class_name' => 'Traject::ArrayWriter'
+      )
+      i.load_config_file('./lib/traject/config/sirsi_config.rb')
+    end
+  end
+  let(:records) { MARC::Reader.new(file_fixture(fixture_name).to_s).to_a }
+  let(:results) { indexer.process_with(records, Traject::ArrayWriter.new).values }
+  let(:fixture_name) { 'buildingTests.mrc' }
+  it 'without an item_display field' do
+    expect(results.count).to eq 41
+    expect(records.count).to eq 45
+  end
+end


### PR DESCRIPTION
Fixes #45 

Upon investigation, it seemed that solrmarc-sw never sends off deletes, it just logs that its skipping the record.

https://github.com/sul-dlss/solrmarc-sw/blob/master/core/src/org/solrmarc/index/SolrIndexer.java#L680-L693