### PR TITLE
Remove double quotes from contributor search value in author_struct.

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -804,7 +804,7 @@ def assemble_contributor_data_struct(field)
 
   {
     link: link_text.join(' '),
-    search: "\"#{link_text.join(' ')}\"",
+    search: link_text.join(' '),
     pre_text: before_text.join(' '),
     post_text: relator_text.join(' ') + extra_text.join(' '),
     authorities: field.subfields.select { |x| x.code == '0' }.map(&:value),

--- a/spec/lib/traject/config/author_spec.rb
+++ b/spec/lib/traject/config/author_spec.rb
@@ -682,7 +682,7 @@ RSpec.describe 'Author config' do
       expect(result).to include contributors: array_including(
         hash_including(
           link: '700a 700b 700c 700d none 700g 700j 700q 700u',
-          search: '"700a 700b 700c 700d none 700g 700j 700q 700u"',
+          search: '700a 700b 700c 700d none 700g 700j 700q 700u',
           pre_text: '',
           post_text: '700e'
         )


### PR DESCRIPTION
Fixes SearchWorks #2770.