### PR TITLE
Make sure chapter numbers are in a non-matching group to avoid extra splitting

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2040,8 +2040,8 @@ to_field 'toc_struct' do |marc, accumulator|
     /[^\S]\.-[^\S]/, # or a .-
     /(?=(?:Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i, # and sometimes not even that; here are some common patterns that suggest chapters
     /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i,
-    /(?=(\d+[:\.-]\s+))/i, # but sometimes it's just a number with something after it
-    /(?=(\s{2,}\d+\s+))/i # or even just a number with a little extra whitespace in front of it
+    /(?=(?:\d+[:\.-]\s+))/i, # but sometimes it's just a number with something after it
+    /(?=(?:\s{2,}\d+\s+))/i # or even just a number with a little extra whitespace in front of it
   ]
   fields = []
   vern = []

--- a/spec/lib/traject/config/note_fields_spec.rb
+++ b/spec/lib/traject/config/note_fields_spec.rb
@@ -296,6 +296,28 @@ RSpec.describe 'Sirsi config' do
           expect(result_field.first[:fields].first).to include '1 Introduction 9', '1.1 Human Body - Kinematic Perspective 10'
         end
       end
+
+      context 'with chapters with colons' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '905', ' ', ' ',
+                MARC::Subfield.new('a', toc)
+              )
+            )
+          end
+        end
+
+        let(:toc) do
+          'Preface  Part I: Fundamentals  1: Energy in Thermal Physics  2: The Second Law  3: Interactions and Implications  Part II: Thermodynamics  4: Engines and Refrigerators  5: Free Energy and Chemical Thermodynamics  Part III: Statistical Mechanics  6: Boltzmann Statistics  7: Quantum Statistics  8: Systems of Interacting Particles  Appendix A: Elements of Quantum Mechanics  Appendix B: Mathematical Results  Suggested Reading  Reference Data  Index.'
+        end
+
+        it 'splits on chapter numbers' do
+          expect(result_field.first[:fields].first).not_to include '1:'
+          expect(result_field.first[:fields].first).to include '1: Energy in Thermal Physics'
+        end
+      end
     end
 
     context 'with unmatched vernacular' do


### PR DESCRIPTION
e.g. https://searchworks.stanford.edu/view/9629895