### PR TITLE
Provide our own HTTPClient instance with a timeout appropriate for long-running commits

### DIFF
--- a/lib/traject/config/delete_config.rb
+++ b/lib/traject/config/delete_config.rb
@@ -14,6 +14,8 @@ settings do
   if defined?(JRUBY_VERSION)
     require 'traject/manticore_http_client'
     provide 'solr_json_writer.http_client', Traject::ManticoreHttpClient.new
+  else
+    provide 'solr_json_writer.http_client', HTTPClient.new.tap { |x| x.receive_timeout = 600 }
   end
 end
 

--- a/lib/traject/config/sdr_config.rb
+++ b/lib/traject/config/sdr_config.rb
@@ -17,6 +17,8 @@ settings do
   if defined?(JRUBY_VERSION)
     require 'traject/manticore_http_client'
     provide 'solr_json_writer.http_client', Traject::ManticoreHttpClient.new
+  else
+    provide 'solr_json_writer.http_client', HTTPClient.new.tap { |x| x.receive_timeout = 600 }
   end
 end
 

--- a/lib/traject/config/sdr_delete_config.rb
+++ b/lib/traject/config/sdr_delete_config.rb
@@ -17,6 +17,8 @@ settings do
   if defined?(JRUBY_VERSION)
     require 'traject/manticore_http_client'
     provide 'solr_json_writer.http_client', Traject::ManticoreHttpClient.new
+  else
+    provide 'solr_json_writer.http_client', HTTPClient.new.tap { |x| x.receive_timeout = 600 }
   end
 end
 

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -37,6 +37,8 @@ settings do
     provide "marc4j_reader.permissive", true
     require 'traject/manticore_http_client'
     provide 'solr_json_writer.http_client', Traject::ManticoreHttpClient.new
+  else
+    provide 'solr_json_writer.http_client', HTTPClient.new.tap { |x| x.receive_timeout = 600 }
   end
   provide 'solr_json_writer.skippable_exceptions', [HTTPClient::TimeoutError, StandardError]
 end


### PR DESCRIPTION


It turns out HTTPClient uses a shared session pool that doesn't allow run-time changes to timeouts, etc that traject tries to use; instead, we need to set the receive timeout for our worst-case and hope for the best.