### PR TITLE
Handle empty author named elements which could cause processing to fail

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -136,10 +136,10 @@ to_field 'dc_publisher_s',
          stanford_mods(:term_values, %I[origin_info publisher]),
          first_only
 to_field 'dc_creator_sm' do |record, accumulator|
-  record.stanford_mods.sw_person_authors.map do |author|
+  record.stanford_mods.sw_person_authors.compact.map do |author|
     accumulator << author.gsub(/\.$/, '')
   end
-  record.stanford_mods.sw_corporate_authors.map do |author|
+  record.stanford_mods.sw_corporate_authors.compact.map do |author|
     accumulator << author.gsub(/\.$/, '')
   end
 end


### PR DESCRIPTION
https://purl.stanford.edu/cw692sh3587.mods

```
./lib/traject/config/geo_config.rb:140:in `block (3 levels) in load_config_file': undefined method `gsub' for nil:NilClass (NoMethodError)
	from ./lib/traject/config/geo_config.rb:139:in `map'
	from ./lib/traject/config/geo_config.rb:139:in `block (2 levels) in load_config_file'
```