### PR TITLE
Cherry-pick useful refactoring from #692

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -34,7 +34,7 @@ class FolioClient
   end
 
   def source_record(**kwargs)
-    FolioRecord.new(get_json("/source-storage/source-records", params: kwargs).dig('sourceRecords', 0), self)
+    FolioRecord.new_from_source_record(get_json("/source-storage/source-records", params: kwargs).dig('sourceRecords', 0), self)
   end
 
   private

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -10,6 +10,17 @@ class FolioRecord
     @client = client
   end
 
+  def self.new_from_source_record(record, client)
+    FolioRecord.new({
+      'source_record' => [
+        record.dig('parsedRecord', 'content')
+      ],
+      'instance' => {
+        'id' => record.dig('externalIdsHolder', 'instanceId')
+      }
+    }, client)
+  end
+
   def marc_record
     @marc_record ||= MARC::Record.new_from_hash(stripped_marc_json)
   end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -5,11 +5,6 @@ class FolioRecord
   attr_reader :record, :client
   delegate :fields, :each, :[], :leader, :tags, :select, :find_all, :to_hash, to: :marc_record
 
-  def initialize(record, client)
-    @record = record
-    @client = client
-  end
-
   def self.new_from_source_record(record, client)
     FolioRecord.new({
       'source_record' => [
@@ -21,12 +16,17 @@ class FolioRecord
     }, client)
   end
 
+  def initialize(record, client = nil)
+    @record = record
+    @client = client
+  end
+
   def marc_record
     @marc_record ||= MARC::Record.new_from_hash(stripped_marc_json)
   end
 
   def instance_id
-    record.dig('externalIdsHolder', 'instanceId')
+    record.dig('instance', 'id')
   end
 
   def sirsi_holdings
@@ -77,12 +77,21 @@ class FolioRecord
   end
 
   def items
-    items_and_holdings&.dig('items') || []
+    record['items'] || items_and_holdings&.dig('items') || []
   end
 
   def holdings
-    items_and_holdings&.dig('holdings') || []
+    record['holdings'] || items_and_holdings&.dig('holdings') || []
   end
+
+  def as_json
+    json = record.except('source_record')
+    json['items'] ||= items
+    json['holdings'] ||= holdings
+    json
+  end
+
+  private
 
   def items_and_holdings
     @items_and_holdings ||= begin
@@ -90,15 +99,13 @@ class FolioRecord
         instanceIds: [instance_id],
         skipSuppressedFromDiscoveryRecords: false
       }
-      client.get_json("/inventory-hierarchy/items-and-holdings", method: :post, body: body.to_json)
+      client.get_json('/inventory-hierarchy/items-and-holdings', method: :post, body: body.to_json)
     end
   end
 
-  private
-
   def stripped_marc_json
-    record.dig('parsedRecord', 'content').tap do |record|
-      record['fields'] = record['fields'].reject { |field| Constants::JUNK_TAGS.include?(field.keys.first)  }
+    record.dig('source_record', 0).tap do |record|
+      record['fields'] = record['fields'].reject { |field| Constants::JUNK_TAGS.include?(field.keys.first) }
     end
   end
 end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -84,10 +84,14 @@ class FolioRecord
     record['holdings'] || items_and_holdings&.dig('holdings') || []
   end
 
-  def as_json
+  def as_json(include_items: false)
     json = record.except('source_record')
-    json['items'] ||= items
-    json['holdings'] ||= holdings
+
+    if include_items
+      json['items'] ||= items
+      json['holdings'] ||= holdings
+    end
+
     json
   end
 

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -165,9 +165,12 @@ to_field 'uuid_ssi' do |record, accumulator|
 end
 
 to_field 'folio_json_struct' do |record, accumulator|
-  accumulator << JSON.generate(record.record.except('parsedRecord'))
+  accumulator << JSON.generate(record.as_json)
 end
 
 to_field 'holdings_json_struct' do |record, accumulator|
-  accumulator << JSON.generate(record.items_and_holdings) if record.items_and_holdings
+  accumulator << JSON.generate({
+    holdings: record.holdings,
+    items: record.items
+  })
 end

--- a/lib/traject/extractors/folio_kafka_extractor.rb
+++ b/lib/traject/extractors/folio_kafka_extractor.rb
@@ -17,7 +17,7 @@ class Traject::FolioKafkaExtractor
       # sometimes folio source records don't have an associated instance record
       next if record.instance_id.nil? || record.instance_id.empty?
 
-      producer.produce(record.record.to_json, key: record.instance_id, topic: topic)
+      producer.produce(record.as_json(include_items: false), key: record.instance_id, topic: topic)
     end
 
     producer.deliver_messages

--- a/lib/traject/readers/folio_reader.rb
+++ b/lib/traject/readers/folio_reader.rb
@@ -13,7 +13,7 @@ module Traject
     def each(&block)
       return to_enum(:each) unless block_given?
 
-      response = client.get('/source-storage/stream/source-records', params: { limit: settings.fetch('source-records-limit', 2147483647).to_i, updatedAfter: settings['folio.updated_after'] })
+      response = client.get('/source-storage/stream/source-records', params: { limit: settings.fetch('source-records-limit', 2147483647).to_i, updatedAfter: settings.fetch('folio.updated_after', Time.at(0).utc.iso8601) })
       buffer = ""
       @last_response_date = Time.httpdate(response.headers['Date'])
 

--- a/lib/traject/readers/folio_reader.rb
+++ b/lib/traject/readers/folio_reader.rb
@@ -23,7 +23,15 @@ module Traject
 
         buffer.each_line do |line|
           if line.end_with?("\n")
-            yield FolioRecord.new(JSON.parse(line), client)
+            record = JSON.parse(line)
+            yield FolioRecord.new({
+              'source_record' => [
+                record.dig('parsedRecord', 'content')
+              ],
+              'instance' => {
+                'id' => record.dig('externalIdsHolder', 'instanceId')
+              }
+            }, client)
           else
             newbuffer += line
           end

--- a/lib/traject/readers/kafka_folio_reader.rb
+++ b/lib/traject/readers/kafka_folio_reader.rb
@@ -17,7 +17,12 @@ class Traject::KafkaFolioReader
     kafka.each_message(max_bytes: 10000000) do |message|
       Utils.logger.debug("Traject::KafkaFolioReader#each(#{message.key})")
       record = JSON.parse(message.value)
-      yield FolioRecord.new(record, @client)
+
+      if record.key? 'source_record'
+        yield FolioRecord.new_from_source_record(record['source_record'], @client)
+      else
+        yield FolioRecord.new(record, @client)
+      end
     end
   end
 

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -13,7 +13,7 @@ describe 'SDR indexing' do
   end
 
   let(:folio_record) do
-    FolioRecord.new(source_record_json, client)
+    FolioRecord.new_from_source_record(source_record_json, client)
   end
 
   let(:source_record_json) do

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -4,7 +4,7 @@ require 'folio_client'
 require 'folio_record'
 
 RSpec.describe FolioRecord do
-  subject(:folio_record) { described_class.new(record, client) }
+  subject(:folio_record) { described_class.new_from_source_record(record, client) }
   let(:client) { instance_double(FolioClient) }
   let(:record) do
     {


### PR DESCRIPTION
This brings over the new `FolioRecord#as_json` serialization and updates the `folio_json_struct` data structure etc in preparation for a more descriptive intermediate representation of FOLIO instances.


0a5e7f5a9b5f77181ceb6da4b918395a57a4d175 also adds a default to ensure we get records even if the timestamp isn't supplied.