### PR TITLE
Simplify and and unify logic for when a link is considered full-text.

### DIFF
--- a/lib/marc_links.rb
+++ b/lib/marc_links.rb
@@ -119,19 +119,18 @@ module MarcLinks
       rescue URI::InvalidURIError
         return nil
     end
+
     def link_is_fulltext?(field)
       resource_labels = ["table of contents", "abstract", "description", "sample text"]
-      if field.indicator2 == "2"
-        return false
-      elsif field.indicator2 == "0" or field.indicator2 == "1" or field.indicator2.nil? or field.indicator2.empty?
-        resource_labels.each do |resource_label|
-          return false if "#{field['3']} #{field['z']}".downcase.include?(resource_label)
-        end
-        return true
-      else
-        # this should catch bad indicators
-        return nil
+      return false unless %w[0 1].include?(field.indicator2)
+
+      # Similar logic exists in the mapping for the url_fulltext field in sirsi traject config.
+      # They need to remain the same (or should be refactored to use the same code in the future)
+      resource_labels.each do |resource_label|
+        return false if "#{field['3']} #{field['z']}".downcase.include?(resource_label)
       end
+
+      true
     end
 
     def link_is_finding_aid?(field)

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1316,12 +1316,9 @@ end
 # get full text urls from 856, then reject gsb forms
 to_field 'url_fulltext' do |record, accumulator|
   Traject::MarcExtractor.new('856u', alternate_script: false).collect_matching_lines(record) do |field, spec, extractor|
-    case field.indicator2
-    when '0'
-      accumulator.concat extractor.collect_subfields(field, spec)
-    when '2'
-      # no-op
-    else
+    if %w[0 1].include?(field.indicator2)
+      # Similar logic exists in the link_is_fulltext? method in the MarcLinks class.
+      # They need to remain the same (or should be refactored to use the same code in the future)
       accumulator.concat extractor.collect_subfields(field, spec) unless field.subfields.select { |f| f.code == 'z' || f.code == '3' }.map(&:value).any? { |v| v =~ /(table of contents|abstract|description|sample text)/i}
     end
   end

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'Access config' do
       expect(select_by_id('856ind2is0')[field]).to include 'Online'
       expect(select_by_id('856ind2is0Again')[field]).to include 'Online'
       expect(select_by_id('856ind2is1NotToc')[field]).to include 'Online'
-      expect(select_by_id('856ind2isBlankFulltext')[field]).to include 'Online'
       expect(select_by_id('956BlankIndicators')[field]).to include 'Online'
       expect(select_by_id('956ind2is0')[field]).to include 'Online'
       expect(select_by_id('956and856TOC')[field]).to include 'Online'
@@ -26,6 +25,8 @@ RSpec.describe 'Access config' do
       expect(select_by_id('956and856TOCand856suppl')[field]).to include 'Online'
       expect(select_by_id('7117119')[field]).to include 'Online'
       expect(select_by_id('newSfx')[field]).to include 'Online'
+      # blank ind2 is most likely not fulltext
+      expect(select_by_id('856ind2isBlankFulltext')[field]).not_to include 'Online'
     end
   end
 

--- a/spec/lib/traject/config/marc_links_spec.rb
+++ b/spec/lib/traject/config/marc_links_spec.rb
@@ -145,10 +145,6 @@ RSpec.describe 'marc_links_struct' do
             <subfield code='u'>https://library.stanford.edu</subfield>
             <subfield code='y'>Link text</subfield>
           </datafield>
-          <datafield tag='856' ind1='0' ind2=''>
-            <subfield code='u'>https://library.stanford.edu</subfield>
-            <subfield code='y'>Link text</subfield>
-          </datafield>
         </record>
       xml
     end
@@ -245,6 +241,10 @@ RSpec.describe 'marc_links_struct' do
             <subfield code='u'>https://library.stanford.edu</subfield>
             <subfield code='y'>Link text</subfield>
             <subfield code='z'>this is the description</subfield>
+          </datafield>
+          <datafield tag='856' ind1='0' ind2=''>
+            <subfield code='u'>https://library.stanford.edu</subfield>
+            <subfield code='y'>Link text</subfield>
           </datafield>
         </record>
       xml

--- a/spec/lib/traject/config/url_spec.rb
+++ b/spec/lib/traject/config/url_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe 'Access config' do
       expect(select_by_id('856ind2is0')[field]).to eq ["http://www.netLibrary.com/urlapi.asp?action=summary&v=1&bookid=122436"]
       expect(select_by_id('856ind2is0Again')[field]).to eq ["http://www.url856.com/fulltext/ind2_0"]
       expect(select_by_id('856ind2is1NotToc')[field]).to eq ["http://www.url856.com/fulltext/ind2_1/not_toc"]
-      expect(select_by_id('856ind2isBlankFulltext')[field]).to eq ["http://www.url856.com/fulltext/ind2_blank/not_toc"]
+      # empty/blank ind2 is most likely not fulltext
+      expect(select_by_id('856ind2isBlankFulltext')[field]).to be_blank
       expect(select_by_id('956BlankIndicators')[field]).to eq ["http://www.url956.com/fulltext/blankIndicators"]
       expect(select_by_id('956ind2is0')[field]).to eq ["http://www.url956.com/fulltext/ind2_is_0"]
       expect(select_by_id('956and856TOC')[field]).to eq ["http://www.url956.com/fulltext/ind2_is_blank"]
@@ -58,6 +59,27 @@ RSpec.describe 'Access config' do
     it 'omits url_fulltext fields for docs with jackson forms for off-site paging requests' do
       expect(select_by_id('123http')[field]).to be_nil
       expect(select_by_id('124http')[field]).to be_nil
+    end
+
+    describe 'Blank 2nd indicators' do
+      let(:records) do
+        [
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '856',
+                '4',
+                nil,
+                MARC::Subfield.new('u', 'http://example.com/')
+              )
+            )
+          end
+        ]
+      end
+
+      it 'are not considered full text' do
+        expect(results.first[field]).to be_blank
+      end
     end
   end
 


### PR DESCRIPTION
We were handling "blank" a indicator2 a bit differently between the marc_links_struct and the url_fulltext field (which is used to determine of Access = Online)

This unifies that approach and simplifies it a bit.

We are no longer trying to treat "blank" indicator2 as full-text anymore in the Online facet.  We only appeared to be in the code before in the marc_links_struct, however a nil or blank indicator2 comes through as " " (failing the `.empty?` check), so was always falling through as falsey for the full-text check anyway (the behavior we likely wanted).

According to https://www.loc.gov/marc/bibliographic/bd856.html, an indicator2 of 0 or 1 is either the resource itself or a version of the resource.  We then take those 856s and cast out any links that have labels that arouse suspicion about the full-text nature of the link (e.g. table of contents).  Any other indicators are treated as not full-text, which is the behavior of what we're showing in the UI. This should have the Online facet more accurately match where we will be displaying links to the user.