### PR TITLE
Update regex for TOC to require either a colon, period, or hyphen...

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1918,7 +1918,13 @@ to_field "vern_toc_search", extract_marc("505art", alternate_script: :only)
 #    vernacular: [['The same, but pulled from the matched vernacular fields']]
 #    unmatched_vernacular: [['The same, but pulled from any unmatched vernacular fields']]
 to_field 'toc_struct' do |marc, accumulator|
-  formatted_chapter_regex = Regexp.union(/[^\S]--[^\S]/, /      /, /(?=(?:Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i,  /(?=(?<!Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i, /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i)
+  formatted_chapter_regex = Regexp.union(
+    /[^\S]--[^\S]/,
+    /      /,
+    /(?=(?:Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i,
+    /(?=(?<!Chapter|Section|Appendix|Part|v\.) \d+[:\.-]\s+)/i,
+    /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i
+  )
   fields = []
   vern = []
   unmatched_vern = []

--- a/spec/lib/traject/config/note_fields_spec.rb
+++ b/spec/lib/traject/config/note_fields_spec.rb
@@ -165,6 +165,23 @@ RSpec.describe 'Sirsi config' do
         end
       end
 
+      context 'with numbers that should not be split on in the data' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '505', ' ', ' ',
+                MARC::Subfield.new('a', 'aaa -- Word 10 Another Word -- ccc')
+              )
+            )
+          end
+        end
+
+        it 'does not split on a number that is not intended to be the beginning of a new chapter/line' do
+          expect(result_field.first[:fields].first).to eq ['aaa', 'Word 10 Another Word', 'ccc']
+        end
+      end
+
       context 'with data in separate subfields' do
         let(:record) do
           MARC::Record.new.tap do |r|


### PR DESCRIPTION
…er a number before using it to split on.

Fixes #387

See https://github.com/sul-dlss/searchworks_traject_indexer/issues/387#issuecomment-542946027 for some more context/details.