### PR TITLE
adds more robost schema.org record for geo content

### DIFF
--- a/lib/traject/config/sdr_config.rb
+++ b/lib/traject/config/sdr_config.rb
@@ -158,6 +158,34 @@ to_field 'set_with_title' do |record, accumulator|
   end)
 end
 
+to_field 'schema_dot_org_struct' do |record, accumulator, context|
+  ## Schema.org representation for content type geo objects
+  if record.dor_content_type == 'geo'
+    accumulator << {
+      '@context': 'http://schema.org',
+      '@type': 'Dataset',
+      citation: record.mods.xpath('//mods:note[@displayLabel="Preferred citation"]', mods: 'http://www.loc.gov/mods/v3').text,
+      identifier: context.output_hash['url_fulltext'],
+      license: record.mods.xpath('//mods:accessCondition[@type="license"]', mods: 'http://www.loc.gov/mods/v3').text,
+      name: context.output_hash['title_display'],
+      description: context.output_hash['summary_search'],
+      sameAs: "https://earthworks.stanford.edu/catalog/stanford-#{record.druid}",
+      keywords: context.output_hash['subject_all_search'],
+      includedInDataCatalog: {
+        '@type': 'DataCatalog',
+        'name': 'https://earthworks.stanford.edu'
+      },
+      distribution: [
+        {
+          '@type': 'DataDownload',
+          encodingFormat: 'application/zip',
+          contentUrl: "https://stacks.stanford.edu/file/druid:#{record.druid}/data.zip"
+        }
+      ]
+    }
+  end
+end
+
 each_record do |record, context|
   $druid_title_cache[record.druid] = record.label if record.is_collection
 end

