### PR TITLE
Add a script to seed hashed_id_ssi fields

### DIFF
--- a/script/seed_hashed_id_field.rb
+++ b/script/seed_hashed_id_field.rb
@@ -1,0 +1,16 @@
+require 'httpclient'
+require 'digest/md5'
+
+client = HTTPClient.new
+id_field = ENV['ID_FIELD'] || :id
+
+ARGF.each_line do |id|
+  id.strip!
+
+  doc = {
+   id_field => id.to_s,
+   hashed_id_ssi: Digest::MD5.hexdigest(id)
+ }
+
+  client.post ENV['SOLR_URL'], data: doc.to_json, 'Content-Type' => 'application/json'
+end


### PR DESCRIPTION
Here's a quick, one-off script to seed the hashed_id_ssi fields with data by feeding it  a list of document ids to run an atomic update on.

