### PR TITLE
Update + test against Ruby 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,6 +19,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install dependencies
-      run: bundle install
+      run: bundle install --without production
     - name: Run tests
       run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [jruby-9.2.12.0, 2.7]
+        ruby: [jruby-9.2.14.0, 2.7, 3.0]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/Gemfile
+++ b/Gemfile
@@ -20,8 +20,6 @@ gem 'whenever'
 gem 'honeybadger'
 gem 'retriable'
 gem 'mods_display'
-gem 'eye', platform: :mri
-gem 'config'
 gem 'statsd-ruby'
 gem 'debouncer'
 gem 'dor-rights-auth'

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'dor-rights-auth'
 gem 'sequel'
 gem 'mysql2', '< 0.5.3', platform: :mri
 gem 'jdbc-mysql', '~> 5.1.0', platform: :jruby
+gem 'rexml' # required for ruby 3
 
 group :deployment do
   gem 'capistrano', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,7 @@ GEM
     racc (1.5.2-java)
     rake (13.0.3)
     retriable (3.1.2)
+    rexml (3.2.4)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
       rspec-expectations (~> 3.10.0)
@@ -266,6 +267,7 @@ DEPENDENCIES
   mysql2 (< 0.5.3)
   rake
   retriable
+  rexml
   rspec
   ruby-kafka
   sequel

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     dry-logic (1.1.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
-    dry-schema (1.6.0)
+    dry-schema (1.6.1)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.8, >= 0.8.3)
       dry-core (~> 0.5, >= 0.5)
@@ -134,7 +134,7 @@ GEM
     http-parser (1.2.3)
       ffi-compiler (>= 1.0, < 2.0)
     httpclient (2.8.3)
-    i18n (1.8.7)
+    i18n (1.8.8)
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.10)
     jdbc-mysql (5.1.47)
@@ -162,7 +162,7 @@ GEM
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
-    nio4r (2.5.4)
+    nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -196,7 +196,7 @@ GEM
     ruby-kafka (1.3.0)
       digest-crc
     scrub_rb (1.0.1)
