### PR TITLE
Ignore empty catkeys

### DIFF
--- a/lib/sdr_stuff.rb
+++ b/lib/sdr_stuff.rb
@@ -50,7 +50,7 @@ class PublicXmlRecord
 
   # @return catkey value from the DOR identity_metadata, or nil if there is no catkey
   def catkey
-    get_value(public_xml_doc.xpath("/publicObject/identityMetadata/otherId[@name='catkey']"))
+    get_value(public_xml_doc.xpath("/publicObject/identityMetadata/otherId[@name='catkey']")).presence
   end
 
   # @return objectLabel value from the DOR identity_metadata, or nil if there is no barcode

--- a/lib/traject/readers/kafka_purl_fetcher_reader.rb
+++ b/lib/traject/readers/kafka_purl_fetcher_reader.rb
@@ -49,7 +49,7 @@ class Traject::KafkaPurlFetcherReader
 
     if target.nil? || (change['true_targets'] && change['true_targets'].map(&:upcase).include?(target.upcase))
       # Remove changed records that now have a catkey
-      return true if skip_catkey && (change['catkey'] || record.catkey)
+      return true if skip_catkey && (change['catkey'].presence || record.catkey)
       # Remove withdrawn records that are missing public xml
       return true if !record.public_xml?
     end

--- a/spec/lib/traject/readers/kafka_purl_fetcher_reader_spec.rb
+++ b/spec/lib/traject/readers/kafka_purl_fetcher_reader_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'utils'
 
 RSpec.describe Traject::KafkaPurlFetcherReader do
   subject(:reader) { described_class.new('', settings) }
@@ -8,7 +9,8 @@ RSpec.describe Traject::KafkaPurlFetcherReader do
   describe '#each' do
     before do
       allow(consumer).to receive(:each_message).and_yield(double(key: 'x', value: { druid: 'x', true_targets: ['Searchworks'] }.to_json))
-                                               .and_yield(double(key: 'y', value: { druid: 'y', true_targets: ['Searchworks'] }.to_json))
+                                               .and_yield(double(key: 'y', value: { druid: 'y', true_targets: ['Searchworks'], catkey:  '' }.to_json))
+                                               .and_yield(double(key: 'deleted', value: { druid: 'y', true_targets: ['Searchworks'], catkey:  'catkey' }.to_json))
                                                .and_yield(double(key: 'z', value: { druid: 'z', true_targets: ['SomethingElse'] }.to_json))
 
 
@@ -16,7 +18,11 @@ RSpec.describe Traject::KafkaPurlFetcherReader do
     end
 
     it 'returns objects from the purl-fetcher api' do
-      expect(reader.each.map(&:druid)).to eq ['x', 'y']
+      expect(reader.each.select { |x| x.is_a? PublicXmlRecord }.map(&:druid)).to eq ['x', 'y']
+    end
+
+    it 'returns deletes for objects with a catkey' do
+      expect(reader.each.reject { |x| x.is_a? PublicXmlRecord }.map { |x| x[:id] }).to eq ['deleted']
     end
   end
 end


### PR DESCRIPTION
There's an issue with some old data in the kafka topic where the catkey is recorded as an empty string (triggering a delete). This PR  guards against it, because it's easier to do that than to make sure we wipe out all the bad data.