### PR TITLE
Add fields to capture DOR Public XML info: content types, resource counts, rights, etc.

### DIFF
--- a/lib/sdr_stuff.rb
+++ b/lib/sdr_stuff.rb
@@ -127,6 +127,31 @@ class PublicXmlRecord
     public_xml_doc.xpath('//contentMetadata/@type').text
   end
 
+  # the values of the type attribute for a DOR object's contentMetadata/resource elements
+  # @return [Array<String>]
+  def dor_resource_content_type
+    public_xml_doc.xpath('//contentMetadata/resource/@type').map(&:text)
+  end
+
+  # the values of the mimetype attribute for a DOR object's contentMetadata/resource/* elements
+  # @return [Array<String>]
+  def dor_file_mimetype
+    public_xml_doc.xpath('//contentMetadata/resource/*/@mimetype').map(&:text)
+  end
+
+  # the count of a DOR object's contentMetadata/resource elements
+  # @return [Integer]
+  def dor_resource_count
+    public_xml_doc.xpath('//contentMetadata/resource').count
+  end
+
+  # the element names for a DOR object's rightsMetadata/access/machine/*
+  # where the access type is "read"
+  # @return [Array<String>]
+  def dor_read_rights
+    public_xml_doc.xpath('//rightsMetadata/access[@type="read"]/machine/*').map(&:name)
+  end
+
   # the thumbnail in publicXML, falling back to the first image if no thumb node is found
    # @return [String] thumb filename with druid prepended, e.g. oo000oo0001/filename withspace.jp2
    def parse_thumb

--- a/lib/traject/config/sdr_config.rb
+++ b/lib/traject/config/sdr_config.rb
@@ -388,6 +388,32 @@ to_field 'iiif_manifest_url_ssim' do |record, accumulator|
   end
 end
 
+to_field 'dor_content_type_ssi' do |record, accumulator|
+  accumulator << record.dor_content_type if record.dor_content_type.present?
+end
+
+to_field 'dor_resource_content_type_ssim' do |record, accumulator|
+  record.dor_resource_content_type.uniq.each do |type|
+    accumulator << type
+  end
+end
+
+to_field 'dor_file_mimetype_ssim' do |record, accumulator|
+  record.dor_file_mimetype.uniq.each do |mimetype|
+    accumulator << mimetype
+  end
+end
+
+to_field 'dor_resource_count_isi' do |record, accumulator|
+  accumulator << record.dor_resource_count
+end
+
+to_field 'dor_read_rights_ssim' do |record, accumulator|
+  record.dor_read_rights.uniq.each do |right|
+    accumulator << right
+  end
+end
+
 to_field 'context_source_ssi', literal('sdr')
 
 to_field 'context_version_ssi' do |_record, accumulator|

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -279,6 +279,79 @@ describe 'SDR indexing' do
     end
   end
 
+  context 'content metadata' do
+    subject(:result) { indexer.map_record(PublicXmlRecord.new('abc')) }
+
+    before do
+      stub_purl_request(druid, data)
+    end
+
+    let(:druid) { 'abc' }
+    let(:data) do
+      <<-XML
+        <publicObject>
+          <contentMetadata type="image">
+            <resource id="cocina-fileSet-5925b0a8-fa41-4fb8-94e2-704fce68caf9" sequence="1" type="object">
+              <label>Data</label>
+              <file id="data.zip" mimetype="application/zip" size="172098005" role="master"></file>
+              <file id="data_EPSG_4326.zip" mimetype="application/zip" size="146314425" role="derivative"></file>
+            </resource>
+            <resource id="cocina-fileSet-569954ba-6239-4222-88a4-2f8d584bfc42" sequence="2" type="preview">
+              <label>Preview</label>
+              <file id="preview.jpg" mimetype="image/jpeg" size="16749" role="master">
+                <imageData height="200" width="300"/>
+              </file>
+            </resource>
+          </contentMetadata>
+          <mods xmlns="http://www.loc.gov/mods/v3"></mods>
+        </publicObject>
+      XML
+    end
+
+    it 'maps the right data' do
+      expect(result['dor_content_type_ssi']).to eq ['image']
+      expect(result['dor_resource_content_type_ssim']).to eq ['object', 'preview']
+      expect(result['dor_file_mimetype_ssim']).to eq ['application/zip', 'image/jpeg']
+      expect(result['dor_resource_count_isi']).to eq [2]
+    end
+  end
+
+  context 'rights metadata' do
+    subject(:result) { indexer.map_record(PublicXmlRecord.new('abc')) }
+
+    before do
+      stub_purl_request(druid, data)
+    end
+
+    let(:druid) { 'abc' }
+    let(:data) do
+      <<-XML
+        <publicObject>
+          <rightsMetadata>
+            <access type="discover">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <access type="read">
+              <machine>
+                <world/>
+              </machine>
+            </access>
+            <use>
+              <human type="useAndReproduction">Property rights reside with the repository.</human>
+            </use>
+          </rightsMetadata>
+          <mods xmlns="http://www.loc.gov/mods/v3"></mods>
+        </publicObject>
+      XML
+    end
+
+    it 'maps the right data' do
+      expect(result['dor_read_rights_ssim']).to eq ['world']
+    end
+  end
+
   context 'dates' do
     subject(:result) { indexer.map_record(PublicXmlRecord.new('abc')) }
 


### PR DESCRIPTION
New fields:

`dor_content_type_ssi`
`dor_resource_content_type_ssim`
`dor_file_mimetype_ssim`
`dor_resource_count_isi`
`dor_read_rights_ssim`

Partially addresses https://github.com/sul-dlss/SearchWorks/issues/2885