### PR TITLE
Change contents label according to 505 indicator

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -1555,6 +1555,7 @@ to_field 'toc_struct' do |marc, accumulator|
   fields = []
   vern = []
   unmatched_vern = []
+  label = 'Contents'
 
   tag = '905' if marc['905'] && (marc['505'].nil? or (marc['505']['t'].nil? and marc['505']['r'].nil?))
   tag ||= '505'
@@ -1589,6 +1590,8 @@ to_field 'toc_struct' do |marc, accumulator|
         end
       end
 
+      label = 'Partial contents' if field.indicator1 == '1' || field.indicator1 == '2'
+
       data << buffer.map { |w| w.strip unless w.strip.empty? }.compact.join(' ') unless buffer.empty?
       fields << data
 
@@ -1607,7 +1610,7 @@ to_field 'toc_struct' do |marc, accumulator|
   new_vern = vern unless vern.empty?
   new_fields = fields unless fields.empty?
   new_unmatched_vern = unmatched_vern unless unmatched_vern.empty?
-  accumulator << { label: 'Contents', fields: new_fields, vernacular: new_vern,
+  accumulator << { label:, fields: new_fields, vernacular: new_vern,
                    unmatched_vernacular: new_unmatched_vern } unless new_fields.nil? and new_vern.nil? and new_unmatched_vern.nil?
 end
 

--- a/spec/lib/traject/config/note_fields_spec.rb
+++ b/spec/lib/traject/config/note_fields_spec.rb
@@ -150,6 +150,54 @@ RSpec.describe 'Sirsi config' do
         end
       end
 
+      context 'with a partial indicator in the 505' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '505', '2', ' '
+              )
+            )
+          end
+        end
+
+        it 'uses the label Partial contents' do
+          expect(result_field.first[:label]).to eq 'Partial contents'
+        end
+      end
+
+      context 'with an incomplete indicator in the 505' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '505', '1', ' '
+              )
+            )
+          end
+        end
+
+        it 'uses the label Partial contents' do
+          expect(result_field.first[:label]).to eq 'Partial contents'
+        end
+      end
+
+      context 'with no indicator in the 505' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '505', ' ', ' '
+              )
+            )
+          end
+        end
+
+        it 'uses the label Contents' do
+          expect(result_field.first[:label]).to eq 'Contents'
+        end
+      end
+
       context 'with Nielsen-sourced data' do
         let(:record) do
           MARC::Record.new.tap do |r|


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/SearchWorks/issues/3103

See https://www.loc.gov/marc/bibliographic/bd505.html for indicator/status names

<img width="1134" alt="Screenshot 2023-04-14 at 10 51 22" src="https://user-images.githubusercontent.com/1328900/232078432-dc833fc0-6e96-499b-a16a-9bdc2f531cfc.png">



