### PR TITLE
Index 795 fields as collection data

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -443,7 +443,7 @@ to_field 'author_authorities_ssim', extract_marc('1001:1000:1100:1101:1110:1111:
 #
 # # Subject Search Fields
 # #  should these be split into more separate fields?  Could change relevancy if match is in field with fewer terms
-to_field "topic_search", extract_marc("650abcdefghijklmnopqrstuw:653abcdefghijklmnopqrstuw:654abcdefghijklmnopqrstuw:690abcdefghijklmnopqrstuw", alternate_script: false) do |record, accumulator, context|
+to_field "topic_search", extract_marc("650abcdefghijklmnopqrstuw:653abcdefghijklmnopqrstuw:654abcdefghijklmnopqrstuw:690abcdefghijklmnopqrstuw:795ap", alternate_script: false) do |record, accumulator, context|
   accumulator.reject! { |v| v.start_with?('nomesh') }
   if holdings(record, context).any? { |holding| holding.library == 'LANE-MED' }
     arr = []
@@ -452,7 +452,7 @@ to_field "topic_search", extract_marc("650abcdefghijklmnopqrstuw:653abcdefghijkl
   end
 end
 
-to_field "vern_topic_search", extract_marc("650abcdefghijklmnopqrstuw:653abcdefghijklmnopqrstuw:654abcdefghijklmnopqrstuw:690abcdefghijklmnopqrstuw", alternate_script: :only)
+to_field "vern_topic_search", extract_marc("650abcdefghijklmnopqrstuw:653abcdefghijklmnopqrstuw:654abcdefghijklmnopqrstuw:690abcdefghijklmnopqrstuw:795ap", alternate_script: :only)
 to_field "topic_subx_search", extract_marc("600x:610x:611x:630x:647x:650x:651x:655x:656x:657x:690x:691x:696x:697x:698x:699x", alternate_script: false)
 to_field "vern_topic_subx_search", extract_marc("600xx:610xx:611xx:630xx:647xx:650xx:651xx:655xx:656xx:657xx:690xx:691xx:696xx:697xx:698xx:699xx", alternate_script: :only)
 to_field "geographic_search", extract_marc("651abcdefghijklmnopqrstuw:691abcdefghijklmnopqrstuw:691abcdefghijklmnopqrstuw", alternate_script: false)
@@ -471,8 +471,8 @@ end
 to_field "vern_subject_other_search", extract_marc(%w(600 610 611 630 647 655 656 657 658 696 697 698 699).map { |c| "#{c}abcdefghijklmnopqrstuw"}.join(':'), alternate_script: :only)
 to_field "subject_other_subvy_search", extract_marc(%w(600 610 611 630 647 650 651 654 655 656 657 658 690 691 696 697 698 699).map { |c| "#{c}vy"}.join(':'), alternate_script: false)
 to_field "vern_subject_other_subvy_search", extract_marc(%w(600 610 611 630 647 650 651 654 655 656 657 658 690 691 696 697 698 699).map { |c| "#{c}vy"}.join(':'), alternate_script: :only)
-to_field "subject_all_search", extract_marc(%w(600 610 611 630 647 648 650 651 652 653 654 655 656 657 658 662 690 691 696 697 698 699).map { |c| "#{c}#{ALPHABET}" }.join(':'), alternate_script: false)
-to_field "vern_subject_all_search", extract_marc(%w(600 610 611 630 647 648 650 651 652 653 654 655 656 657 658 662 690 691 696 697 698 699).map { |c| "#{c}#{ALPHABET}"}.join(':'), alternate_script: :only)
+to_field "subject_all_search", extract_marc(%w(600 610 611 630 647 648 650 651 652 653 654 655 656 657 658 662 690 691 696 697 698 699 795).map { |c| "#{c}#{ALPHABET}" }.join(':'), alternate_script: false)
+to_field "vern_subject_all_search", extract_marc(%w(600 610 611 630 647 648 650 651 652 653 654 655 656 657 658 662 690 691 696 697 698 699 795).map { |c| "#{c}#{ALPHABET}"}.join(':'), alternate_script: :only)
 
 # Subject Facet Fields
 to_field "topic_facet", extract_marc("600abcdq:600t:610ab:610t:630a:630t:650a", alternate_script: false) do |record, accumulator|

--- a/spec/lib/traject/config/subject_spec.rb
+++ b/spec/lib/traject/config/subject_spec.rb
@@ -1026,4 +1026,45 @@ RSpec.describe 'Subject config' do
       expect(result).to eq ['vern699a vern699b vern699c vern699d vern699e vern699f vern699g vern699h vern699j vern699k vern699l vern699m vern699n vern699o vern699p vern699q vern699r vern699s vern699t vern699u vern699v vern699x vern699y vern699z']
     end
   end
+
+  describe 'marc_collection_title_ssim' do
+    let(:field) { 'marc_collection_title_ssim' }
+    let(:record) do
+      MARC::Record.new.tap do |r|
+        r.append(MARC::DataField.new('795', ' ', ' ', MARC::Subfield.new('a', 'Main title'), MARC::Subfield.new('p', 'A subtitle')))
+      end
+    end
+
+    it 'includes the title and subtitle from the 795' do
+      expect(result[field]).to eq ['Main title A subtitle']
+    end
+  end
+
+  describe 'vern_marc_collection_title_ssim' do
+    let(:field) { 'vern_marc_collection_title_ssim' }
+    let(:record) do
+      MARC::Record.new.tap do |r|
+        r.append(MARC::DataField.new('880', ' ', ' ', MARC::Subfield.new('6', '795-00'), MARC::Subfield.new('a', 'Main title'), MARC::Subfield.new('p', 'A subtitle')))
+      end
+    end
+
+    it 'includes the title and subtitle from the 795' do
+      expect(result[field]).to eq ['Main title A subtitle']
+    end
+  end
+
+  describe 'collection_struct' do
+    let(:field) { 'collection_struct' }
+
+    let(:record) do
+      MARC::Record.new.tap do |r|
+        r.append(MARC::DataField.new('795', ' ', ' ', MARC::Subfield.new('a', 'Main title'), MARC::Subfield.new('p', 'A subtitle')))
+        r.append(MARC::DataField.new('880', ' ', ' ', MARC::Subfield.new('6', '795-00'), MARC::Subfield.new('a', 'Vernacular title')))
+      end
+    end
+
+    it 'includes the collection title and subtitle' do
+      expect(result[field]).to eq [{ title: 'Main title A subtitle', source: 'sirsi' }, { source: 'sirsi', vernacular: 'Vernacular title' }].map(&:to_json)
+    end
+  end
 end


### PR DESCRIPTION
Metadata is moving some collection data from 690 to 795. To support the transition, we should treat 795 as if it was a 690 (indexed into the same places) and also create some fields for future faceting. 