### PR TITLE
API-based indexing refactor

### DIFF
--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -34,7 +34,8 @@ class FolioClient
   end
 
   def source_record(**kwargs)
-    FolioRecord.new_from_source_record(get_json("/source-storage/source-records", params: kwargs).dig('sourceRecords', 0), self)
+    response = get_json('/source-storage/source-records', params: kwargs)
+    FolioRecord.new_from_source_record(response['sourceRecords'].first)
   end
 
   private

--- a/lib/folio_client.rb
+++ b/lib/folio_client.rb
@@ -33,6 +33,13 @@ class FolioClient
     parse(get(path, **kwargs))
   end
 
+  def get_jsonl(path, **kwargs)
+    response = get(path, **kwargs)
+    return nil if response.body.empty?
+
+    response.body.to_s.gsub('}{', '}\n{').split('\n').map { |line| JSON.parse(line) }
+  end
+
   def source_record(**kwargs)
     response = get_json('/source-storage/source-records', params: kwargs)
     FolioRecord.new_from_source_record(response['sourceRecords'].first)

--- a/lib/traject/readers/kafka_folio_reader.rb
+++ b/lib/traject/readers/kafka_folio_reader.rb
@@ -1,6 +1,5 @@
 require 'kafka'
 require 'kafka/statsd'
-require_relative '../../folio_client'
 require_relative '../../folio_record'
 
 class Traject::KafkaFolioReader
@@ -8,7 +7,6 @@ class Traject::KafkaFolioReader
 
   def initialize(input_stream, settings)
     @settings = Traject::Indexer::Settings.new settings
-    @client = settings['folio.client'] || FolioClient.new
   end
 
   def each
@@ -19,9 +17,9 @@ class Traject::KafkaFolioReader
       record = JSON.parse(message.value)
 
       if record.key? 'source_record'
-        yield FolioRecord.new_from_source_record(record['source_record'], @client)
+        yield FolioRecord.new_from_source_record(record['source_record'])
       else
-        yield FolioRecord.new(record, @client)
+        yield FolioRecord.new(record)
       end
     end
   end

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -1,6 +1,5 @@
 require 'spec_helper'
 
-require 'folio_client'
 require 'folio_record'
 
 describe 'SDR indexing' do
@@ -13,17 +12,11 @@ describe 'SDR indexing' do
   end
 
   let(:folio_record) do
-    FolioRecord.new_from_source_record(source_record_json, client)
+    FolioRecord.new_from_source_record(source_record_json)
   end
 
   let(:source_record_json) do
     JSON.parse(File.read(file_fixture('a14185492.json')))
-  end
-
-  let(:client) { instance_double(FolioClient) }
-
-  before do
-    allow(folio_record).to receive(:items_and_holdings).and_return({})
   end
 
   it 'maps the record with sirsi fields' do

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -1,11 +1,9 @@
 # frozen_string_literal: true
 
-require 'folio_client'
 require 'folio_record'
 
 RSpec.describe FolioRecord do
-  subject(:folio_record) { described_class.new_from_source_record(record, client) }
-  let(:client) { instance_double(FolioClient) }
+  subject(:folio_record) { described_class.new_from_source_record(record) }
   let(:record) do
     {
       'parsedRecord' => {


### PR DESCRIPTION
- Don't store or use FolioClient on FolioRecord
- Update FolioReader to use batch querying strategy
