### PR TITLE
Index information about a holding's Bound-with parent item

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -225,3 +225,7 @@ end
 to_field 'courses_json_struct' do |record, accumulator|
   accumulator << JSON.generate(record.courses)
 end
+
+to_field 'bound_with_parents_struct' do |record, accumulator|
+  accumulator << record.bound_with_parents.to_json
+end

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe 'FOLIO indexing' do
           'temporaryLocation' => {} },
         'formerIds' => [],
         'callNumber' => {},
-        'holdingsType' => 'Unknown',
+        'holdingsType' => { 'id' => '03c9c400-b9e3-4a07-ac0e-05ab470233ed', 'name' => 'Monograph', 'source' => 'folio' },
         'electronicAccess' => [],
         'receivingHistory' => { 'entries' => [] },
         'statisticalCodes' => [],
@@ -394,7 +394,7 @@ RSpec.describe 'FOLIO indexing' do
             'temporaryLocation' => {} },
           'formerIds' => [],
           'callNumber' => { 'typeId' => '95467209-6d7b-468b-94df-0f5d7ad2747d', 'typeName' => 'Library of Congress classification', 'callNumber' => 'G1 .N27' },
-          'holdingsType' => 'Monograph',
+          'holdingsType' => { 'id' => '03c9c400-b9e3-4a07-ac0e-05ab470233ed', 'name' => 'Monograph', 'source' => 'folio' },
           'electronicAccess' => [],
           'receivingHistory' => { 'entries' => [{ 'enumeration' => 'TEST', 'publicDisplay' => true }, nil] },
           'statisticalCodes' => [],
@@ -467,6 +467,28 @@ RSpec.describe 'FOLIO indexing' do
         [{ 'staffNote' => 'Send to cataloging to receive and update holdings...', 'statement' => 'v.1, 11' }]
       end
       it { is_expected.to eq ['EARTH-SCI -|- STACKS -|-  -|- v.1, 11 -|- '] }
+    end
+  end
+
+  describe 'bound_with_parents_struct' do
+    let(:bound_with_parents) do
+      [{
+        'parentInstanceId' => '134624',
+        'parentInstanceTitle' => 'Investigations of the relative amount of time spent on the ground',
+        'parentItemBarcode' => '36105131576063',
+        'parentItemId' => 'd1eece03-e4b6-5bd3-b6be-3d76ae8cf96d',
+        'childHoldingCallNumber' => '064.8 .D191H'
+      }]
+    end
+    before do
+      allow(folio_record).to receive(:bound_with_parents).and_return(bound_with_parents)
+    end
+    it 'has bound with parent data as json' do
+      # rubocop:disable Layout/LineLength
+      expect(
+        result['bound_with_parents_struct']
+      ).to eq ['[{"parentInstanceId":"134624","parentInstanceTitle":"Investigations of the relative amount of time spent on the ground","parentItemBarcode":"36105131576063","parentItemId":"d1eece03-e4b6-5bd3-b6be-3d76ae8cf96d","childHoldingCallNumber":"064.8 .D191H"}]']
+      # rubocop:enable Layout/LineLength
     end
   end
 end

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe FolioRecord do
       }
     }
   end
-
+  before do
+    allow(folio_record).to receive(:load_unsuppressed).and_return({})
+  end
   describe '#marc_record' do
     it 'strips junk tags' do
       expect(folio_record.marc_record['918']).to be_nil
@@ -31,6 +33,180 @@ RSpec.describe FolioRecord do
 
     it 'preserves non-junk tags' do
       expect(folio_record.marc_record['001']).to have_attributes(tag: '001', value: 'a14154194')
