### PR TITLE
Disable RSpec output truncation; when we're dealing with large string…

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,9 @@ RSpec.configure do |config|
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
   config.expect_with :rspec do |expectations|
+    # prevent RSpec from truncating output
+    expectations.max_formatted_output_length = nil
+
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods
     # defined using `chain`, e.g.:


### PR DESCRIPTION
… comparison, the full output is helpful.