### PR TITLE
Split TOC data in the same way for 505 and 880 fields

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2001,16 +2001,6 @@ end
 #    vernacular: [['The same, but pulled from the matched vernacular fields']]
 #    unmatched_vernacular: [['The same, but pulled from any unmatched vernacular fields']]
 to_field 'toc_struct' do |marc, accumulator|
-  formatted_chapter_regexes = [
-    /[^\S]--[^\S]/, # this is the normal, expected MARC delimiter
-    /      /, # but a bunch of eResources like to use whitespace
-    /--[^\S]/, # or omit the leading whitespace
-    /[^\S]\.-[^\S]/, # or a .-
-    /(?=(?:Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i, # and sometimes not even that; here are some common patterns that suggest chapters
-    /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i,
-    /(?=[^\d](?:\d+[:\.-]\s+))/i, # but sometimes it's just a number with something after it
-    /(?=(?:\s{2,}\d+\s+))/i # or even just a number with a little extra whitespace in front of it
-  ]
   fields = []
   vern = []
   unmatched_vern = []
@@ -2026,18 +2016,12 @@ to_field 'toc_struct' do |marc, accumulator|
         if sub_field.code == 'a'
           data << buffer.map { |w| w.strip unless w.strip.empty? }.compact.join(' ') if buffer.any?
           buffer = []
-          found = false
-          formatted_chapter_regexes.each do |regex|
-            chapters = regex_split(sub_field.value, regex).map { |w| w.strip unless w.strip.empty? }.compact
-
-            if chapters.length > 1
-              found = true
-              data.concat(chapters)
-              break
-            end
+          chapters = split_toc_chapters(sub_field.value)
+          if chapters.length > 1
+            data.concat(chapters)
+          else
+            data.concat([sub_field.value])
           end
-
-          data.concat([sub_field.value]) unless found
         elsif sub_field.code == "1" && !Constants::SOURCES[sub_field.value.strip].nil?
           data << buffer.map { |w| w.strip unless w.strip.empty? }.compact.join(' ') if buffer.any?
           buffer = []
@@ -2053,10 +2037,12 @@ to_field 'toc_struct' do |marc, accumulator|
           end
         end
       end
+
       data << buffer.map { |w| w.strip unless w.strip.empty? }.compact.join(' ') unless buffer.empty?
       fields << data
+
       vernacular = get_marc_vernacular(marc,field)
-      vern << regex_split(vernacular, /[^\S]--[^\S]/).map { |w| w.strip unless w.strip.empty? }.compact unless vernacular.nil?
+      vern << split_toc_chapters(vernacular).map { |w| w.strip unless w.strip.empty? }.compact unless vernacular.nil?
     end
   end
 
@@ -2071,6 +2057,30 @@ to_field 'toc_struct' do |marc, accumulator|
   new_fields = fields unless fields.empty?
   new_unmatched_vern = unmatched_vern unless unmatched_vern.empty?
   accumulator << {:label=>"Contents",:fields=>new_fields,:vernacular=>new_vern,:unmatched_vernacular=>new_unmatched_vern} unless (new_fields.nil? and new_vern.nil? and new_unmatched_vern.nil?)
+end
+
+def split_toc_chapters(value)
+  formatted_chapter_regexes = [
+    /[^\S]--[^\S]/, # this is the normal, expected MARC delimiter
+    /      /, # but a bunch of eResources like to use whitespace
+    /--[^\S]/, # or omit the leading whitespace
+    /[^\S]\.-[^\S]/, # or a .-
+    /(?=(?:Chapter|Section|Appendix|Part|v\.) \d+[:\.-]?\s+)/i, # and sometimes not even that; here are some common patterns that suggest chapters
+    /(?=(?:Appendix|Section|Chapter) [XVI]+[\.-]?)/i,
+    /(?=[^\d](?:\d+[:\.-]\s+))/i, # but sometimes it's just a number with something after it
+    /(?=(?:\s{2,}\d+\s+))/i # or even just a number with a little extra whitespace in front of it
+  ]
+  chapters = []
+  match = false
+  formatted_chapter_regexes.each do |regex|
+    chapters = regex_split(value, regex).map { |w| w.strip unless w.strip.empty? }.compact
+    # if the regex_split found a match and actually split the string, we are done
+    if chapters.length > 1
+      match = true
+      break
+    end
+  end
+  chapters
 end
 
 # work-around for https://github.com/jruby/jruby/issues/4868

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2070,17 +2070,12 @@ def split_toc_chapters(value)
     /(?=[^\d](?:\d+[:\.-]\s+))/i, # but sometimes it's just a number with something after it
     /(?=(?:\s{2,}\d+\s+))/i # or even just a number with a little extra whitespace in front of it
   ]
-  chapters = []
-  match = false
   formatted_chapter_regexes.each do |regex|
-    chapters = regex_split(value, regex).map { |w| w.strip unless w.strip.empty? }.compact
-    # if the regex_split found a match and actually split the string, we are done
-    if chapters.length > 1
-      match = true
-      break
-    end
+    chapters = value.split(regex).map { |w| w.strip unless w.strip.empty? }.compact
+    # if the split found a match and actually split the string, we are done
+    return chapters if chapters.length > 1
   end
-  chapters
+  [value]
 end
 
 # work-around for https://github.com/jruby/jruby/issues/4868

--- a/spec/lib/traject/config/note_fields_spec.rb
+++ b/spec/lib/traject/config/note_fields_spec.rb
@@ -182,6 +182,28 @@ RSpec.describe 'Sirsi config' do
         end
       end
 
+      context 'with vernacular toc data' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(MARC::DataField.new(
+              '505', ' ', ' ',
+              MARC::Subfield.new('a', 'aaa -- bbb -- ccc'),
+              MARC::Subfield.new('6', '880-04')
+            ))
+            r.append(MARC::DataField.new(
+              '880', ' ', ' ',
+              MARC::Subfield.new('a', 'v. 1. 土偶--v. 2. 仏像--v. 3. 銅器, 玉器.'),
+              MARC::Subfield.new('6', '505-04')
+            ))
+          end
+        end
+
+        it 'structures the output' do
+          expect(result_field.first[:fields].first).to eq ['aaa', 'bbb', 'ccc']
+          expect(result_field.first[:vernacular].first).to eq ['v. 1. 土偶--', 'v. 2. 仏像--', 'v. 3. 銅器, 玉器.']
+        end
+      end
+
       context 'with numbers that should not be split on in the data' do
         let(:record) do
           MARC::Record.new.tap do |r|


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/SearchWorks/issues/2848

This PR pulls out the regex logic into its own method, and applies that to both 505 and 880 TOC fields. Before, the 880 field was only getting checked by a minimal regex, instead of the whole array of regexes applied to the 505 field. 