### PR TITLE
Query our HT database to look up the htid for our items

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'manticore', platform: :jruby
 gem 'rake'
 gem 'ruby-kafka'
 gem 'stanford-mods'
-gem 'iso-639', '< 0.3' # v0.3+ requires ruby 2.6+ (and out jruby is at 2.5) 
+gem 'iso-639', '< 0.3' # v0.3+ requires ruby 2.6+ (and out jruby is at 2.5)
 gem 'whenever'
 gem 'honeybadger'
 gem 'retriable'
@@ -25,6 +25,9 @@ gem 'config'
 gem 'statsd-ruby'
 gem 'debouncer'
 gem 'dor-rights-auth'
+gem 'sequel'
+gem 'mysql2', '< 0.5.3', platform: :mri
+gem 'jdbc-mysql', platform: :jruby
 
 group :deployment do
   gem 'capistrano', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,4 @@
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -140,6 +141,7 @@ GEM
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.10)
+    jdbc-mysql (8.0.17)
     kostya-sigar (2.0.6)
     manticore (0.6.4-java)
       openssl_pkcs8_pure
@@ -160,6 +162,7 @@ GEM
     mods_display (0.7.1)
       i18n
       stanford-mods (~> 2.1)
+    mysql2 (0.5.2)
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.0.2)
@@ -191,6 +194,7 @@ GEM
     ruby-kafka (1.0.0)
       digest-crc
     scrub_rb (1.0.1)
