### PR TITLE
Guard against deletes for a document without an id

### DIFF
--- a/lib/traject/writers/solr_better_json_writer.rb
+++ b/lib/traject/writers/solr_better_json_writer.rb
@@ -67,7 +67,8 @@ class Traject::SolrBetterJsonWriter < Traject::SolrJsonWriter
 
     batch.each do |c|
       if c.skip?
-        arr << "delete: #{JSON.generate(id: Array(c.output_hash['id']).first)}"
+        id = Array(c.output_hash['id']).first
+        arr << "delete: #{JSON.generate(id: id)}" if id
       else
         arr << "add: #{JSON.generate(doc: c.output_hash)}"
       end


### PR DESCRIPTION
I don't really understand how this happens, presumably some incredibly mangled data, but this'll fix at least one of the crashes that's getting reported to honeybadger..