+    end
+  end
+
+  describe 'the 590 field' do
+    context 'when record has existing 590 in its MARC' do
+      context 'when 590 has subfield a' do
+        let(:folio_record) do
+          described_class.new_from_source_record(
+            {
+              'parsedRecord' => {
+                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
+                'content' => {
+                  'fields' => [
+                    { '001' => 'a14154194' },
+                    { '590' => {
+                      'subfields' => [
+                        { 'a' => 'Cataloged info about the Bound-with' }
+                      ]
+                    } }
+                  ]
+                }
+              }
+            },
+            client
+          )
+        end
+        it 'does not overwrite existing 590a' do
+          expect(folio_record.marc_record['590']['a']).to eq('Cataloged info about the Bound-with')
+        end
+      end
+      context 'when 590 has subfield c' do
+        let(:folio_record) do
+          described_class.new_from_source_record(
+            {
+              'parsedRecord' => {
+                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
+                'content' => {
+                  'fields' => [
+                    { '001' => 'a14154194' },
+                    { '590' => {
+                      'subfields' => [
+                        { 'c' => 'Cataloged info about the parent id' }
+                      ]
+                    } }
+                  ]
+                }
+              }
+            }, client
+          )
+        end
+        it 'does not overwrite existing 590c' do
+          expect(folio_record.marc_record['590']['c']).to eq('Cataloged info about the parent id')
+        end
+      end
+      context 'when 590 has subfield d' do
+        let(:folio_record) do
+          described_class.new_from_source_record(
+            {
+              'parsedRecord' => {
+                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
+                'content' => {
+                  'fields' => [
+                    { '001' => 'a14154194' },
+                    { '590' => {
+                      'subfields' => [
+                        { 'd' => 'Cataloged info totally unrelated to Bound-withs' }
+                      ]
+                    } }
+                  ]
+                }
+              }
+            },
+            client
+          )
+        end
+        it 'does not overwrite existing 590d' do
+          expect(folio_record.marc_record['590']['d']).to eq('Cataloged info totally unrelated to Bound-withs')
+        end
+      end
+
+      context 'when 590 exists but is missing subfield a, c, or d, and has Bound-with parents via FOLIO APIs' do
+        let(:folio_record) do
+          described_class.new_from_source_record(
+            {
+              'parsedRecord' => {
+                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
+                'content' => {
+                  'fields' => [
+                    { '001' => 'a84564' },
+                    { '590' => {
+                      'subfields' => []
+                    } }
+                  ]
+                }
+              }
+            },
+            client
+          )
+        end
+        before do
+          allow(folio_record).to receive(:bound_with_parents).and_return(
+            [
+              {
+                'parentInstanceId' => '134624',
+                'parentInstanceTitle' => 'Mursilis Sprachlähmung',
+                'parentItemId' => 'd1eece03-e4b6-5bd3-b6be-3d76ae8cf96d',
+                'parentItemBarcode' => '36105018739321',
+                'childHoldingCallNumber' => '064.8 .D191H'
+              }
+            ]
+          )
+        end
+        it 'writes to 590a' do
+          expect(folio_record.marc_record['590']['a']).to eq('064.8 .D191H bound with Mursilis Sprachlähmung')
+        end
+        it 'writes to 590c' do
+          expect(folio_record.marc_record['590']['c']).to eq('134624 (parent record)')
+        end
+        it 'does not write to 590d' do
+          expect(folio_record.marc_record['590']['d']).to be_nil
+        end
+      end
+    end
+    context 'when record does not have existing 590 in its MARC' do
+      let(:folio_record) do
+        described_class.new_from_source_record(
+          {
+            'parsedRecord' => {
+              'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
+              'content' => {
+                'fields' => [
+                  { '001' => 'a84564' }
+                ]
+              }
+            }
+          },
+          client
+        )
+      end
+      context 'when FOLIO returns Bound-with data' do
+        before do
+          allow(folio_record).to receive(:bound_with_parents).and_return(
+            [
+              {
+                'parentInstanceId' => '134624',
+                'parentInstanceTitle' => 'Mursilis Sprachlähmung',
+                'parentItemId' => 'd1eece03-e4b6-5bd3-b6be-3d76ae8cf96d',
+                'parentItemBarcode' => '36105018739321',
+                'childHoldingCallNumber' => '064.8 .D191H'
+              }
+            ]
+          )
+        end
+        it 'creates a new 590 field' do
+          expect(folio_record.marc_record['590']).to be_a MARC::DataField
+        end
+        it 'writes to 590a' do
+          expect(folio_record.marc_record['590']['a']).to eq('064.8 .D191H bound with Mursilis Sprachlähmung')
+        end
+        it 'writes to 590c' do
+          expect(folio_record.marc_record['590']['c']).to eq('134624 (parent record)')
+        end
+        it 'does not write to 590d' do
+          expect(folio_record.marc_record['590']['d']).to be_nil
+        end
+      end
+      context 'when FOLIO does not return Bound-with data' do
+        before do
+          allow(folio_record).to receive(:bound_with_parents).and_return([])
+        end
+        it 'does not create a new 590 field' do
+          expect(folio_record.marc_record['590']).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Even if we are not consuming this presently, we would now have it available to SearchWorks if we need to move away from relying on reading 590 MARC.

Unsure if the multiple client calls in the `bound_with_parents` method is too inefficient, open to thoughts, but via APIs it is necessary. 

Fixes https://github.com/sul-dlss/searchworks_traject_indexer/issues/881