### PR TITLE
Explicitly set the language in the eye config

### DIFF
--- a/traject.eye
+++ b/traject.eye
@@ -10,6 +10,8 @@ Eye.application 'traject' do
   working_dir File.expand_path(File.join(File.dirname(__FILE__)))
   stop_on_delete true
 
+  env 'LANG' => 'en_US.UTF-8' # Force UTF-8 or character class literals (e.g. /\p{L}/) will fail
+
   group 'workers' do
     # workers can take a while to restart, especially when they've consumed a lot of memory
     start_timeout 90.seconds


### PR DESCRIPTION
This will prevent syntax errors on character class literals

Fixes #841