### PR TITLE
Suppress SIRSI MHLD indexing if the library/location has no data

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2531,7 +2531,9 @@ to_field 'mhld_display' do |record, accumulator, _context|
       mhld_field.fields868 << field
     end
   end
-  accumulator.concat mhld_results.concat add_values_to_result(mhld_field)
+  mhld_results.concat add_values_to_result(mhld_field)
+
+  accumulator.concat(mhld_results.select { |mhld_result| mhld_result.present? })
 end
 
 def add_values_to_result(mhld_field)
@@ -2567,7 +2569,7 @@ def add_values_to_result(mhld_field)
   end
   if !has866 && !has867 && !has868
     latest_received = mhld_field.latest_received if mhld_field.df852has_equals_sf
-    mhld_results << mhld_field.display(latest_received)
+    mhld_results << mhld_field.display(latest_received) unless mhld_field.public_note.blank? && mhld_field.library_has.blank? && latest_received.blank?
   end
 
   mhld_results

--- a/spec/lib/traject/config/holdings_spec.rb
+++ b/spec/lib/traject/config/holdings_spec.rb
@@ -351,12 +351,10 @@ RSpec.describe 'Holdings config' do
       describe 'test 852 output' do
         let(:fixture_name) { 'mhldDisplay852only.mrc' }
         it do
-          expect(select_by_id('358041')[field].length).to eq 5
+          expect(select_by_id('358041')[field].length).to eq 3
           expect(select_by_id('358041')[field][0]).to eq 'GREEN -|- CURRENTPER -|- COUNTRY LIFE INTERNATIONAL. Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in SAL -|-  -|- '
-          expect(select_by_id('358041')[field][1]).to eq 'SAL3 -|- STACKS -|-  -|-  -|- '
-          expect(select_by_id('358041')[field][2]).to eq 'SAL -|- STACKS -|-  -|-  -|- '
-          expect(select_by_id('358041')[field][3]).to eq 'GREEN -|- CURRENTPER -|- Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in SAL -|-  -|- '
-          expect(select_by_id('358041')[field][4]).to eq 'GREEN -|- CURRENTPER -|- COUNTRY LIFE TRAVEL. Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in SAL -|-  -|- '
+          expect(select_by_id('358041')[field][1]).to eq 'GREEN -|- CURRENTPER -|- Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in SAL -|-  -|- '
+          expect(select_by_id('358041')[field][2]).to eq 'GREEN -|- CURRENTPER -|- COUNTRY LIFE TRAVEL. Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in SAL -|-  -|- '
         end
       end
       describe 'skip mhlds' do
@@ -372,18 +370,14 @@ RSpec.describe 'Holdings config' do
         # it should not be included.
         let(:fixture_name) { 'mhldDisplay.mrc' }
         it do
-          expect(select_by_id('SkippedLocs')[field]).not_to include(/3FL-REF-S/)
-          expect(select_by_id('SkippedLocs')[field]).not_to include(/LOCKSS/)
-          expect(select_by_id('SkippedLocs')[field]).not_to include(/WITHDRAWN/)
-          expect(select_by_id('SkippedLocs')[field].length).to eq 1
-          expect(select_by_id('SkippedLocs')[field]).to include 'lib -|- loc -|-  -|-  -|- '
+          expect(select_by_id('SkippedLocs')[field]).to be_blank
         end
       end
       describe 'number of separators' do
         # ensure output with and without 86x have same number of separators
         let(:fixture_name) { 'mhldDisplay852only.mrc' }
         it '852 alone without comment' do
-          expect(select_by_id('358041')[field]).to include 'SAL3 -|- STACKS -|-  -|-  -|- '
+          expect(select_by_id('358041')[field]).not_to include 'SAL3 -|- STACKS -|-  -|-  -|- '
         end
         it '852 alone without comment' do
           expect(select_by_id('358041')[field]).to include 'GREEN -|- CURRENTPER -|- Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in SAL -|-  -|- '
@@ -456,8 +450,8 @@ RSpec.describe 'Holdings config' do
         it do
           expect(select_by_id('keep867ind0')[field]).to eq ['GREEN -|- CURRENTPER -|- keep 867 -|- Supplement: keep me (867) -|- ']
           start = 'GREEN -|- STACKS -|- Supplement -|- Supplement: '
-          expect(select_by_id('multKeep867ind0')[field][1]).to eq "#{start}keep me 1 (867) -|- "
-          expect(select_by_id('multKeep867ind0')[field][2]).to eq "#{start}keep me 2 (867) -|- "
+          expect(select_by_id('multKeep867ind0')[field][0]).to eq "#{start}keep me 1 (867) -|- "
+          expect(select_by_id('multKeep867ind0')[field][1]).to eq "#{start}keep me 2 (867) -|- "
         end
       end
       describe '867 no 866' do


### PR DESCRIPTION
FOLIO doesn't have a holdings or order pieces when we're missing the data, so we can't generate anything. That's fine, because Searchworks ignores `mhld_display` data without data:

https://github.com/sul-dlss/SearchWorks/blob/master/lib/holdings/mhld.rb#L15-L19

Instead of indexing data we just ignore, let's not generate it in the first place.