--- a/spec/fixtures/files/vv853br8653.xml
+++ b/spec/fixtures/files/vv853br8653.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:vv853br8653" published="2018-04-09T23:03:04Z" publishVersion="dor-services/5.23.1">
+  <identityMetadata>
+    <sourceId source="branner">Pinsky2009</sourceId>
+    <objectId>druid:vv853br8653</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>Watersheds of the Pacific Salmon Conservation Assessment Study Area, 1950-2005</objectLabel>
+    <objectType>item</objectType>
+    <adminPolicy>druid:yx192qg7444</adminPolicy>
+    <otherId name="uuid">9b008d68-8d01-11e3-b3cb-0050569b3c3c</otherId>
+    <tag>Process : Content Type : File</tag>
+    <tag>Project : GIS</tag>
+    <tag>Registered By : drh</tag>
+    <tag>Dataset : GIS</tag>
+    <displayType>file</displayType>
+    <tag>Remediated By : 5.5.3</tag>
+  </identityMetadata>
+  <contentMetadata objectId="vv853br8653" type="geo">
+    <resource id="vv853br8653_1" sequence="1" type="object">
+      <label>Data</label>
+      <file id="data.zip" mimetype="application/zip" size="6506889" role="master">
+        <geoData>
+          <rdf:Description xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://purl.stanford.edu/vv853br8653">
+            <dc:format xmlns:dc="http://purl.org/dc/elements/1.1/">application/x-esri-shapefile; format=Shapefile</dc:format>
+            <dc:type xmlns:dc="http://purl.org/dc/elements/1.1/">Dataset#Polygon</dc:type>
+            <gml:boundedBy xmlns:gml="http://www.opengis.net/gml/3.2/">
+              <gml:Envelope gml:srsName="EPSG:4326">
+                <gml:lowerCorner>-180.0 24.23126</gml:lowerCorner>
+                <gml:upperCorner>180.0 73.990866</gml:upperCorner>
+              </gml:Envelope>
+            </gml:boundedBy>
+            <dc:coverage xmlns:dc="http://purl.org/dc/elements/1.1/" rdf:resource="http://sws.geonames.org/4030875/about.rdf" dc:language="eng" dc:title="North Pacific Ocean"/>
+          </rdf:Description>
+        </geoData>
+      </file>
+      <file id="data_EPSG_4326.zip" mimetype="application/zip" size="6039278" role="derivative">
+        <geoData srsName="EPSG:4326"/>
+      </file>
+    </resource>
+    <resource id="vv853br8653_2" sequence="2" type="preview">
+      <label>Preview</label>
+      <file id="preview.jpg" mimetype="image/jpeg" size="273966" role="master">
+        <imageData width="1024" height="785"/>
+      </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</human>
+      <human type="creativeCommons">CC BY-NC Attribution-NonCommercial</human>
+      <machine type="creativeCommons">by-nc</machine>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:vv853br8653">
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008</dc:title>
+    <dc:creator>Pinsky, Malin L.</dc:creator>
+    <dc:creator>Springmeyer, Dane B.</dc:creator>
+    <dc:creator>Goslin, Matthew N.</dc:creator>
+    <dc:creator>Augerot, Xanthippe</dc:creator>
+    <dc:type>Geospatial data</dc:type>
+    <dc:type>cartographic dataset</dc:type>
+    <dc:date>2009</dc:date>
+    <dc:publisher>Stanford Digital Repository</dc:publisher>
+    <dc:language>eng</dc:language>
+    <dc:format>7.793</dc:format>
+    <dc:format>Shapefile</dc:format>
+    <dc:coverage>Scale not given.</dc:coverage>
+    <dc:coverage>EPSG::4267</dc:coverage>
+    <dc:coverage>(W 180°--E 180°/N 73°59ʹ27ʺ--N 24°13ʹ53ʺ)</dc:coverage>
+    <dc:description displayLabel="Abstract">This dataset is a visualization of abundance estimates for six species of Pacific salmon (Oncorhynchus spp.): Chinook, Chum, Pink, Steelhead, Sockeye, and Coho in catchment areas of the Northern Pacific Ocean, including Canada, China, Japan, Russia, and the United States. Catchment polygons included in this layer range in dates from 1978 to 2008. Sources dating from 1950 to 2005, including published literature and agency reports were consulted in order to create these data. In addition to abundance estimates, the PCSA database includes information on distribution, diversity, run-timings, land cover/land-use, dams, hatcheries, data sources, drainages, and administrative categories and provides a consistent format for comparing watersheds across the range of wild Pacific salmon.</dc:description>
+    <dc:description displayLabel="Purpose">The Conservation Science team at the Wild Salmon Center has created a geographic database, the Pacific Salmon Conservation Assessment (PSCA) that covers the whole range of wild Pacific Salmon. By providing estimations of salmon abundance and diversity, these data can provide opportunities to conduct range-wide analysis for conservation planning, prioritizing, and assessments.  The primary goal in developing the PSCA database is to guide proactive international salmon conservation.</dc:description>
+    <dc:description displayLabel="Preferred citation">Pinsky, M.L., Springmeyer, D.B., Goslin, M.N., Augerot, X (2009). Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008. Stanford Digital Repository. Available at: http://purl.stanford.edu/vv853br8653</dc:description>
+    <dc:description displayLabel="Supplemental information">Based upon expert opinion and validation with the literature, the PSCA database accurately represents broad, range-wide patterns of salmon abundance and diversity.  Much of the data, particularly in the Russian Far East, is based upon modeling. The database offers a geo-referenced watershed dataset and twenty tables that all join on a common primary key attribute.</dc:description>
+    <dc:relation type="url" href="http://onlinelibrary.wiley.com/doi/10.1111/j.1523-1739.2008.01156.x/full">Range-Wide Selection of Catchments for Pacific Salmon Conservation</dc:relation>
+    <dc:relation type="url" href="http://purl.stanford.edu/zc193vn8689">
+      Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation."
+      </dc:relation>
+    <dc:subject>Marine habitat conservation</dc:subject>
+    <dc:subject>Freshwater habitat conservation</dc:subject>
+    <dc:subject>Pacific salmon</dc:subject>
+    <dc:subject>Conservation</dc:subject>
+    <dc:subject>Watersheds</dc:subject>
+    <dc:coverage>North Pacific Ocean</dc:coverage>
+    <dc:coverage>1978-2005</dc:coverage>
+    <dc:subject>Environment</dc:subject>
+    <dc:subject>Oceans</dc:subject>
+    <dc:subject>Inland Waters</dc:subject>
+    <dc:identifier>http://purl.stanford.edu/vv853br8653</dc:identifier>
+    <dc:coverage>Scale not given.</dc:coverage>
+    <dc:coverage>EPSG::4326</dc:coverage>
+    <dc:coverage>W 180°--E 180°/N 73°59ʹ27ʺ--N 24°13ʹ53ʺ</dc:coverage>
+    <dc:description displayLabel="WGS84 Cartographics">This layer is presented in the WGS84 coordinate system for web display purposes. Downloadable data are provided in native coordinate system or projection.</dc:description>
+  </oai_dc:dc>
+  <mods xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" version="3.4" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-4.xsd">
+    <titleInfo>
+      <title>Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008</title>
+    </titleInfo>
+    <name type="personal">
+      <namePart>Pinsky, Malin L.</namePart>
+      <role>
+        <roleTerm type="text" authority="marcrelator">creator</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart>Springmeyer, Dane B.</namePart>
+      <role>
+        <roleTerm type="text" authority="marcrelator">creator</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart>Goslin, Matthew N.</namePart>
+      <role>
+        <roleTerm type="text" authority="marcrelator">creator</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart>Augerot, Xanthippe</namePart>
+      <role>
+        <roleTerm type="text" authority="marcrelator">creator</roleTerm>
+      </role>
+    </name>
+    <typeOfResource>cartographic</typeOfResource>
+    <typeOfResource>software, multimedia</typeOfResource>
+    <genre authority="lcgft" valueURI="http://id.loc.gov/authorities/genreForms/gf2011026297">Geospatial data</genre>
+    <genre authority="rdacontent" valueURI="http://rdvocab.info/termList/RDAContentType/1001">cartographic dataset</genre>
+    <originInfo>
+      <publisher>Stanford Digital Repository</publisher>
+      <place>
+        <placeTerm type="text">Stanford, California, US</placeTerm>
+      </place>
+      <dateIssued encoding="w3cdtf" keyDate="yes">2009</dateIssued>
+      <dateValid encoding="w3cdtf" point="start">1978</dateValid>
+      <dateValid encoding="w3cdtf" point="end">2005</dateValid>
+    </originInfo>
+    <language>
+      <languageTerm authority="iso639-2b">eng</languageTerm>
+    </language>
+    <physicalDescription>
+      <form>Shapefile</form>
+      <extent>7.793</extent>
+      <digitalOrigin>born digital</digitalOrigin>
+    </physicalDescription>
+    <subject>
+      <cartographics>
+        <scale>Scale not given.</scale>
+        <projection>EPSG::4267</projection>
+        <coordinates>(W 180°--E 180°/N 73°59ʹ27ʺ--N 24°13ʹ53ʺ)</coordinates>
+      </cartographics>
+    </subject>
+    <abstract displayLabel="Abstract" lang="eng">This dataset is a visualization of abundance estimates for six species of Pacific salmon (Oncorhynchus spp.): Chinook, Chum, Pink, Steelhead, Sockeye, and Coho in catchment areas of the Northern Pacific Ocean, including Canada, China, Japan, Russia, and the United States. Catchment polygons included in this layer range in dates from 1978 to 2008. Sources dating from 1950 to 2005, including published literature and agency reports were consulted in order to create these data. In addition to abundance estimates, the PCSA database includes information on distribution, diversity, run-timings, land cover/land-use, dams, hatcheries, data sources, drainages, and administrative categories and provides a consistent format for comparing watersheds across the range of wild Pacific salmon.</abstract>
+    <abstract displayLabel="Purpose" lang="eng">The Conservation Science team at the Wild Salmon Center has created a geographic database, the Pacific Salmon Conservation Assessment (PSCA) that covers the whole range of wild Pacific Salmon. By providing estimations of salmon abundance and diversity, these data can provide opportunities to conduct range-wide analysis for conservation planning, prioritizing, and assessments.  The primary goal in developing the PSCA database is to guide proactive international salmon conservation.</abstract>
+    <note displayLabel="Preferred citation" lang="eng">Pinsky, M.L., Springmeyer, D.B., Goslin, M.N., Augerot, X (2009). Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008. Stanford Digital Repository. Available at: http://purl.stanford.edu/vv853br8653</note>
+    <note displayLabel="Supplemental information">Based upon expert opinion and validation with the literature, the PSCA database accurately represents broad, range-wide patterns of salmon abundance and diversity.  Much of the data, particularly in the Russian Far East, is based upon modeling. The database offers a geo-referenced watershed dataset and twenty tables that all join on a common primary key attribute.</note>
+    <relatedItem type="isReferencedBy">
+      <titleInfo>
+        <title>Range-Wide Selection of Catchments for Pacific Salmon Conservation</title>
+      </titleInfo>
+      <location>
+        <url>http://onlinelibrary.wiley.com/doi/10.1111/j.1523-1739.2008.01156.x/full</url>
+      </location>
+      <name type="personal">
+        <namePart>Pinsky, Malin L.</namePart>
+      </name>
+      <name type="personal">
+        <namePart>Springmeyer, Dane B.</namePart>
+      </name>
+      <name type="personal">
+        <namePart>Goslin, Matthew N.</namePart>
+      </name>
+      <name type="personal">
+        <namePart>Augerot, Xanthippe</namePart>
+      </name>
+      <originInfo>
+        <dateIssued encoding="w3cdtf">2009</dateIssued>
+      </originInfo>
+    </relatedItem>
+    <relatedItem>
+      <titleInfo>
+        <title>
+      Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation."
+      </title>
+      </titleInfo>
+      <location>
+        <url>http://purl.stanford.edu/zc193vn8689</url>
+      </location>
+    </relatedItem>
+    <subject>
+      <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects.html" lang="eng">Marine habitat conservation</topic>
+    </subject>
+    <subject>
+      <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects.html" lang="eng">Freshwater habitat conservation</topic>
+    </subject>
+    <subject>
+      <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects.html" lang="eng">Pacific salmon</topic>
+    </subject>
+    <subject>
+      <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects.html" lang="eng">Conservation</topic>
+    </subject>
+    <subject>
+      <topic authority="lcsh" authorityURI="http://id.loc.gov/authorities/subjects.html" lang="eng">Watersheds</topic>
+    </subject>
+    <subject>
+      <geographic lang="eng" valueURI="http://sws.geonames.org/4030875/" authority="geonames" authorityURI="http://www.geonames.org/ontology#">North Pacific Ocean</geographic>
+    </subject>
+    <subject>
+      <temporal encoding="w3cdtf" point="start">1978</temporal>
+      <temporal encoding="w3cdtf" point="end">2005</temporal>
+    </subject>
+    <subject>
+      <topic authority="ISO19115TopicCategory" authorityURI="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopicCategoryCode" valueURI="environment">Environment</topic>
+    </subject>
+    <subject>
+      <topic authority="ISO19115TopicCategory" authorityURI="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopicCategoryCode" valueURI="oceans">Oceans</topic>
+    </subject>
+    <subject>
+      <topic authority="ISO19115TopicCategory" authorityURI="http://www.isotc211.org/2005/resources/Codelist/gmxCodelists.xml#MD_TopicCategoryCode" valueURI="inlandWaters">Inland Waters</topic>
+    </subject>
+    <location>
+      <url>http://purl.stanford.edu/vv853br8653</url>
+    </location>
+    <recordInfo>
+      <recordContentSource>Stanford</recordContentSource>
+      <recordIdentifier>edu.stanford.purl:vv853br8653</recordIdentifier>
+      <recordOrigin>This record was translated from ISO 19139 to MODS v.3 using an xsl transformation.</recordOrigin>
+      <languageOfCataloging>
+        <languageTerm authority="iso639-2b" type="code">eng</languageTerm>
+      </languageOfCataloging>
+    </recordInfo>
+    <extension displayLabel="geo">
+      <rdf:RDF xmlns:gml="http://www.opengis.net/gml/3.2/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+        <rdf:Description rdf:about="http://purl.stanford.edu/vv853br8653">
+          <dc:format>application/x-esri-shapefile; format=Shapefile</dc:format>
+          <dc:type>Dataset#Polygon</dc:type>
+          <gml:boundedBy>
+            <gml:Envelope gml:srsName="EPSG:4326">
+              <gml:lowerCorner>-180.0 24.23126</gml:lowerCorner>
+              <gml:upperCorner>180.0 73.990866</gml:upperCorner>
+            </gml:Envelope>
+          </gml:boundedBy>
+          <dc:coverage rdf:resource="http://sws.geonames.org/4030875/about.rdf" dc:language="eng" dc:title="North Pacific Ocean"/>
+        </rdf:Description>
+      </rdf:RDF>
+    </extension>
+    <subject authority="EPSG" valueURI="http://opengis.net/def/crs/EPSG/0/4326" displayLabel="WGS84">
+      <cartographics>
+        <scale>Scale not given.</scale>
+        <projection>EPSG::4326</projection>
+        <coordinates>W 180°--E 180°/N 73°59ʹ27ʺ--N 24°13ʹ53ʺ</coordinates>
+      </cartographics>
+    </subject>
+    <note displayLabel="WGS84 Cartographics">This layer is presented in the WGS84 coordinate system for web display purposes. Downloadable data are provided in native coordinate system or projection.</note>
+    <accessCondition type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
+    <accessCondition type="license">CC by-nc: CC BY-NC Attribution-NonCommercial</accessCondition>
+  </mods>
+  <releaseData>
+    <release to="Searchworks">true</release>
+  </releaseData>
+</publicObject>

