### PR TITLE
Remove unused direct dependency rexml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem 'parallel'
 gem 'pg', platform: :mri
 gem 'rake'
 gem 'retriable'
-gem 'rexml' # required for ruby 3
 gem 'ruby-kafka'
 gem 'stanford-mods', '~> 3.0'
 gem 'statsd-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -267,7 +267,6 @@ DEPENDENCIES
   pg
   rake
   retriable
-  rexml
   rspec
   rubocop
   ruby-kafka


### PR DESCRIPTION
It is a transitive dependency, so we don't need it in Gemfile