### PR TITLE
Guard against records  (like catkey 440849) that have implausible val…

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1128,13 +1128,13 @@ to_field 'pub_date_sort' do |record, accumulator|
 
   # hyphens sort before 0, so the lexical sorting will be correct. I think.
   year ||= if f008_bytes7to10 =~ /\d\d[u-][u-]/
-    "#{record['008'].value[7..8]}--"
+    "#{record['008'].value[7..8]}--" if record['008'].value[7..8] <= Time.now.year.to_s[0..1]
   end
 
   # colons sort after 9, so the lexical sorting will be correct. I think.
   # NOTE: the solrmarc code has this comment, and yet still uses hyphens below; maybe a bug?
   year ||= if f008_bytes11to14 =~ /\d\d[u-][u-]/
-    "#{record['008'].value[11..12]}--"
+    "#{record['008'].value[11..12]}--" if record['008'].value[11..12] <= Time.now.year.to_s[0..1]
   end
 
   accumulator << year.to_s if year

--- a/spec/lib/traject/config/publication_spec.rb
+++ b/spec/lib/traject/config/publication_spec.rb
@@ -745,6 +745,17 @@ RSpec.describe 'Publication config' do
       expect(select_by_id('z2009')[field]).to eq ['2009']
       expect(select_by_id('zpubDate2010')[field]).to eq ['2010']
     end
+
+    context 'with garbage in the 008' do
+      subject(:result) { indexer.map_record(record) }
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          r.append(MARC::ControlField.new('008', '800124d1uuu99uuru'))
+        end
+      end
+
+      specify { expect(result[field]).to eq nil }
+    end
   end
 
 end


### PR DESCRIPTION
…ues for the 008 year.

This adds the same logic we apply to years  with 1 unknown digit  to  years with 2 unknown digits (like 99uu).