### PR TITLE
Retain O.S. designation before volume number

### DIFF
--- a/lib/call_numbers/call_number_base.rb
+++ b/lib/call_numbers/call_number_base.rb
@@ -10,9 +10,9 @@ module CallNumbers
       'sheet', 'small folder', 'small map folder', 'suppl', 'tube', 'series'
     ].freeze
     ADDL_VOL_PATTERN = /[\:\/]?(#{ADDL_VOL_PARTS.join('|')}).*/i
-    VOL_PATTERN         = /([\.:\/\(])?(n\.s\.?\,? ?)?[\:\/]?(#{VOL_PARTS}|#{MONTHS})[\. -\/]?\d+([\/-]\d+)?( \d{4}([\/-]\d{4})?)?( ?suppl\.?)?/i
-    VOL_PATTERN_LOOSER  = /([\.:\/\(])?(n\.s\.?\,? ?)?[\:\/]?(#{VOL_PARTS}|#{MONTHS})[\. -]?\d+.*/i
-    VOL_PATTERN_LETTERS = /([\.:\/\(])?(n\.s\.?\,? ?)?[\:\/]?(#{VOL_PARTS}|#{MONTHS})[\/\. -]?[A-Z]?([\/-][A-Z]+)?.*/i
+    VOL_PATTERN         = /([\.:\/\(])?([no]\.s\.?\,? ?)?[\:\/]?(#{VOL_PARTS}|#{MONTHS})[\. -\/]?\d+([\/-]\d+)?( \d{4}([\/-]\d{4})?)?( ?suppl\.?)?/i
+    VOL_PATTERN_LOOSER  = /([\.:\/\(])?([no]\.s\.?\,? ?)?[\:\/]?(#{VOL_PARTS}|#{MONTHS})[\. -]?\d+.*/i
+    VOL_PATTERN_LETTERS = /([\.:\/\(])?([no]\.s\.?\,? ?)?[\:\/]?(#{VOL_PARTS}|#{MONTHS})[\/\. -]?[A-Z]?([\/-][A-Z]+)?.*/i
     FOUR_DIGIT_YEAR_REGEX = /\W *(20|19|18|17|16|15|14)\d{2}\D?$?/
     LOOSE_MONTHS_REGEX = /([\.:\/\(])? *#{MONTHS}/i
 

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -439,6 +439,44 @@ RSpec.describe 'ItemInfo config' do
             'LC')
         end
       end
+
+      context 'volume includes an O.S. (old series) designation' do
+        let(:record) do
+          MARC::Record.new.tap do |record|
+            record.append(
+              MARC::DataField.new(
+                '999', ' ', ' ',
+                MARC::Subfield.new('a', '551.46 .I55 O.S:V.1 1909/1910'),
+                MARC::Subfield.new('w', 'DEWEYPER'),
+                MARC::Subfield.new('l', 'SHELBYTITL')
+              )
+            )
+          end
+        end
+
+        it 'retains the O.S. designation before the volume number' do
+          expect(result[field].first.split(' -|- ')[8]).to include('O.S:V.1 1909/1910')
+        end
+      end
+
+      context 'volume includes an N.S. (new series) designation' do
+        let(:record) do
+          MARC::Record.new.tap do |record|
+            record.append(
+              MARC::DataField.new(
+                '999', ' ', ' ',
+                MARC::Subfield.new('a', '551.46 .I55 N.S:V.1 1909/1910'),
+                MARC::Subfield.new('w', 'DEWEYPER'),
+                MARC::Subfield.new('l', 'SHELBYTITL')
+              )
+            )
+          end
+        end
+
+        it 'retains the N.S. designation before the volume number' do
+          expect(result[field].first.split(' -|- ')[8]).to include('N.S:V.1 1909/1910')
+        end
+      end
     end
 
     describe 'locations should not be displayed' do


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/SearchWorks/issues/3102

N.S. was already being retained, but was untested. This change retains both N.S. and O.S. before the volume number for shelved by title call numbers and adds test coverage.