### PR TITLE
Course reserves indexing refactor for Sirsi

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -48,6 +48,9 @@ each_record do |record, context|
   end
 end
 
+# Disable Sirsi reserves lookup from file in favor of FOLIO data
+def reserves_lookup = {}
+
 load_config_file(File.expand_path('sirsi_config.rb', __dir__))
 
 def call_number_for_holding(record, holding, context)

--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -22,6 +22,7 @@ require 'i18n'
 require 'honeybadger'
 require 'digest/md5'
 require 'active_support'
+require 'active_support/core_ext/enumerable'
 
 I18n.available_locales = [:en]
 
@@ -179,6 +180,12 @@ to_field 'id', extract_marc('001') do |_record, accumulator|
   accumulator.map! do |v|
     v.sub(/^a/, '')
   end
+end
+
+# Look up course reserves data once per record for reference later
+each_record do |_record, context|
+  id = context.output_hash['id']&.first
+  context.clipboard[:crez_data] = reserves_lookup[id] || []
 end
 
 to_field 'hashed_id_ssi' do |_record, accumulator, context|
@@ -2696,66 +2703,33 @@ DEPT_CODE_2_USER_STR = Traject::TranslationMap.new('dept_code_2_user_str').freez
 LOAN_CODE_2_USER_STR = Traject::TranslationMap.new('loan_code_2_user_str').freeze
 
 to_field 'crez_instructor_search' do |_record, accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
-
-  course_reserves.each do |row|
-    accumulator << row[:instructor_name]
-  end
+  accumulator.concat(context.clipboard[:crez_data].pluck(:instructor_name))
 end
 
 to_field 'crez_course_name_search' do |_record, accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
-
-  course_reserves.each do |row|
-    accumulator << row[:course_name]
-  end
+  accumulator.concat(context.clipboard[:crez_data].pluck(:course_name))
 end
 
 to_field 'crez_course_id_search' do |_record, accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
-
-  course_reserves.each do |row|
-    accumulator << row[:course_id]
-  end
+  accumulator.concat(context.clipboard[:crez_data].pluck(:course_id))
 end
 
 to_field 'crez_desk_facet' do |_record, accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
-
-  course_reserves.each do |row|
-    accumulator << REZ_DESK_2_REZ_LOC_FACET[row[:rez_desk]]
-  end
+  accumulator.concat(context.clipboard[:crez_data].pluck(:rez_desk).map do |desk|
+    REZ_DESK_2_REZ_LOC_FACET[desk]
+  end)
 end
 
 to_field 'crez_dept_facet' do |_record, accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
-
-  course_reserves.each do |row|
-    dept = row[:course_id].split('-')[0].split(' ')[0]
-    accumulator << DEPT_CODE_2_USER_STR[dept]
-  end
+  accumulator.concat(context.clipboard[:crez_data].pluck(:course_id).map do |course_id|
+    DEPT_CODE_2_USER_STR[course_id.split('-')[0].split(' ')[0]]
+  end)
 end
 
 to_field 'crez_course_info' do |_record, accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
-
-  course_reserves.each do |row|
-    accumulator << %i[course_id course_name instructor_name].map do |sym|
-      row[sym]
-    end.join(' -|- ')
-  end
+  accumulator.concat(context.clipboard[:crez_data].map do |data|
+    "#{data[:course_id]} -|- #{data[:course_name]} -|- #{data[:instructor_name]}"
+  end)
 end
 
 each_record do |_record, context|
@@ -2772,9 +2746,8 @@ end
 
 # We update item_display once we have crez info
 to_field 'item_display' do |_record, _accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
+  course_reserves = context.clipboard[:crez_data]
+  next if course_reserves.empty?
 
   context.output_hash['item_display'].map! do |item_display_value|
     split_item_display = item_display_value.split('-|-')
@@ -2797,9 +2770,8 @@ to_field 'item_display' do |_record, _accumulator, context|
 end
 
 to_field 'building_facet' do |_record, _accumulator, context|
-  id = context.output_hash['id']&.first
-  course_reserves = reserves_lookup[id]
-  next unless course_reserves
+  course_reserves = context.clipboard[:crez_data]
+  next if course_reserves.empty?
 
   new_building_facet_vals = context.output_hash['item_display'].map do |item_display_value|
     split_item_display = item_display_value.split('-|-').map(&:strip)


### PR DESCRIPTION
We access course reserve related info for many fields. This change ensures that it's easier to alter where the info comes from (for FOLIO), and that information is loaded at most once per record.

Also turns off fetching of course reserve info from dump files for FOLIO indexing, so that it's easier to see what data is actually missing. Right now everything looks like it's working, because we're still loading the old course dump files in searchworks-folio-test.

Supports https://github.com/sul-dlss/searchworks_traject_indexer/issues/667; largely copied from https://github.com/sul-dlss/searchworks_traject_indexer/pull/686.