### PR TITLE
add comment about Lane's ETL dependency on format_main_ssim code

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1396,6 +1396,12 @@ to_field 'access_facet' do |record, accumulator, context|
   accumulator.uniq!
 end
 
+##
+# Lane Medical Library relies on the underlying logic of "format_main_ssim" 
+# data (next ~200+ lines) to accurately represent SUL records in 
+# http://lane.stanford.edu. Please consider notifying Ryan Steinberg 
+# (ryanmax at stanford dot edu) in the event of changes to this logic.
+#
 # # old format field, left for continuity in UI URLs for old formats
 # format = custom, getOldFormats
 to_field 'format_main_ssim' do |record, accumulator|

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1400,7 +1400,8 @@ end
 # Lane Medical Library relies on the underlying logic of "format_main_ssim" 
 # data (next ~200+ lines) to accurately represent SUL records in 
 # http://lane.stanford.edu. Please consider notifying Ryan Steinberg 
-# (ryanmax at stanford dot edu) in the event of changes to this logic.
+# (ryanmax at stanford dot edu) or LaneAskUs@stanford.edu in the event of 
+# changes to this logic.
 #
 # # old format field, left for continuity in UI URLs for old formats
 # format = custom, getOldFormats


### PR DESCRIPTION
I ported format_main_ssim logic into Lane's Java-based ETL process which will be used to index SearchWorks data for [Lane Search](https://lane.stanford.edu/) later this year. Monitoring for changes will primarily be a Lane responsibility, but please consider adding a comment like this one to document this dependency and ensure that SUL's data is properly represented in Lane's system.