### PR TITLE
Parallelize the postgres data load into kafka by sharding on the instance id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'dor-rights-auth'
 gem 'rexml' # required for ruby 3
 gem 'config'
 gem 'pg', platform: :mri
+gem 'parallel'
 
 group :deployment do
   gem 'capistrano', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,6 +142,8 @@ GEM
     net-ssh (7.0.1)
     nokogiri (1.13.8-java)
       racc (~> 1.4)
+    nokogiri (1.13.8-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
       racc (~> 1.4)
     nom-xml (1.2.0)
@@ -242,6 +244,7 @@ PLATFORMS
   java
   universal-java-15
   universal-java-18
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -268,6 +271,7 @@ DEPENDENCIES
   iso-639
   manticore
   mods_display (~> 1.0)
+  parallel
   pg
   rake
   retriable

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,5 +13,6 @@ environments:
   morison:
     kafka_topic: marc_morison
   folio_test:
+    processes: 8
     kafka_topic: marc_folio_test
     okapi_url: 'https://okapi-test.stanford.edu'

--- a/lib/traject/extractors/folio_kafka_extractor.rb
+++ b/lib/traject/extractors/folio_kafka_extractor.rb
@@ -19,7 +19,7 @@ class Traject::FolioKafkaExtractor
 
       producer.produce(record.as_json(include_items: false).to_json, key: record.instance_id, topic: topic)
     end
-
+  ensure
     producer.deliver_messages
     producer.shutdown
     @producer = nil

--- a/lib/traject/extractors/marc_kafka_extractor.rb
+++ b/lib/traject/extractors/marc_kafka_extractor.rb
@@ -17,6 +17,7 @@ class Traject::MarcKafkaExtractor
 
       producer.produce(records_to_combine.map { |x| x.to_marc }.join(''), key: ckey, topic: topic)
     end
+  ensure
     producer.deliver_messages
     producer.shutdown
     @producer = nil

--- a/lib/traject/extractors/purl_fetcher_kafka_extractor.rb
+++ b/lib/traject/extractors/purl_fetcher_kafka_extractor.rb
@@ -20,7 +20,7 @@ class Traject::PurlFetcherKafkaExtractor
         producer.produce(change.to_json, key: change['druid'], topic: topic)
       end
     end
-
+  ensure
     producer.deliver_messages
     producer.shutdown
     @producer = nil

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -22,7 +22,7 @@ module Traject
 
       @connection.transaction do
         # check postgres's clock time
-        @last_response_date = Time.parse(@connection.exec('SELECT NOW()').getvalue(0, 0))
+        @last_response_date = last_response_date
 
         # set search path to avoid namespacing problems with folio functions
         @connection.exec('SET search_path = "sul_mod_inventory_storage"')
@@ -40,6 +40,10 @@ module Traject
           end
         end
       end
+    end
+
+    def last_response_date
+      Time.parse(@connection.exec('SELECT NOW()').getvalue(0, 0))
     end
 
     def sql_query


### PR DESCRIPTION
Parallelizing with 8 threads is ~4x faster; it's unclear at the moment why it isn't even better, but hopefully this lets us fail faster when doing data loading.