### PR TITLE
Display "(source: Casalini)" only once.

### DIFF
--- a/lib/marc_links.rb
+++ b/lib/marc_links.rb
@@ -43,7 +43,8 @@ module MarcLinks
     private
 
     def link_is_casalini?
-      field["x"] and field["x"] == "CasaliniTOC"
+      (field["x"] && field["x"] == "CasaliniTOC") ||
+        (field.subfields.find { |sf| sf.code == "z" && sf.value.match?(casalini_subz_regex) })
     end
 
     def link_is_sfx?
@@ -104,6 +105,8 @@ module MarcLinks
       return unless stanford_only?
 
       subbed_title = subzs.gsub(stanford_affiliated_regex, '')
+                          .gsub(casalini_subz_regex, '')
+                          .strip
       subbed_title unless subbed_title.empty?
     end
 
@@ -148,6 +151,10 @@ module MarcLinks
 
     def stanford_affiliated_regex
       Regexp.new(/available[ -]?to[ -]?stanford[ -]?affiliated[ -]?users[ -]?a?t?[:;.]?/i)
+    end
+
+    def casalini_subz_regex
+      Regexp.new(/\(?source:?\s?casalini\)?/i)
     end
 
     def stanford_law_affiliated_regex

--- a/spec/lib/traject/config/marc_links_spec.rb
+++ b/spec/lib/traject/config/marc_links_spec.rb
@@ -57,27 +57,48 @@ RSpec.describe 'marc_links_struct' do
     let(:marc) do
       <<-xml
         <record>
-          <datafield tag='856' ind1='0' ind2='0'>
+          <datafield tag='856' ind1='4' ind2='1'>
             <subfield code='3'>Link text</subfield>
+            <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
             <subfield code='u'>https://library.stanford.edu</subfield>
             <subfield code='x'>CasaliniTOC</subfield>
             <subfield code='y'>Link text</subfield>
-            <subfield code='z'>Title text1</subfield>
-            <subfield code='z'>Title text2</subfield>
+            <subfield code='z'>(source: Casalini)</subfield>
+          </datafield>
+          <datafield tag='856' ind1='4' ind2='1'>
+            <subfield code='3'>Link text</subfield>
+            <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
+            <subfield code='u'>https://library.stanford.edu</subfield>
+            <subfield code='y'>Link text</subfield>
+            <subfield code='z'>(source: Casalini)</subfield>
+          </datafield>
+          <datafield tag='856' ind1='4' ind2='1'>
+            <subfield code='3'>Link text</subfield>
+            <subfield code='z'>Available to Stanford-affiliated users at:</subfield>
+            <subfield code='u'>https://library.stanford.edu</subfield>
+            <subfield code='x'>CasaliniTOC</subfield>
+            <subfield code='y'>Link text</subfield>
           </datafield>
         </record>
       xml
     end
-    it "should not have any text before the link" do
+    it "does not have any text before the link" do
       expect(result_field.first[:html]).to match /^<a /
     end
-    it "should place $3 as the link text" do
+    it "places $3 as the link text" do
       expect(result_field.first[:html]).to match /<a.*>Link text<\/a>/
     end
-    it "should place '(source: Casalini)' after the link" do
+    it "places '(source: Casalini)' after the link" do
       expect(result_field.first[:html]).to match /<\/a> \(source: Casalini\)/
     end
+    it "does not place '(source: Casalini)' twice after the link" do
+      expect(result_field.first[:html]).not_to match /<\/a> \(source: Casalini\).*\(source: Casalini\)/
+    end
+    it "identifies the link as a Casalini link from value of $x or $z" do
+      expect(result_field.all? { |x| x[:casalini] }).to be_truthy
+    end
   end
+
   context "stanford_only" do
     let(:marc) do
       <<-xml


### PR DESCRIPTION
This solution assumes that we can identify a Casalini link by the presence of:

`<subfield code='x'>CasaliniTOC</subfield>` OR `<subfield code='z'>(source: Casalini)</subfield>`

It also assumes that we may not be able to count on the presence of $z for all Casalini links so we retain the logic related to generating the "(source: Casalini)" text within `MarcLink` rather than plucking it from the MARC record.

Fixes: https://github.com/sul-dlss/SearchWorks/issues/2863