### PR TITLE
Language map

### DIFF
--- a/lib/translation_maps/marc_languages.properties
+++ b/lib/translation_maps/marc_languages.properties
@@ -11,6 +11,7 @@ afa = Afroasiatic (Other)
 afh = Afrihili (Artificial language)
 afr = Afrikaans
 ain = Ainu
+# ajm is deprecated
 ajm = Aljamía
 aka = Akan
 akk = Akkadian
@@ -73,6 +74,7 @@ bur = Burmese
 byn = Bilin
 cad = Caddo
 cai = Central American Indian (Other)
+# cam is deprecated
 cam = Khmer
 car = Carib
 cat = Catalan
@@ -131,14 +133,18 @@ elx = Elamite
 eng = English
 enm = English, Middle (1100-1500)
 epo = Esperanto
+# esk is deprecated
 esk = Eskimo languages
+# esp is deprecated
 esp = Esperanto
 est = Estonian
+# eth is deprecated
 eth = Ethiopic
 ewe = Ewe
 ewo = Ewondo
 fan = Fang
 fao = Faroese
+# far is deprecated
 far = Faroese
 fat = Fanti
 fij = Fijian
@@ -147,6 +153,7 @@ fin = Finnish
 fiu = Finno-Ugrian (Other)
 fon = Fon
 fre = French
+# fri is deprecated
 fri = Frisian
 frm = French, Middle (ca. 1300-1600)
 fro = French, Old (ca. 842-1300)
@@ -156,8 +163,11 @@ fry = Frisian
 ful = Fula
 fur = Friulian
 gaa = Gã
+# gae is deprecated
 gae = Scottish Gaelic
+# gag is deprecated
 gag = Galician
+# gal is deprecated
 gal = Oromo
 gay = Gayo
 gba = Gbaya
@@ -180,6 +190,7 @@ grc = Greek, Ancient (to 1453)
 gre = Greek, Modern (1453-)
 grn = Guarani
 gsw = Swiss German
+# gua is deprecated
 gua = Guarani
 guj = Gujarati
 gwi = Gwich'in
@@ -213,9 +224,11 @@ inc = Indic (Other)
 ind = Indonesian
 ine = Indo-European (Other)
 inh = Ingush
+# int is deprecated
 int = Interlingua (International Auxiliary Language Association)
 ipk = Inupiaq
 ira = Iranian (Other)
+# iri is deprecated
 iri = Irish
 iro = Iroquoian (Other)
 ita = Italian
@@ -257,13 +270,16 @@ kru = Kurukh
 kua = Kuanyama
 kum = Kumyk
 kur = Kurdish
+# kus is deprecated
 kus = Kusaie
 kut = Kootenai
 lad = Ladino
 lah = Lahndā
 lam = Lamba (Zambia and Congo)
+# lan is deprecated
 lan = Occitan (post 1500)
 lao = Lao
+# lap is deprecated
 lap = Sami
 lat = Latin
 lav = Latvian
@@ -293,6 +309,7 @@ mao = Maori
 map = Austronesian (Other)
 mar = Marathi
 mas = Maasai
+# max is deprecated
 max = Manx
 may = Malay
 mdf = Moksha
@@ -303,6 +320,7 @@ mic = Micmac
 min = Minangkabau
 mis = Miscellaneous languages
 mkh = Mon-Khmer (Other)
+# mla is deprecated
 mla = Malagasy
 mlg = Malagasy
 mlt = Maltese
@@ -310,6 +328,7 @@ mnc = Manchu
 mni = Manipuri
 mno = Manobo languages
 moh = Mohawk
+# mol is deprecated
 mol = Moldavian
 mon = Mongolian
 mos = Mooré
@@ -392,18 +411,22 @@ sai = South American Indian (Other)
 sal = Salishan languages
 sam = Samaritan Aramaic
 san = Sanskrit
+# sao is deprecated
 sao = Samoan
 sas = Sasak
 sat = Santali
+# scc is deprecated
 scc = Serbian
 scn = Sicilian Italian
 sco = Scots
+# scr is deprecated
 scr = Croatian
 sel = Selkup
 sem = Semitic (Other)
 sga = Irish, Old (to 1100)
 sgn = Sign languages
 shn = Shan
+# sho is deprecated
 sho = Shona
 sid = Sidamo
 sin = Sinhalese
@@ -421,6 +444,7 @@ smo = Samoan
 sms = Skolt Sami
 sna = Shona
 snd = Sindhi
+# snh is deprecated
 snh = Sinhalese
 snk = Soninke
 sog = Sogdian
@@ -433,6 +457,7 @@ srn = Sranan
 srp = Serbian
 srr = Serer
 ssa = Nilo-Saharan (Other)
+# sso is deprecated
 sso = Sotho
 ssw = Swazi
 suk = Sukuma
@@ -441,14 +466,18 @@ sus = Susu
 sux = Sumerian
 swa = Swahili
 swe = Swedish
+# swz is deprecated
 swz = Swazi
 syc = Syriac
 syr = Syriac, Modern
+# tag is deprecated
 tag = Tagalog
 tah = Tahitian
 tai = Tai (Other)
+# taj is deprecated
 taj = Tajik
 tam = Tamil
+# tar is deprecated
 tar = Tatar
 tat = Tatar
 tel = Telugu
@@ -469,10 +498,12 @@ tmh = Tamashek
 tog = Tonga (Nyasa)
 ton = Tongan
 tpi = Tok Pisin
+# tru is deprecated
 tru = Truk
 tsi = Tsimshian
 tsn = Tswana
 tso = Tsonga
+# tsw is deprecated
 tsw = Tswana
 tuk = Turkmen
 tum = Tumbuka


### PR DESCRIPTION
Updates language code mapping to match the current MARC languages standard. Deprecated codes are marked for future reference, but cannot be removed until legacy data has been remediated.