### PR TITLE
Don't skip indexing druids with catkeys for EarthWorks

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -99,8 +99,7 @@ settings do
   provide 'geoserver.stan_url', ENV.fetch('GEOSERVER_STAN_URL', 'https://geowebservices-restricted.stanford.edu/geoserver')
 
   provide 'purl_fetcher.target', ENV.fetch('PURL_FETCHER_TARGET', 'Earthworks')
-  provide 'purl_fetcher.skip_catkey', ENV['PURL_FETCHER_SKIP_CATKEY']
-  self['purl_fetcher.skip_catkey'] = self['purl_fetcher.skip_catkey'] != 'false'
+  provide 'purl_fetcher.skip_catkey', false
 
   provide 'solr_writer.commit_on_close', true
   if defined?(JRUBY_VERSION)


### PR DESCRIPTION
Fixes #776
