### PR TITLE
Avoid splitting TOC data on strings like 'v. 1. asdfasdf'

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1919,7 +1919,7 @@ to_field "vern_toc_search", extract_marc("505art", alternate_script: :only)
 #    vernacular: [['The same, but pulled from the matched vernacular fields']]
 #    unmatched_vernacular: [['The same, but pulled from any unmatched vernacular fields']]
 to_field 'toc_struct' do |marc, accumulator|
-  formatted_chapter_regex = Regexp.union(/[^\S]--[^\S]/, /      /, /(?=(?:Chapter|Section|Appendix|Part) \d+[:\.-]?\s+)/i,  /(?=(?<!Chapter|Section|Appendix|Part) \d+[:\.-]?\s+)/i, /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i)
+  formatted_chapter_regex = Regexp.union(/[^\S]--[^\S]/, /      /, /(?=(?:Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i,  /(?=(?<!Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i, /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i)
   fields = []
   vern = []
   unmatched_vern = []

--- a/spec/lib/traject/config/note_fields_spec.rb
+++ b/spec/lib/traject/config/note_fields_spec.rb
@@ -227,7 +227,7 @@ RSpec.describe 'Sirsi config' do
             r.append(
               MARC::DataField.new(
                 '505', ' ', ' ',
-                MARC::Subfield.new('a', 'Part 1: Nasal Surgery 1.0 1. Septoplasty Marcelo Antunes, Sam Becker, Michael Lupa and Dan Becker. Chapter 2: The Theory of Organizations. Chapter 3: The University in America. -- 4. Drugs: Intoxicating Consumption 5. Food: Embodied Consumption      Whole Lotta Shakin Goin On: The Politics of Youth in 1950s Fiction Nick Bentley, University of Keele, UK')
+                MARC::Subfield.new('a', 'Part 1: Nasal Surgery 1.0 1. Septoplasty Marcelo Antunes, Sam Becker, Michael Lupa and Dan Becker. Chapter 2: The Theory of Organizations. Chapter 3: The University in America. -- 4. Drugs: Intoxicating Consumption 5. Food: Embodied Consumption      Whole Lotta Shakin Goin On: The Politics of Youth in 1950s Fiction Nick Bentley, University of Keele, UK v. 4. 1852-1863.')
               )
             )
           end
@@ -241,7 +241,8 @@ RSpec.describe 'Sirsi config' do
             'Chapter 3: The University in America.',
             '4. Drugs: Intoxicating Consumption',
             '5. Food: Embodied Consumption',
-            'Whole Lotta Shakin Goin On: The Politics of Youth in 1950s Fiction Nick Bentley, University of Keele, UK'
+            'Whole Lotta Shakin Goin On: The Politics of Youth in 1950s Fiction Nick Bentley, University of Keele, UK',
+            'v. 4. 1852-1863.'
           ]
         end
       end


### PR DESCRIPTION
Fixes [VUF-7003](https://jirasul.stanford.edu/jira/browse/VUF-7003)