+    sequel (5.30.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -252,12 +256,15 @@ DEPENDENCIES
   http
   i18n
   iso-639 (< 0.3)
+  jdbc-mysql
   manticore
   mods_display
+  mysql2 (< 0.5.3)
   rake
   retriable
   rspec
   ruby-kafka
+  sequel
   simplecov
   stanford-mods
   statsd-ruby

--- a/script/load_hathifiles.rb
+++ b/script/load_hathifiles.rb
@@ -1,0 +1,76 @@
+## HT Overlap report (received out of band)
+# CREATE TABLE `overlap` (
+#   `oclc` varchar(255) DEFAULT NULL,
+#   `local_id` INT UNSIGNED NOT NULL,
+#   `item_type` varchar(16) DEFAULT NULL,
+#   `access` varchar(16) DEFAULT NULL,
+#   `rights` varchar(16) DEFAULT NULL,
+#   KEY `idx_local_id`  (`local_id`),
+#   KEY `idx_oclc_num` (`oclc`)
+# ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+# LOAD DATA INFILE '/data/ht/overlap_20200316_stanford.tsv' INTO table hathifiles.overlap FIELDS ESCAPED BY '\b';
+
+## HT HAthifiles dump (from https://www.hathitrust.org/hathifiles)
+# CREATE TABLE `hathifiles` (
+#  `htid` varchar(64) NOT NULL DEFAULT '',
+#  `access` varchar(16) DEFAULT NULL,
+#  `rights` varchar(16) DEFAULT NULL,
+#  `ht_bib_key` varchar(16) DEFAULT NULL,
+#  `description` text,
+#  `source` varchar(16) DEFAULT NULL,
+#  `source_bib_num` varchar(1023) DEFAULT NULL,
+#  `oclc_num` varchar(255) DEFAULT NULL,
+#  `isbn` varchar(2047) DEFAULT NULL,
+#  `issn` varchar(2047) DEFAULT NULL,
+#  `lccn` varchar(2047) DEFAULT NULL,
+#  `title` text,
+#  `imprint` text,
+#  `rights_reason_code` varchar(32) DEFAULT NULL,
+#  `rights_timestamp` datetime DEFAULT NULL,
+#  `us_gov_doc_flag` varchar(8) DEFAULT NULL,
+#  `rights_date_used` varchar(32) DEFAULT NULL,
+#  `pub_place` text,
+#  `lang` varchar(8) DEFAULT NULL,
+#  `bib_fmt` varchar(16) DEFAULT NULL,
+#  `collection_code` varchar(16) DEFAULT NULL,
+#  `content_provider_code` varchar(32) DEFAULT NULL,
+#  `responsible_entity_code` varchar(32) DEFAULT NULL,
+#  `digitization_agent_code` varchar(32) DEFAULT NULL,
+#  `access_profile_code` varchar(32) DEFAULT NULL,
+#  `author` text,
+#  PRIMARY KEY (`htid`),
+#  KEY `idx_oclc_num` (`oclc_num`),
+#  KEY `idx_lccn` (`lccn`(255)),
+#  KEY `idx_source` (`source`,`source_bib_num`(255)),
+#  KEY `idx_ht_bib_key` (`ht_bib_key`,`htid`)
+#) ENGINE=InnoDB DEFAULT CHARSET=utf8; 
+# CREATE TABLE  `stdnums` (
+#   `htid` varchar(64) NOT NULL,
+#   `type` varchar(16) NOT NULL,
+#   `value` varchar(1023) NOT NULL,
+#   KEY `idx_htid` (`htid`),
+#   KEY `idx_type_value` (`type`, `value`, `htid`)
+# )
+# LOAD DATA INFILE '/data/ht/hathi_full_20200501.txt' INTO table hathifiles.hathifiles FIELDS ESCAPED BY '\b';
+
+db = Sequel.connect(ENV[:hathitrust_lookup_db])
+
+
+# Transform hathifiles oclc_num column into stdnums table (for ease of joining with the overlap report)
+class HT < Sequel::Model(db[:hathifiles].where(Sequel.lit('oclc_num != ""')).select(:htid, :oclc_num)); end
+
+i = 0
+HT.each do |row|
+  i += 1
+  puts i if (i % 1000) == 0
+  oclc = row.oclc_num.split(",").map(&:strip).reject(&:empty?)
+  db.transaction do
+    db.from('stdnums').where(htid: row[:htid]).delete
+    db[:stdnums].multi_insert(
+      oclc.map do |num|
+        { htid: row[:htid], type: 'oclc', value: num }
+      end
+    )
+  end
+end

--- a/script/seed_hathi_data.rb
+++ b/script/seed_hathi_data.rb
@@ -1,0 +1,32 @@
+require 'sequel'
+require 'json'
+require 'httpclient'
+
+db = Sequel.connect(ENV['hathitrust_lookup_db'])
+client = HTTPClient.new
+
+data = db.from('stdnums').join(:overlap, oclc: :value).join('hathifiles', htid: Sequel[:stdnums][:htid]).where(type: 'oclc').where(Sequel.~(local_id: 0)).order(:local_id).select_all(:hathifiles).select_append(:local_id)
+
+data.paged_each.slice_when { |before, after| before[:local_id] != after[:local_id] }.each do |rows|
+  hathitrust_info = rows.map { |x| x.slice(:htid, :ht_bib_key, :content_provider_code, :access, :rights, :description, :oclc_num) }.uniq { |x| x[:htid] }
+  puts rows.first[:local_id]
+
+  doc = {
+    id: rows.first[:local_id].to_s,
+    hathitrust_info_struct: {
+      set: Array(hathitrust_info).map { |x| JSON.generate(x) }
+    },
+    ht_access_sim: {
+      set: rows.map { |x| x[:access] }.uniq
+    },
+    ht_bib_key_ssim: {
+      set: rows.map { |x| x[:ht_bib_key] }.uniq
+    },
+    ht_htid_ssim: {
+      set: rows.length > 1 ? nil : rows.first[:htid]
+    }
+  }
+
+  resp = client.post ENV['SOLR_URL'], [doc].to_json, 'Content-Type' => 'application/json'
+  puts resp.body unless resp.status == 200
+end


### PR DESCRIPTION
Augment solr documents with hathitrust identifiers (for items available to read, at least ) by looking them up by OCLC  number in a locally managed database.