### PR TITLE
Remove okapi_url from settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,4 +9,3 @@ environments:
   folio_test:
     processes: 8
     kafka_topic: marc_folio_test
-    okapi_url: 'https://okapi-test.stanford.edu'

--- a/script/process_folio_to_kafka.rb
+++ b/script/process_folio_to_kafka.rb
@@ -24,7 +24,7 @@ File.open(state_file, 'r+') do |f|
   Utils.logger.info "Found last_date in #{state_file}: #{last_date}"
 
   reader = Traject::FolioReader.new(nil, 'folio.updated_after': last_date.utc.iso8601,
-                                         'folio.client': FolioClient.new(url: Utils.env_config.okapi_url || ENV.fetch('OKAPI_URL', nil)))
+                                         'folio.client': FolioClient.new(url: ENV.fetch('OKAPI_URL')))
 
   Traject::FolioKafkaExtractor.new(reader:, kafka: Utils.kafka, topic: Utils.env_config.kafka_topic).process!
 


### PR DESCRIPTION
It's now set as an environment variable so that the secrets can be in Vault. This will allow us to manage configs in shared_configs