### PR TITLE
Removes index_sirsi_hourly.sh from catchup.sh.

### DIFF
--- a/script/index_sirsi_catchup.sh
+++ b/script/index_sirsi_catchup.sh
@@ -18,5 +18,4 @@ done
 # And index the current nightly
 $SCRIPT_FULL_PATH/index_sirsi_nightly.sh
 
-# Index the current incremental file
-$SCRIPT_FULL_PATH/index_sirsi_hourly.sh
+# Latest hourly file indexed through cron


### PR DESCRIPTION
If a full reindex of MARC data completes before 6am, the hourly file
from the previous day will be indexed after the nightly file that was
generated just before midnight. There's a chance that the data in the
hourly file is outdated versus the data in the nightly file. We should
rely on the cronjob to index the latest hourly file.