### PR TITLE
Change require statement for locations_map

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -2,7 +2,7 @@
 
 require 'active_support/core_ext/module/delegation'
 require_relative 'traject/common/constants'
-require 'locations_map'
+require_relative 'locations_map'
 
 class FolioRecord
   attr_reader :record, :client


### PR DESCRIPTION
Without this change I was getting the following error:

```ruby
irb(main):003:0> require_relative 'lib/traject/readers/folio_postgres_reader'
<internal:/Users/marloelilongley/.rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require': cannot load such file -- locations_map (LoadError)
	from <internal:/Users/marloelilongley/.rubies/ruby-3.1.2/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:148:in `require'
	from /Users/marloelilongley/Projects/searchworks_traject_indexer/lib/folio_record.rb:5:in `<top (required)>'
	from /Users/marloelilongley/Projects/searchworks_traject_indexer/lib/folio_client.rb:4:in `require_relative'
	from /Users/marloelilongley/Projects/searchworks_traject_indexer/lib/folio_client.rb:4:in `<top (required)>'
	from /Users/marloelilongley/Projects/searchworks_traject_indexer/lib/traject/readers/folio_postgres_reader.rb:6:in `require_relative'
	from /Users/marloelilongley/Projects/searchworks_traject_indexer/lib/traject/readers/folio_postgres_reader.rb:6:in `<top (required)>'
	from (irb):3:in `require_relative'
	from (irb):3:in `<main>'
	from /Users/marloelilongley/.gem/ruby/3.1.2/gems/irb-1.6.4/exe/irb:9:in `<top (required)>'
	from /Users/marloelilongley/.gem/ruby/3.1.2/bin/irb:25:in `load'
	from /Users/marloelilongley/.gem/ruby/3.1.2/bin/irb:25:in `<main>'


```