### PR TITLE
Refactor access_facet to use SirsiHoldings methods

### DIFF
--- a/lib/sirsi_holding.rb
+++ b/lib/sirsi_holding.rb
@@ -20,6 +20,8 @@ class SirsiHolding
                     SPECBX-S SPECM-S SPECMED-S SPECMEDX-S SPECMX-S SSRC-FIC-S SSRC-SLS STAFSHADOW
                     TECHSHADOW TECH-UNIQ WEST-7B SUPERSEDE WITHDRAWN].freeze
   TEMP_CALLNUM_PREFIX = 'XX'.freeze
+  ON_ORDER_IGNORED_LOCATIONS = %w[ENDPROCESS INPROCESS LAC SPEC-INPRO].freeze
+  ONLINE_LOCATIONS = %w[E-RECVD E-RESV ELECTR-LOC INTERNET KIOST ONLINE-TXT RESV-URL WORKSTATN].freeze
 
   attr_reader :current_location, :home_location, :library, :scheme, :type, :barcode, :public_note, :tag
 
@@ -107,7 +109,14 @@ class SirsiHolding
   end
 
   def on_order?
-    temp_call_number? && (current_location == 'ON-ORDER' || (!current_location.nil? && home_location == 'ON-ORDER'))
+    # if we've received the item, it's no longer on order even if it hasn't finished processing
+    return false if ON_ORDER_IGNORED_LOCATIONS.include?(current_location) || ON_ORDER_IGNORED_LOCATIONS.include?(home_location)
+
+    (current_location == 'ON-ORDER' || home_location == 'ON-ORDER')
+  end
+
+  def online?
+    ONLINE_LOCATIONS.include?(current_location) || ONLINE_LOCATIONS.include?(home_location) || e_call_number?
   end
 
   def ==(other)

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -149,7 +149,7 @@ RSpec.describe 'Access config' do
       it { expect(result[field]).to eq ['On order'] }
     end
 
-    context 'when an XX call number is not ON-ORDER (and is not in a blacklisted location)' do
+    context 'when an XX call number is not ON-ORDER' do
       let(:record) do
         MARC::Record.new.tap do |r|
           r.append(
@@ -162,7 +162,7 @@ RSpec.describe 'Access config' do
         end
       end
 
-      it { expect(result[field]).to eq ['On order'] }
+      it { expect(result[field]).to eq ['At the Library'] }
     end
 
     context 'when an XX call number is not ON-ORDER (but is in HV-ARCHIVE)' do
@@ -179,7 +179,7 @@ RSpec.describe 'Access config' do
         end
       end
 
-      it { expect(result[field]).not_to include 'On order' }
+      it { expect(result[field]).to eq ['At the Library'] }
     end
 
     context 'when an XX call number is not ON-ORDER (but it is in a blacklisted home location)' do


### PR DESCRIPTION
This PR refactors the `access_facet` logic to use the SirsiHoldings methods (making a seam for FOLIO work).

It also simplifies the on-order logic to exclusively use home + current locations to figure out on-orderness (previously, we also checked some properties of the call number, but we believe this is now unnecessary... and problematic for FOLIO which may not have items attached in the first place).

The current logic appears to make an instance "on-order" if:
- there's an item with a temporary call number, and
- that item's current location is ON-ORDER or has a home location of ON-ORDER and has no current location

The new logic here is:
- an item's current or home location is ON-ORDER, except if
- the current or home location (whichever one is not ON-ORDER... usually/always the current location?) isn't a processing location; if the library's received it but it's still making its way through internal processing (e.g. before giving it a real home location), we still consider it "At the Library"

TODO:
- [ ] @saseestone to confirm new logic with Vitus et al. 

 