--- a/spec/fixtures/files/zc193vn8689.xml
+++ b/spec/fixtures/files/zc193vn8689.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<publicObject id="druid:zc193vn8689" published="2017-08-22T16:37:34Z" publishVersion="dor-services/5.17.3">
+  <identityMetadata>
+    <sourceId source="Hydrus">item-amyhodge-2013-02-26T21:43:43.948Z</sourceId>
+    <objectId>druid:zc193vn8689</objectId>
+    <objectCreator>DOR</objectCreator>
+    <objectLabel>Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation."</objectLabel>
+    <objectType>item</objectType>
+    <adminPolicy>druid:yx192qg7444</adminPolicy>
+    <otherId name="uuid">98299bae-805d-11e2-8ac9-0050569b3c6e</otherId>
+    <tag>Project : Hydrus : IR : data</tag>
+    <tag>Remediated By : 3.25.3</tag>
+    <displayType>file</displayType>
+  </identityMetadata>
+  <contentMetadata objectId="zc193vn8689" type="file">
+    <resource id="zc193vn8689_1" sequence="1" type="file">
+      <label>Abundance Database as published</label>
+      <file id="Pinsky_etal_AbundanceDatabase2008.csv" mimetype="text/plain" size="2545421">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_2" sequence="2" type="file">
+      <label>Catchment ArcGIS shapefile to be used for georeferencing the Abundance and Run-timing databases (link CatchmentID in the database to NLEVEL5 in the shapefile). Shapefile includes river names.</label>
+      <file id="Hydro1kshapefile.zip" mimetype="application/zip" size="5885010">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_3" sequence="3" type="file">
+      <label>Describes the content of each field in the Abundance Database (Pinsky_etal_AbundanceDatabase2008.csv and Pinsky_etal_2009_AbundanceData-2010-09-29.csv)</label>
+      <file id="Abundance_Database_Metadata.pdf" mimetype="application/pdf" size="76264">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_4" sequence="4" type="file">
+      <label>Describes the content of each field in the Run Timing Database (Pinsky_etal_2009_RunTimingData-2010-09-29.csv)</label>
+      <file id="RunTiming_Database_Metadata.pdf" mimetype="application/pdf" size="68806">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_5" sequence="5" type="file">
+      <label>List of data sources for Abundance Database</label>
+      <file id="Pinsky_etal_Sources.pdf" mimetype="application/pdf" size="94894">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_6" sequence="6" type="file">
+      <label>Overview of this set of supplemental data files</label>
+      <file id="Pinsky et al. 2009 Conservation Biology 23(3)-680-691 Supplemental Data_v2.pdf" mimetype="application/pdf" size="42216">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_7" sequence="7" type="file">
+      <label>Revised Abundance Database; Removed duplicate sockeye abundance record from AK Peninsula (CatchmentID 15917)</label>
+      <file id="Pinsky_etal_2009_AbundanceData-2010-09-29.csv" mimetype="text/plain" size="2851889">
+      
+      
+    </file>
+    </resource>
+    <resource id="zc193vn8689_8" sequence="8" type="file">
+      <label>Run Timing Database</label>
+      <file id="Pinsky_etal_2009_RunTimingData-2010-09-29.csv" mimetype="text/plain" size="194306">
+      
+      
+    </file>
+    </resource>
+  </contentMetadata>
+  <rightsMetadata>
+    <access type="discover">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <access type="read">
+      <machine>
+        <world/>
+      </machine>
+    </access>
+    <use>
+      <human type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</human>
+      <human type="openDataCommons">PDDL Public Domain Dedication and License</human>
+      <machine type="openDataCommons">pddl</machine>
+    </use>
+  </rightsMetadata>
+  <rdf:RDF xmlns:fedora="info:fedora/fedora-system:def/relations-external#" xmlns:fedora-model="info:fedora/fedora-system:def/model#" xmlns:hydra="http://projecthydra.org/ns/relations#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+    <rdf:Description rdf:about="info:fedora/druid:zc193vn8689">
+      <fedora:isMemberOf rdf:resource="info:fedora/druid:pn808wc6253"/>
+      <fedora:isMemberOfCollection rdf:resource="info:fedora/druid:pn808wc6253"/>
+    </rdf:Description>
+  </rdf:RDF>
+  <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:srw_dc="info:srw/schema/1/dc-schema" xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+    <dc:title>Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation."</dc:title>
+    <dc:type>dataset</dc:type>
+    <dc:date>2009</dc:date>
+    <dc:description>Freshwater ecosystems are declining in quality globally, but a lack of data inhibits identification of areas valuable for conservation across national borders. We developed a biological measure of conservation value for six species of Pacific salmon (Oncorhynchus spp.) in catchments of the northern Pacific across Canada, China, Japan, Russia, and the United States. We based the measure on abundance and life-history richness and a model-based method that filled data gaps. Catchments with high conservation value ranged from California to northern Russia and included catchments in regions that are strongly affected by human development (e.g., Puget Sound). Catchments with high conservation value were less affected by agriculture and dams than other catchments, although only 1% were within biodiversity reserves. Our set of high-value areas was largely insensitive to simulated error, although classification remained uncertain for 3% of catchments. Although salmon face many threats, we propose they will be most likely to exhibit resilience into the future if a complementary mosaic of conservation strategies can be proactively adopted in catchments with healthy salmon populations. Our analysis provides an initial map of where these catchments are likely to be located.</dc:description>
+    <dc:description type="preferred citation" displayLabel="Preferred Citation">Pinsky, ML, Springmeyer, DB, Goslin, MN, Augerot, X (2009). Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation." Stanford Digital Repository. Available at http://purl.stanford.edu/zc193vn8689.</dc:description>
+    <dc:description type="citation/reference" displayLabel="Related Publication">Pinsky, M. L., Springmeyer, D. B., Goslin, M. N. and Augerot, X. (2009), Range-Wide Selection of Catchments for Pacific Salmon Conservation. Conservation Biology, 23: 680–691. doi: 10.1111/j.1523-1739.2008.01156.x. Available at http://onlinelibrary.wiley.com/doi/10.1111/j.1523-1739.2008.01156.x/full.</dc:description>
+    <dc:description type="contact" displayLabel="Contact">malin.pinsky@gmail.com</dc:description>
+    <dc:relation type="url" href="http://www.wildsalmoncenter.org/">Wild Salmon Center</dc:relation>
+    <dc:relation type="url" href="http://www.stateofthesalmon.org/">State of the Salmon</dc:relation>
+    <dc:relation type="url" href="http://purl.stanford.edu/vv853br8653">Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008</dc:relation>
+    <dc:subject>conservation planning</dc:subject>
+    <dc:subject>freshwater protected areas</dc:subject>
+    <dc:subject>landscape variables</dc:subject>
+    <dc:subject>northern Pacific</dc:subject>
+    <dc:subject>Oncorhynchus</dc:subject>
+    <dc:subject>salmon áreas dulceacuícolas protegidas</dc:subject>
+    <dc:subject>Oncorhynchus</dc:subject>
+    <dc:subject>Pacífico del norte</dc:subject>
+    <dc:subject>planificación de la conservación</dc:subject>
+    <dc:subject>salmón</dc:subject>
+    <dc:subject>variables de paisaje</dc:subject>
+    <dc:contributor>Pinsky, Malin L (Author)</dc:contributor>
+    <dc:contributor>Springmeyer, Dane B. (Author)</dc:contributor>
+    <dc:contributor>Goslin, Matthew N. (Author)</dc:contributor>
+    <dc:contributor>Augerot, Xanthippe (Author)</dc:contributor>
+    <dc:language>eng</dc:language>
+    <dc:relation type="collection">Hopkins Marine Station Collection</dc:relation>
+  </oai_dc:dc>
+  <mods xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.loc.gov/mods/v3" version="3.3" xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-3.xsd">
+    <titleInfo>
+      <title>Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation."</title>
+    </titleInfo>
+    <typeOfResource>software, multimedia</typeOfResource>
+    <genre>dataset</genre>
+    <originInfo>
+      <dateCreated>2009</dateCreated>
+    </originInfo>
+    <abstract>Freshwater ecosystems are declining in quality globally, but a lack of data inhibits identification of areas valuable for conservation across national borders. We developed a biological measure of conservation value for six species of Pacific salmon (Oncorhynchus spp.) in catchments of the northern Pacific across Canada, China, Japan, Russia, and the United States. We based the measure on abundance and life-history richness and a model-based method that filled data gaps. Catchments with high conservation value ranged from California to northern Russia and included catchments in regions that are strongly affected by human development (e.g., Puget Sound). Catchments with high conservation value were less affected by agriculture and dams than other catchments, although only 1% were within biodiversity reserves. Our set of high-value areas was largely insensitive to simulated error, although classification remained uncertain for 3% of catchments. Although salmon face many threats, we propose they will be most likely to exhibit resilience into the future if a complementary mosaic of conservation strategies can be proactively adopted in catchments with healthy salmon populations. Our analysis provides an initial map of where these catchments are likely to be located.</abstract>
+    <note type="preferred citation" displayLabel="Preferred Citation">Pinsky, ML, Springmeyer, DB, Goslin, MN, Augerot, X (2009). Data Supplement for "Range-wide selection of catchments for Pacific salmon conservation." Stanford Digital Repository. Available at http://purl.stanford.edu/zc193vn8689.</note>
+    <note type="citation/reference" displayLabel="Related Publication">Pinsky, M. L., Springmeyer, D. B., Goslin, M. N. and Augerot, X. (2009), Range-Wide Selection of Catchments for Pacific Salmon Conservation. Conservation Biology, 23: 680–691. doi: 10.1111/j.1523-1739.2008.01156.x. Available at http://onlinelibrary.wiley.com/doi/10.1111/j.1523-1739.2008.01156.x/full.</note>
+    <note type="contact" displayLabel="Contact">malin.pinsky@gmail.com</note>
+    <relatedItem>
+      <titleInfo>
+        <title>Wild Salmon Center</title>
+      </titleInfo>
+      <location>
+        <url>http://www.wildsalmoncenter.org/</url>
+      </location>
+    </relatedItem>
+    <relatedItem>
+      <titleInfo>
+        <title>State of the Salmon</title>
+      </titleInfo>
+      <location>
+        <url>http://www.stateofthesalmon.org/</url>
+      </location>
+    </relatedItem>
+    <relatedItem>
+      <titleInfo>
+        <title>Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008</title>
+      </titleInfo>
+      <location>
+        <url>http://purl.stanford.edu/vv853br8653</url>
+      </location>
+    </relatedItem>
+    <subject>
+      <topic>conservation planning</topic>
+    </subject>
+    <subject>
+      <topic>freshwater protected areas</topic>
+    </subject>
+    <subject>
+      <topic>landscape variables</topic>
+    </subject>
+    <subject>
+      <topic>northern Pacific</topic>
+    </subject>
+    <subject>
+      <topic>Oncorhynchus</topic>
+    </subject>
+    <subject>
+      <topic>salmon áreas dulceacuícolas protegidas</topic>
+    </subject>
+    <subject>
+      <topic>Oncorhynchus</topic>
+    </subject>
+    <subject>
+      <topic>Pacífico del norte</topic>
+    </subject>
+    <subject>
+      <topic>planificación de la conservación</topic>
+    </subject>
+    <subject>
+      <topic>salmón</topic>
+    </subject>
+    <subject>
+      <topic>variables de paisaje</topic>
+    </subject>
+    <name type="personal">
+      <namePart>Pinsky, Malin L </namePart>
+      <role>
+        <roleTerm authority="marcrelator" type="text">Author</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart>Springmeyer, Dane B.</namePart>
+      <role>
+        <roleTerm authority="marcrelator" type="text">Author</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart>Goslin, Matthew N.</namePart>
+      <role>
+        <roleTerm authority="marcrelator" type="text">Author</roleTerm>
+      </role>
+    </name>
+    <name type="personal">
+      <namePart>Augerot, Xanthippe</namePart>
+      <role>
+        <roleTerm authority="marcrelator" type="text">Author</roleTerm>
+      </role>
+    </name>
+    <language>
+      <languageTerm type="code" authority="iso639-2b">eng</languageTerm>
+    </language>
+    <relatedItem type="host">
+      <titleInfo>
+        <title>Hopkins Marine Station Collection</title>
+      </titleInfo>
+      <location>
+        <url>https://purl.stanford.edu/pn808wc6253</url>
+      </location>
+      <typeOfResource collection="yes"/>
+    </relatedItem>
+    <accessCondition type="useAndReproduction">User agrees that, where applicable, content will not be used to identify or to otherwise infringe the privacy or confidentiality rights of individuals. Content distributed via the Stanford Digital Repository may be subject to additional license and use restrictions applied by the depositor.</accessCondition>
+    <accessCondition type="license">ODC pddl: PDDL Public Domain Dedication and License</accessCondition>
+  </mods>
+  <releaseData>
+    <release to="Searchworks">true</release>
+  </releaseData>
+</publicObject>

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -82,4 +82,42 @@ describe 'SDR indexing' do
                                     "set", "set_with_title"
     end
   end
