### PR TITLE
Remove ENDPROCESS items from being "On order"

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1367,6 +1367,7 @@ end
 #
 to_field 'access_facet' do |record, accumulator, context|
   online_locs = ['E-RECVD', 'E-RESV', 'ELECTR-LOC', 'INTERNET', 'KIOST', 'ONLINE-TXT', 'RESV-URL', 'WORKSTATN']
+  on_order_ignore_locs = %w[INPROCESS LAC]
   holdings(record, context).each do |holding|
     next if holding.skipped?
 
@@ -1374,7 +1375,7 @@ to_field 'access_facet' do |record, accumulator, context|
 
     if online_locs.include?(field['k']) || online_locs.include?(field['l']) || holding.e_call_number?
       accumulator << 'Online'
-    elsif field['a'] =~ /^XX/ && (field['k'] == 'ON-ORDER' || (!field['k'].nil? && !field['k'].empty? && field['l'] != 'INPROCESS' && field['k'] != 'INPROCESS' && field['k'] != 'LAC' && field['l'] != 'LAC' && field['m'] != 'HV-ARCHIVE' && field['k'] != 'SPEC-INPRO'))
+    elsif field['a'] =~ /^XX/ && (field['k'] == 'ON-ORDER' || (!field['k'].nil? && !field['k'].empty? && (on_order_ignore_locs & [field['k'], field['l']]).empty? && field['m'] != 'HV-ARCHIVE' && field['k'] != 'SPEC-INPRO'))
       accumulator << 'On order'
     else
       accumulator << 'At the Library'

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1367,7 +1367,7 @@ end
 #
 to_field 'access_facet' do |record, accumulator, context|
   online_locs = ['E-RECVD', 'E-RESV', 'ELECTR-LOC', 'INTERNET', 'KIOST', 'ONLINE-TXT', 'RESV-URL', 'WORKSTATN']
-  on_order_ignore_locs = %w[INPROCESS LAC]
+  on_order_ignore_locs = %w[INPROCESS LAC SPEC-INPRO]
   holdings(record, context).each do |holding|
     next if holding.skipped?
 
@@ -1375,7 +1375,7 @@ to_field 'access_facet' do |record, accumulator, context|
 
     if online_locs.include?(field['k']) || online_locs.include?(field['l']) || holding.e_call_number?
       accumulator << 'Online'
-    elsif field['a'] =~ /^XX/ && (field['k'] == 'ON-ORDER' || (!field['k'].nil? && !field['k'].empty? && (on_order_ignore_locs & [field['k'], field['l']]).empty? && field['m'] != 'HV-ARCHIVE' && field['k'] != 'SPEC-INPRO'))
+    elsif field['a'] =~ /^XX/ && (field['k'] == 'ON-ORDER' || (!field['k'].nil? && !field['k'].empty? && (on_order_ignore_locs & [field['k'], field['l']]).empty? && field['m'] != 'HV-ARCHIVE'))
       accumulator << 'On order'
     else
       accumulator << 'At the Library'

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1367,7 +1367,7 @@ end
 #
 to_field 'access_facet' do |record, accumulator, context|
   online_locs = ['E-RECVD', 'E-RESV', 'ELECTR-LOC', 'INTERNET', 'KIOST', 'ONLINE-TXT', 'RESV-URL', 'WORKSTATN']
-  on_order_ignore_locs = %w[INPROCESS LAC SPEC-INPRO]
+  on_order_ignore_locs = %w[ENDPROCESS INPROCESS LAC SPEC-INPRO]
   holdings(record, context).each do |holding|
     next if holding.skipped?
 

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -183,8 +183,28 @@ RSpec.describe 'Access config' do
       it { expect(result[field]).not_to include 'On order' }
     end
 
-    context 'when an XX call number is not ON-ORDER (but it is in a blacklisted location)' do
-      let(:test_locations) { %w[LAC INPROCESS] }
+    context 'when an XX call number is not ON-ORDER (but it is in a blacklisted home location)' do
+      let(:test_locations) { %w[LAC INPROCESS SPEC-INPRO] }
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          test_locations.each do |loc|
+            r.append(
+              MARC::DataField.new(
+                '999', ' ', ' ',
+                MARC::Subfield.new('a', 'XXwhatever'),
+                MARC::Subfield.new('k', 'ANYTHING'),
+                MARC::Subfield.new('l', loc)
+              )
+            )
+          end
+        end
+      end
+
+      it { expect(result[field]).not_to include 'On order' }
+    end
+
+    context 'when an XX call number is not ON-ORDER (but it is in a blacklisted current location)' do
+      let(:test_locations) { %w[LAC INPROCESS SPEC-INPRO] }
       let(:record) do
         MARC::Record.new.tap do |r|
           test_locations.each do |loc|
