### PR TITLE
Better control flow for presence of solr_geom

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -175,12 +175,15 @@ each_record do |record, context|
 end
 
 each_record do |_record, context|
-  context.skip!(
-    "No ENVELOPE available for #{context.output_hash['id']}"
-  ) unless context.output_hash['solr_geom'].present?
   # Make sure that this field is single valued. GeoBlacklight at the moment only
   # supports single valued srpt
-  context.output_hash['solr_geom'] = context.output_hash['solr_geom'].first
+  if context.output_hash['solr_geom'].present?
+    context.output_hash['solr_geom'] = context.output_hash['solr_geom'].first
+  else
+    context.skip!(
+      "No ENVELOPE available for #{context.output_hash['id']}"
+    )
+  end
 end
 
 each_record do |record, context|


### PR DESCRIPTION
```
./lib/traject/config/geo_config.rb:183:in `block (2 levels) in load_config_file': undefined method `first' for nil:NilClass (NoMethodError)
```

The skip doesn't stop execution, so we need just a little bit more specific control flow here.