### PR TITLE
Use double quotes to enclose HTML attributes in marc_links_struct; fixes #2962

### DIFF
--- a/lib/marc_links.rb
+++ b/lib/marc_links.rb
@@ -18,8 +18,11 @@ module MarcLinks
       {
         version: '0.1',
 
-        html: [%Q(<a title="#{link_title}" href="#{link_field['u']}">#{link_text}</a>), "#{'(source: Casalini)' if link_is_casalini?}", (%Q( <span class="additional-link-text">#{additional_text}</span>) if additional_text)].compact.join(' '),
-        text: [link_text, "#{'(source: Casalini)' if link_is_casalini?}", (" <span class='additional-link-text'>#{additional_text}</span>" if additional_text)].compact.join(' ').strip,
+        html: [%Q(<a title="#{link_title_html_escaped}" href="#{link_field_html_escaped}">#{link_text_html_escaped}</a>),
+               "#{'(source: Casalini)' if link_is_casalini?}",
+               (%Q( <span class="additional-link-text">#{additional_text_html_escaped}</span>) if additional_text)].compact.join(' '),
+        text: [link_text_html_escaped, "#{'(source: Casalini)' if link_is_casalini?}",
+               (" <span class='additional-link-text'>#{additional_text_html_escaped}</span>" if additional_text)].compact.join(' ').strip,
 
         stanford_only: stanford_only?,
         stanford_law_only: stanford_law_only?,
@@ -41,6 +44,22 @@ module MarcLinks
     end
 
     private
+
+    def link_title_html_escaped
+      CGI::escapeHTML(link_title.to_s)
+    end
+
+    def link_field_html_escaped
+      CGI::escapeHTML(link_field['u'].to_s)
+    end
+
+    def link_text_html_escaped
+      CGI::escapeHTML(link_text.to_s)
+    end
+
+    def additional_text_html_escaped
+      CGI::escapeHTML(additional_text.to_s)
+    end
 
     def link_is_casalini?
       (field["x"] && field["x"] == "CasaliniTOC") ||

--- a/lib/marc_links.rb
+++ b/lib/marc_links.rb
@@ -18,7 +18,7 @@ module MarcLinks
       {
         version: '0.1',
 
-        html: ["<a title='#{link_title}' href='#{link_field["u"]}'>#{link_text}</a>", "#{'(source: Casalini)' if link_is_casalini?}", (" <span class='additional-link-text'>#{additional_text}</span>" if additional_text)].compact.join(' '),
+        html: [%Q(<a title="#{link_title}" href="#{link_field['u']}">#{link_text}</a>), "#{'(source: Casalini)' if link_is_casalini?}", (%Q( <span class="additional-link-text">#{additional_text}</span>) if additional_text)].compact.join(' '),
         text: [link_text, "#{'(source: Casalini)' if link_is_casalini?}", (" <span class='additional-link-text'>#{additional_text}</span>" if additional_text)].compact.join(' ').strip,
 
         stanford_only: stanford_only?,

--- a/spec/lib/traject/config/marc_links_spec.rb
+++ b/spec/lib/traject/config/marc_links_spec.rb
@@ -344,6 +344,22 @@ RSpec.describe 'marc_links_struct' do
         expect(result_field.first[:html]).to match(%r{>library\.stanford\.edu</a>})
       end
     end
+
+    context 'with characters that need to be HTML escaped' do
+      let(:marc) do
+        <<-xml
+          <record>
+            <datafield tag='856' ind1='0' ind2='0'>
+              <subfield code='u'>https://somelink/with'singlequote.pdf</subfield>
+            </datafield>
+          </record>
+        xml
+      end
+
+      it 'HTML escapes the single quote' do
+        expect(result_field.first[:html]).to match(%r{with&#39;singlequote\.pdf})
+      end
+    end
   end
 
   # this is testing a workaround for a JRuby internal encoding bug that blows up with

--- a/spec/lib/traject/config/marc_links_spec.rb
+++ b/spec/lib/traject/config/marc_links_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'marc_links_struct' do
       expect(result_field.first[:html]).to match /<a.*>Link text 1 Link text 2<\/a>/
     end
     it "should place the $z as the link title attribute" do
-      expect(result_field.first[:html]).to match /<a.*title='Title text1 Title text2'.*>/
+      expect(result_field.first[:html]).to match /<a.*title="Title text1 Title text2".*>/
     end
     it 'should include the plain text version' do
       expect(result_field.first[:text]).to eq "Link text 1 Link text 2"


### PR DESCRIPTION
The other way to fix this would be to encode the single quote as `%27`, but it seems preferable to just use double quotes to enclose the HTML attributes since un-encoded double quotes are not valid in URLs.

Before:
```
<a title='' href='https://www.africamuseum.be/sites/default/files/media/docs/research/publications/rmca/online/documents-social-sciences-humanities/L'Echo_des_Monts_et_Vallees.pdf'>www.africamuseum.be</a>
```
After:
```
<a title="" href="https://www.africamuseum.be/sites/default/files/media/docs/research/publications/rmca/online/documents-social-sciences-humanities/L'Echo_des_Monts_et_Vallees.pdf">www.africamuseum.be</a>
```

Fixes: https://github.com/sul-dlss/SearchWorks/issues/2962