@@ -193,13 +213,6 @@ RSpec.describe 'Access config' do
                 '999', ' ', ' ',
                 MARC::Subfield.new('a', 'XXwhatever'),
                 MARC::Subfield.new('k', loc)
-              )
-            )
-            r.append(
-              MARC::DataField.new(
-                '999', ' ', ' ',
-                MARC::Subfield.new('a', 'XXwhatever'),
-                MARC::Subfield.new('l', loc)
               )
             )
           end

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -134,6 +134,8 @@ RSpec.describe 'Access config' do
   end
 
   describe 'On order' do
+    let(:on_order_ignore_locs) { %w[ENDPROCESS LAC INPROCESS SPEC-INPRO] }
+
     context 'when an XX call number has a current location of ON-ORDER' do
       let(:record) do
         MARC::Record.new.tap do |r|
@@ -184,10 +186,9 @@ RSpec.describe 'Access config' do
     end
 
     context 'when an XX call number is not ON-ORDER (but it is in a blacklisted home location)' do
-      let(:test_locations) { %w[LAC INPROCESS SPEC-INPRO] }
       let(:record) do
         MARC::Record.new.tap do |r|
-          test_locations.each do |loc|
+          on_order_ignore_locs.each do |loc|
             r.append(
               MARC::DataField.new(
                 '999', ' ', ' ',
@@ -204,10 +205,9 @@ RSpec.describe 'Access config' do
     end
 
     context 'when an XX call number is not ON-ORDER (but it is in a blacklisted current location)' do
-      let(:test_locations) { %w[LAC INPROCESS SPEC-INPRO] }
       let(:record) do
         MARC::Record.new.tap do |r|
-          test_locations.each do |loc|
+          on_order_ignore_locs.each do |loc|
             r.append(
               MARC::DataField.new(
                 '999', ' ', ' ',

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -132,4 +132,81 @@ RSpec.describe 'Access config' do
 
     end
   end
+
+  describe 'On order' do
+    context 'when an XX call number has a current location of ON-ORDER' do
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          r.append(
+            MARC::DataField.new(
+              '999', ' ', ' ',
+              MARC::Subfield.new('a', 'XXwhatever'),
+              MARC::Subfield.new('k', 'ON-ORDER')
+            )
+          )
+        end
+      end
+
+      it { expect(result[field]).to eq ['On order'] }
+    end
+
+    context 'when an XX call number is not ON-ORDER (and is not in a blacklisted location)' do
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          r.append(
+            MARC::DataField.new(
+              '999', ' ', ' ',
+              MARC::Subfield.new('a', 'XXwhatever'),
+              MARC::Subfield.new('k', 'SOMEWHERE-ELSE')
+            )
+          )
+        end
+      end
+
+      it { expect(result[field]).to eq ['On order'] }
+    end
+
+    context 'when an XX call number is not ON-ORDER (but is in HV-ARCHIVE)' do
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          r.append(
+            MARC::DataField.new(
+              '999', ' ', ' ',
+              MARC::Subfield.new('a', 'XXwhatever'),
+              MARC::Subfield.new('k', 'SOMEWHERE-ELSE'),
+              MARC::Subfield.new('m', 'HV-ARCHIVE')
+            )
+          )
+        end
+      end
+
+      it { expect(result[field]).not_to include 'On order' }
+    end
+
+    context 'when an XX call number is not ON-ORDER (but it is in a blacklisted location)' do
+      let(:test_locations) { %w[LAC INPROCESS] }
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          test_locations.each do |loc|
+            r.append(
+              MARC::DataField.new(
+                '999', ' ', ' ',
+                MARC::Subfield.new('a', 'XXwhatever'),
+                MARC::Subfield.new('k', loc)
+              )
+            )
+            r.append(
+              MARC::DataField.new(
+                '999', ' ', ' ',
+                MARC::Subfield.new('a', 'XXwhatever'),
+                MARC::Subfield.new('l', loc)
+              )
+            )
+          end
+        end
+      end
+
+      it { expect(result[field]).not_to include 'On order' }
+    end
+  end
 end


### PR DESCRIPTION
Fixes #429 

The first 3 commits make the code a bit more "open" to this change, and just the last one adds it.

Also, I got the 👍 from @saseestone about 6ff2a91 and treating `SPEC-INPRO` like a current and home location.  More details in the commit message.