### PR TITLE
Strip junk tags from folio records

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -1,4 +1,5 @@
 require 'active_support/core_ext/module/delegation'
+require_relative 'traject/common/constants'
 
 class FolioRecord
   attr_reader :record, :client
@@ -10,7 +11,7 @@ class FolioRecord
   end
 
   def marc_record
-    @marc_record ||= MARC::Record.new_from_hash(record.dig('parsedRecord', 'content'))
+    @marc_record ||= MARC::Record.new_from_hash(stripped_marc_json)
   end
 
   def instance_id
@@ -79,6 +80,14 @@ class FolioRecord
         skipSuppressedFromDiscoveryRecords: false
       }
       client.get_json("/inventory-hierarchy/items-and-holdings", method: :post, body: body.to_json)
+    end
+  end
+
+  private
+
+  def stripped_marc_json
+    record.dig('parsedRecord', 'content').tap do |record|
+      record['fields'] = record['fields'].reject { |field| Constants::JUNK_TAGS.include?(field.keys.first)  }
     end
   end
 end

--- a/lib/traject/common/constants.rb
+++ b/lib/traject/common/constants.rb
@@ -218,4 +218,8 @@ module Constants
                     'wdc' => 'Woodcutter',
                     'wde' => 'Wood -engraver',
                     'wit' => 'Witness' }
+
+  # Stripped from MARC when indexing
+  JUNK_TAGS = [
+    '901', '910', '918', '923', '924', '930', '935', '940', '948', '949', '950', '955', '960', '962', '980', '981', '983', '990', '993', '998']
 end

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -171,15 +171,3 @@ end
 to_field 'holdings_json_struct' do |record, accumulator|
   accumulator << JSON.generate(record.items_and_holdings) if record.items_and_holdings
 end
-
-
-## Postprocessing
-# https://consul.stanford.edu/display/SYSTEMS/Data+Feed+to+SearchWorks
-
-# Remove "junk tags"
-each_record do |record, context|
-end
-
-# Add date accessed (from client) to marc 005
-each_record do |record, context|
-end

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -165,9 +165,21 @@ to_field 'uuid_ssi' do |record, accumulator|
 end
 
 to_field 'folio_json_struct' do |record, accumulator|
-  accumulator << JSON.generate(record.record)
+  accumulator << JSON.generate(record.record.except('parsedRecord'))
 end
 
 to_field 'holdings_json_struct' do |record, accumulator|
   accumulator << JSON.generate(record.items_and_holdings) if record.items_and_holdings
+end
+
+
+## Postprocessing
+# https://consul.stanford.edu/display/SYSTEMS/Data+Feed+to+SearchWorks
+
+# Remove "junk tags"
+each_record do |record, context|
+end
+
+# Add date accessed (from client) to marc 005
+each_record do |record, context|
 end

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'folio_client'
+require 'folio_record'
+
+RSpec.describe FolioRecord do
+  subject(:folio_record) { described_class.new(record, client) }
+  let(:client) { instance_double(FolioClient) }
+  let(:record) do
+    {
+      'parsedRecord' => {
+        'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
+        'content' => {
+          'fields' => [
+            { '001' => 'a14154194' },
+            { '918' => {
+              'subfields' => [
+                { 'a' => '14154194' }
+              ]
+            } }
+          ]
+        }
+      }
+    }
+  end
+
+  describe '#marc_record' do
+    it 'strips junk tags' do
+      expect(folio_record.marc_record['918']).to be_nil
+    end
+
+    it 'preserves non-junk tags' do
+      expect(folio_record.marc_record['001']).to have_attributes(tag: '001', value: 'a14154194')
+    end
+  end
+end


### PR DESCRIPTION
See #662 for a list of junk tags, and https://consul.stanford.edu/display/SYSTEMS/Data+Feed+to+SearchWorks#DataFeedtoSearchWorks-PostProcessing for a detailed explanation of processing steps that we're hoping to move to traject (of which this is one).

- Strip parsedRecord from folio_json_struct
- Implement junk tag stripping for Folio records

We ultimately decided not to strip some of the things that were in the list, including 001, 003, and the 8xx fields. It turned out that some of this data was actually used (e.g. for MHLDs in the case of the 8xx) or at least not harmful (in the case of 001 and 003).