### PR TITLE
Allow (or forcibly re-sort) data that has a different order in FOLIO

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2260,7 +2260,7 @@ to_field 'preferred_barcode' do |record, accumulator, context|
   # Prefer items with the first volume sort key
   holding_with_the_most_recent_shelfkey = callnumber_with_the_most_items.min_by do |holding|
     call_number_object = call_number_for_holding(record, holding, context)
-    call_number_object.to_volume_sort
+    [call_number_object.to_volume_sort, holding.barcode]
   end
   accumulator << holding_with_the_most_recent_shelfkey.barcode
 end

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2531,7 +2531,9 @@ to_field 'mhld_display' do |record, accumulator, _context|
       mhld_field.fields868 << field
     end
   end
-  accumulator.concat mhld_results.concat add_values_to_result(mhld_field)
+  mhld_results.concat add_values_to_result(mhld_field)
+
+  accumulator.concat(mhld_results.select { |mhld_result| mhld_result.present? })
 end
 
 def add_values_to_result(mhld_field)
@@ -2567,7 +2569,7 @@ def add_values_to_result(mhld_field)
   end
   if !has866 && !has867 && !has868
     latest_received = mhld_field.latest_received if mhld_field.df852has_equals_sf
-    mhld_results << mhld_field.display(latest_received)
+    mhld_results << mhld_field.display(latest_received) unless mhld_field.public_note.blank? && mhld_field.library_has.blank? && latest_received.blank?
   end
 
   mhld_results

--- a/spec/integration/compare_sirsi_and_folio_spec.rb
+++ b/spec/integration/compare_sirsi_and_folio_spec.rb
@@ -144,11 +144,21 @@ RSpec.describe 'comparing against a well-known location full of documents genera
   end
 
   # pending
-  %w[
-    a576562
-    a12451243
-    a13288549
-    a10151431
+  [
+    'a576562',
+    'a12451243',
+    'a13288549',
+    'a10151431',
+    'a7919757', # on-order
+    'a3372664', # holdings notes are different
+    'a7812385', # missing holdings note "no.409 missing."
+    'a14408747', # missing holdings note
+    'a2741508', # missing a bunch of MHLD data
+    'a4705967', # missing MHLD note
+    'a14317027', # HOOVER + HV-ARCHIVE are merged?
+    'a3324747', # missing temporary location data
+    'a4706463', # missing item-level public note
+    'a9089314', # missing item-level public note
   ].each do |catkey|
     context "catkey #{catkey}" do
       let(:catkey) { catkey }

--- a/spec/integration/compare_sirsi_and_folio_spec.rb
+++ b/spec/integration/compare_sirsi_and_folio_spec.rb
@@ -65,26 +65,51 @@ RSpec.describe 'comparing against a well-known location full of documents genera
         'context_source_ssi' # sirsi_config sets this to 'sirsi', and folio sets it to 'folio'
       ]
     end
+
+    let(:unordered_fields) do
+      [
+        'item_display', # the order of items is not guaranteed
+        'barcode_search',
+        'callnum_search',
+        'reverse_shelfkey',
+        'shelfkey',
+        'mhld_display', # derived from the mhlds
+        'building_facet' # derived from the item list
+      ]
+    end
     it 'matches' do
       aggregate_failures "testing response for catkey #{catkey}" do
         mapped_fields.each do |key|
           next if skipped_fields.include? key
 
-          expect(folio_result[key]).to eq(sirsi_result[key]),
-                                       "expected #{key} to match \n\nSIRSI:\n#{sirsi_result[key].inspect}\nFOLIO:\n#{folio_result[key].inspect}"
+          if unordered_fields.include?(key) && folio_result[key].present?
+            expect(folio_result[key]).to match_array(sirsi_result[key]),
+                                         "expected #{key} to match \n\nSIRSI:\n#{sirsi_result[key].inspect}\nFOLIO:\n#{folio_result[key].inspect}"
+          else
+            expect(folio_result[key]).to eq(sirsi_result[key]),
+                                         "expected #{key} to match \n\nSIRSI:\n#{sirsi_result[key].inspect}\nFOLIO:\n#{folio_result[key].inspect}"
+          end
         end
 
-        sirsi_result['item_display'].each_with_index do |item_display, index|
-          item_display_parts = item_display.split('-|-').map(&:strip)
-          folio_display_parts = folio_result.fetch('item_display', [])[index]&.split('-|-')&.map(&:strip) || []
+        if sirsi_result['item_display'] || folio_result['item_display']
+          sirsi_item_display_fields = sirsi_result.fetch('item_display', []).map { |item_display| item_display.split('-|-').map(&:strip) }
+          folio_item_display_fields = folio_result.fetch('item_display', []).map { |item_display| item_display.split('-|-').map(&:strip) }
 
-          # we're not mapping item types
-          item_display_parts[4] = folio_display_parts[4] = ''
+          sirsi_item_display_fields.each do |item_display_parts|
+            folio_display_parts = folio_item_display_fields.find { |item_displays| item_displays[0] == item_display_parts[0] }
 
-          # The "ASIS" call number type is mapped to "OTHER" in Symphony, but "ALPHANUM" in FOLIO
-          item_display_parts[11] = 'ALPHANUM' if item_display_parts[11] == 'OTHER' && folio_display_parts[11] == 'ALPHANUM'
+            if folio_display_parts.present?
+              # we're not mapping item types
+              item_display_parts[4] = folio_display_parts[4] = ''
 
-          expect(folio_display_parts).to eq item_display_parts
+              # The "ASIS" call number type is mapped to "OTHER" in Symphony, but "ALPHANUM" in FOLIO
+              item_display_parts[11] = 'ALPHANUM' if item_display_parts[11] == 'OTHER' && folio_display_parts[11] == 'ALPHANUM'
+
+              expect(folio_display_parts).to eq item_display_parts
+            else
+              expect(folio_display_parts).to be_present, "could not find item with barcode #{item_display_parts[0]} in FOLIO record"
+            end
+          end
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,9 @@ RSpec.configure do |config|
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
   config.expect_with :rspec do |expectations|
+    # prevent RSpec from truncating output
+    expectations.max_formatted_output_length = nil
+
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
     # defined using `chain`, e.g.:


### PR DESCRIPTION
It looks like FOLIO's default item sort is different (the opposite?) of what we're getting from Symphony. Most of the time this is ok (Searchworks resorts the data for display, or it's used in e.g. a facet), so we can ignore ordering differences in our comparison.