### PR TITLE
Create a helper method for reading one catkey from the db

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ the sirsi traject config uses the special setting `SKIP_EMPTY_ITEM_DISPLAY`, whi
 
 ### SDR
 The indexing machines also have scheduled cron tasks for loading data from purl-fetcher into a kafka topic. This task records a state file (in `./tmp`) that contains the timestamp of the most recent entry from purl-fetcher that was processed. Every minute, the cron task runs, retrieves the purl-fetcher changes since that most recent timestamp, and adds the message to a kafka topic.
+
+### FOLIO
+Data is read directly from the postgres database underlying FOLIO, using a custom SQL query stored in the `FolioPostgresReader`. To mimic this activity in local development, one can SSH tunnel to the FOLIO database and use the `#find_by_catkey` helper method:
+```rb
+# after SSH tunneling to the FOLIO database
+Traject::FolioPostgresReader.find_by_catkey('a123456, 'postgres.url' => 'postgres://[user]:[password]@localhost/okapi')
+```

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -19,6 +19,11 @@ module Traject
       @sql_filters = @settings['postgres.sql_filters'] || 'TRUE'
     end
 
+    # Return a single record by catkey by temporarily applying a SQL filter
+    def self.find_by_catkey(catkey, settings = {})
+      new(nil, settings.merge!('postgres.sql_filters' => "lower(sul_mod_inventory_storage.f_unaccent(vi.jsonb ->> 'hrid'::text)) = '#{catkey}'")).first
+    end
+
     def each
       return to_enum(:each) unless block_given?
 

--- a/spec/integration/compare_sirsi_and_folio_spec.rb
+++ b/spec/integration/compare_sirsi_and_folio_spec.rb
@@ -33,9 +33,7 @@ RSpec.describe 'comparing against a well-known location full of documents genera
     let(:folio_record) do
       if ENV.key?('DATABASE_URL')
         require 'traject/readers/folio_postgres_reader'
-
-        Traject::FolioPostgresReader.new(nil, 'postgres.url' => ENV.fetch('DATABASE_URL'),
-                                              'postgres.sql_filters' => "lower(sul_mod_inventory_storage.f_unaccent(vi.jsonb ->> 'hrid'::text)) = '#{catkey}'").first
+        Traject::FolioPostgresReader.find_by_catkey(catkey, 'postgres.url' => ENV.fetch('DATABASE_URL'))
       else
         client.source_record(instanceHrid: catkey)
       end


### PR DESCRIPTION
This implements and documents (in the README) a helper method that
mimics functionality we were using in tests: fetching a single
record from the database by catkey, using our custom SQL query.

You can use it to see a record "as the indexer sees it" and also
save that record to a JSON file (e.g. for use with #816).
