### PR TITLE
Create a Traject::FolioJsonReader for working with local JSON files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'traject', '~> 3.0'
 gem 'traject-marc4j_reader', platform: :jruby
+gem 'traject_plus'
 
 group :development, :test do
   gem 'debug', platforms: %i[mri]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,8 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     deep_merge (1.2.2)
+    deprecation (1.1.0)
+      activesupport
     diff-lcs (1.5.0)
     digest-crc (0.6.4)
       rake (>= 12.0.0, < 14.0.0)
@@ -118,6 +120,8 @@ GEM
     iso-639 (0.3.6)
     json (2.6.3)
     json (2.6.3-java)
+    jsonpath (1.1.2)
+      multi_json
     llhttp-ffi (0.4.0)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
@@ -142,6 +146,7 @@ GEM
       i18n
       stanford-mods (~> 3.3)
       view_component
+    multi_json (1.15.0)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-ssh (7.1.0)
@@ -227,6 +232,11 @@ GEM
     traject-marc4j_reader (1.1.0-java)
       marc (~> 1.0)
       marc-marc4j (~> 1.0)
+    traject_plus (2.0.0)
+      activesupport
+      deprecation
+      jsonpath
+      traject (~> 3.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unf (0.1.4)
@@ -285,6 +295,7 @@ DEPENDENCIES
   statsd-ruby
   traject (~> 3.0)
   traject-marc4j_reader
+  traject_plus
   webmock
   whenever
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ another option is to use the `JsonWriter` to pipe output directly to somewhere e
 ```sh
 SOLR_URL=http://localhost:8983/solr/core-name bundle exec traject -c lib/traject/config/config_name.rb -w Traject::JsonWriter my_marc_file.marc | tail -n +2 | jq '.pub_country'
 ```
+when working with non-MARC data held locally (e.g. JSON exports from FOLIO), you can use the `FolioJsonReader` to pipe output into traject from stdin:
+```sh
+# after exporting OKAPI_URL, OKAPI_USER, OKAPI_PASSWORD
+cat record.json | bundle exec traject -c lib/traject/config/folio_config.rb -s reader_class_name=Traject::FolioJsonReader --stdin --debug-mode
+```
 
 ## environments
 ### Symphony ILS (Sirsi)

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ SOLR_URL=http://localhost:8983/solr/core-name bundle exec traject -c lib/traject
 ```
 when working with non-MARC data held locally (e.g. JSON exports from FOLIO), you can use the `FolioJsonReader` to pipe output into traject from stdin:
 ```sh
-# after exporting OKAPI_URL, OKAPI_USER, OKAPI_PASSWORD
 cat record.json | bundle exec traject -c lib/traject/config/folio_config.rb -s reader_class_name=Traject::FolioJsonReader --stdin --debug-mode
 ```
+note that this approach doesn't use the `FolioClient` to make API calls, so the burden is on the user to create a fully-formed `FolioRecord` prior to indexing.
 
 ## environments
 ### Symphony ILS (Sirsi)

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -32,6 +32,7 @@ settings do
     require 'traject/readers/folio_postgres_reader'
     provide 'reader_class_name', 'Traject::FolioPostgresReader'
   else
+    require 'traject/readers/folio_json_reader'
     provide 'reader_class_name', 'Traject::FolioReader'
     provide 'folio.client', FolioClient.new(url: self['okapi.url'] || ENV.fetch('OKAPI_URL', nil))
   end

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -31,8 +31,9 @@ settings do
   elsif self['postgres.url']
     require 'traject/readers/folio_postgres_reader'
     provide 'reader_class_name', 'Traject::FolioPostgresReader'
-  else
+  elsif self['reader_class_name'] == 'Traject::FolioJsonReader'
     require 'traject/readers/folio_json_reader'
+  else
     provide 'reader_class_name', 'Traject::FolioReader'
     provide 'folio.client', FolioClient.new(url: self['okapi.url'] || ENV.fetch('OKAPI_URL', nil))
   end

--- a/lib/traject/readers/folio_json_reader.rb
+++ b/lib/traject/readers/folio_json_reader.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'traject_plus'
+require_relative '../../folio_client'
+require_relative '../../folio_record'
+
+module Traject
+  # A Traject reader for processing MARC JSON from FOLIO via stdin.
+  class FolioJsonReader < TrajectPlus::JsonReader
+    def each(&)
+      return to_enum(:each) unless block_given?
+
+      super do |record|
+        yield FolioRecord.new(record, nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
traject-plus offers a simple JsonReader, so this just subclasses it
to generate `FolioRecord` from the files passed to it.

Adds documentation to the README about how you could use it, after
e.g. using #823 (or the APIs) to get the record and save it as JSON.