+  context 'with vv853br8653' do
+    subject(:result) { indexer.map_record(PublicXmlRecord.new('vv853br8653')) }
+
+    before do
+      without_partial_double_verification do
+        if defined?(JRUBY_VERSION)
+          allow(Manticore).to receive(:get).with('https://purl.stanford.edu/vv853br8653.xml').and_return(double(code: 200, body: File.read(file_fixture('vv853br8653.xml').to_s)))
+          allow(Manticore).to receive(:get).with('https://purl.stanford.edu/zc193vn8689.xml').and_return(double(code: 200, body: File.read(file_fixture('zc193vn8689.xml').to_s)))
+        else
+          allow(HTTP).to receive(:get).with('https://purl.stanford.edu/vv853br8653.xml').and_return(double(body: File.read(file_fixture('vv853br8653.xml').to_s), status: double(ok?: true)))
+          allow(HTTP).to receive(:get).with('https://purl.stanford.edu/zc193vn8689.xml').and_return(double(body: File.read(file_fixture('zc193vn8689.xml').to_s), status: double(ok?: true)))
+        end
+      end
+    end
+    it 'maps schema.org data for geo content' do
+      expect(result['schema_dot_org_struct'].first).to include '@context': 'http://schema.org',
+                                                                '@type': 'Dataset',
+                                                                citation: /Pinsky/,
+                                                                description: [/This dataset/, /The Conservation/],
+                                                                distribution: [
+                                                                  {
+                                                                    '@type': 'DataDownload',
+                                                                    contentUrl: 'https://stacks.stanford.edu/file/druid:vv853br8653/data.zip',
+                                                                    encodingFormat: 'application/zip'
+                                                                  }
+                                                                ],
+                                                                identifier: ['https://purl.stanford.edu/vv853br8653'],
+                                                                includedInDataCatalog: {
+                                                                  '@type': 'DataCatalog',
+                                                                  name: 'https://earthworks.stanford.edu'
+                                                                },
+                                                                keywords: ['Geospatial data', 'cartographic dataset', 'Marine habitat conservation', 'Freshwater habitat conservation', 'Pacific salmon', 'Conservation', 'Watersheds', 'Environment', 'Oceans', 'Inland Waters', 'North Pacific Ocean', '1978', '2005'],
+                                                                license: 'CC by-nc: CC BY-NC Attribution-NonCommercial',
+                                                                name: ['Abundance Estimates of the Pacific Salmon Conservation Assessment Database, 1978-2008'],
+                                                                sameAs: 'https://earthworks.stanford.edu/catalog/stanford-vv853br8653'
+    end
+
+  end
 end


### PR DESCRIPTION
This aims to fix https://github.com/sul-dlss/SearchWorks/issues/2041 by providing a more robost schema.org dataset record for content-type geo. The assumptions made in this metadata reflect valid assumptions for all content type geo.