-    sequel (5.40.0)
+    sequel (5.41.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -242,6 +242,7 @@ GEM
 PLATFORMS
   java
   ruby
+  universal-java-15
   x86_64-linux
 
 DEPENDENCIES
@@ -276,4 +277,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   2.2.7
+   2.2.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,34 +32,9 @@ GEM
       capistrano (~> 3.0)
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
-    celluloid (0.17.4)
-      celluloid-essentials
-      celluloid-extras
-      celluloid-fsm
-      celluloid-pool
-      celluloid-supervision
-      timers (>= 4.1.1)
-    celluloid-essentials (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-extras (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-fsm (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-io (0.17.3)
-      celluloid (>= 0.17.2)
-      nio4r (>= 1.1)
-      timers (>= 4.1.1)
-    celluloid-pool (0.20.5)
-      timers (>= 4.1.1)
-    celluloid-supervision (0.20.6)
-      timers (>= 4.1.1)
     chronic (0.10.2)
     concurrent-ruby (1.1.8)
-    config (2.2.3)
-      deep_merge (~> 1.2, >= 1.2.1)
-      dry-validation (~> 1.0, >= 1.0.0)
     debouncer (0.2.2)
-    deep_merge (1.2.1)
     diff-lcs (1.4.4)
     digest-crc (0.6.3)
       rake (>= 12.0.0, < 14.0.0)
@@ -74,48 +49,8 @@ GEM
     dor-rights-auth (1.7.0)
       nokogiri
     dot-properties (0.1.3)
-    dry-configurable (0.12.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 0.5, >= 0.5.0)
-    dry-container (0.7.2)
-      concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.1, >= 0.1.3)
-    dry-core (0.5.0)
-      concurrent-ruby (~> 1.0)
-    dry-equalizer (0.3.0)
-    dry-inflector (0.2.0)
-    dry-initializer (3.0.4)
-    dry-logic (1.1.0)
-      concurrent-ruby (~> 1.0)
-      dry-core (~> 0.5, >= 0.5)
-    dry-schema (1.6.1)
-      concurrent-ruby (~> 1.0)
-      dry-configurable (~> 0.8, >= 0.8.3)
-      dry-core (~> 0.5, >= 0.5)
-      dry-initializer (~> 3.0)
-      dry-logic (~> 1.0)
-      dry-types (~> 1.5)
-    dry-types (1.5.0)
-      concurrent-ruby (~> 1.0)
-      dry-container (~> 0.3)
-      dry-core (~> 0.5, >= 0.5)
-      dry-inflector (~> 0.1, >= 0.1.2)
-      dry-logic (~> 1.0, >= 1.0.2)
-    dry-validation (1.6.0)
-      concurrent-ruby (~> 1.0)
-      dry-container (~> 0.7, >= 0.7.1)
-      dry-core (~> 0.4)
-      dry-equalizer (~> 0.2)
-      dry-initializer (~> 3.0)
-      dry-schema (~> 1.5, >= 1.5.2)
     edtf (3.0.6)
       activesupport (>= 3.0, < 7.0)
-    eye (0.10.0)
-      celluloid (~> 0.17.3)
-      celluloid-io (~> 0.17.0)
-      kostya-sigar (~> 2.0.0)
-      state_machines
-      thor
     ffi (1.14.2)
     ffi (1.14.2-java)
     ffi-compiler (1.0.1)
@@ -138,7 +73,6 @@ GEM
       concurrent-ruby (~> 1.0)
     iso-639 (0.2.10)
     jdbc-mysql (5.1.47)
-    kostya-sigar (2.0.8)
     manticore (0.7.0-java)
       openssl_pkcs8_pure
     marc (1.0.4)
@@ -162,7 +96,6 @@ GEM
     net-scp (3.0.0)
       net-ssh (>= 2.6.5, < 7.0.0)
     net-ssh (6.1.0)
-    nio4r (2.5.5)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -211,10 +144,8 @@ GEM
     stanford-mods (2.6.2)
       activesupport
       mods (~> 2.2)
-    state_machines (0.5.0)
     statsd-ruby (1.5.0)
     thor (1.1.0)
-    timers (4.3.2)
     traject (3.5.0)
       concurrent-ruby (>= 0.8.0)
       dot-properties (>= 0.1.1)
@@ -252,11 +183,9 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rvm
   capistrano-shared_configs
-  config
   debouncer
   dlss-capistrano
   dor-rights-auth
-  eye
   honeybadger
   http
   i18n

--- a/lib/sdr_stuff.rb
+++ b/lib/sdr_stuff.rb
@@ -181,7 +181,7 @@ class PublicXmlRecord
     return unless thumb
     thumb_druid=thumb.split('/').first # the druid (before the first slash)
     thumb_filename=thumb.split(/[a-zA-Z]{2}[0-9]{3}[a-zA-Z]{2}[0-9]{4}[\/]/).last # everything after the druid
-    "#{thumb_druid}%2F#{URI.escape(thumb_filename)}"
+    "#{thumb_druid}%2F#{ERB::Util.url_encode(thumb_filename)}"
   end
 
   # get the druids from predicate relationships in rels-ext from public_xml

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -368,7 +368,7 @@ def reserves_lookup
       header_converters: :symbol, quote_char: "\x00"
     }
 
-    CSV.foreach(reserves_file, csv_options) do |row|
+    CSV.foreach(reserves_file, **csv_options) do |row|
       if row[:item_rez_status] == 'ON_RESERVE'
         ckey = row[:ckey]
         crez_value = reserves_data[ckey] || []


### PR DESCRIPTION
This PR also removes `eye` and `config` from the Gemfile; there's a semi-convincing argument to be made that they aren't really part of the application, just part of how it's deployed, and don't belong here (plus... there's some weird bundler/jruby/eye interaction going on 🤷‍♂️ ).

We'll be moving off `eye` sooner rather than later anyway.