### PR TITLE
Index course reserve data from FOLIO

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require 'active_support/core_ext/module/delegation'
+require 'active_support/core_ext/enumerable'
 require_relative 'traject/common/constants'
 require_relative 'locations_map'
 require_relative 'folio/eresource_holdings_builder'
 require_relative 'folio/mhld_builder'
 
+# rubocop:disable Metrics/ClassLength
 class FolioRecord
   attr_reader :record, :client
 
@@ -110,6 +112,18 @@ class FolioRecord
     record
   end
 
+  # Course information for any courses that have this record's items on reserve
+  # @return [Array<Hash>] course information
+  def courses
+    record['courses'].map do |course|
+      {
+        course_name: course['name'],
+        course_id: course['courseNumber'],
+        instructors: course['instructorObjects'].pluck('name')
+      }
+    end
+  end
+
   private
 
   # @param [String] type either 'items' or 'holdings'
@@ -190,3 +204,4 @@ class FolioRecord
     end.to_hash
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -174,6 +174,27 @@ to_field 'context_source_ssi' do |_record, _accumulator, context|
   context.output_hash['context_source_ssi'] = ['folio']
 end
 
+to_field 'crez_instructor_search' do |record, _accumulator, context|
+  context.output_hash['crez_instructor_search'] = record.courses.flat_map { |course| course[:instructors] }.compact.uniq
+end
+
+to_field 'crez_course_name_search' do |record, _accumulator, context|
+  context.output_hash['crez_course_name_search'] = record.courses.map { |course| course[:course_name] }.compact.uniq
+end
+
+to_field 'crez_course_id_search' do |record, _accumulator, context|
+  context.output_hash['crez_course_id_search'] = record.courses.map { |course| course[:course_id] }.compact.uniq
+end
+
+# TODO: included for parity; refactor SW to use courses_json_struct instead
+to_field 'crez_course_info' do |record, _accumulator, context|
+  context.output_hash['crez_course_info'] = record.courses.flat_map do |course|
+    [course[:course_id]].product(course[:instructors]).map do |course_id, instructor|
+      [course_id, course[:course_name], instructor].join(' -|- ')
+    end
+  end
+end
+
 ## FOLIO specific fields
 
 ## QUESTIONS / ISSUES
@@ -199,4 +220,8 @@ to_field 'holdings_json_struct' do |record, accumulator|
                                  holdings: record.holdings,
                                  items: record.items
                                })
+end
+
+to_field 'courses_json_struct' do |record, accumulator|
+  accumulator << JSON.generate(record.courses)
 end

--- a/spec/fixtures/files/whodunit.json
+++ b/spec/fixtures/files/whodunit.json
@@ -1,0 +1,1873 @@
+{
+  "items": [
+    {
+      "id": "64d4220b-ebae-5fb0-971c-0f98f6d9cc93",
+      "hrid": "ai14238203_2_3",
+      "notes": [
+
+      ],
+      "status": "Available",
+      "barcode": "36105232609557",
+      "_version": 1,
+      "location": {
+        "effectiveLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "temporaryLocation": null
+      },
+      "metadata": {
+        "createdDate": "2023-05-07T16:08:35.666Z",
+        "updatedDate": "2023-05-07T16:08:35.666Z",
+        "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+      },
+      "formerIds": [
+
+      ],
+      "callNumber": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "typeName": "Library of Congress classification",
+        "callNumber": "HV6533 .H3 W55 2022"
+      },
+      "copyNumber": "3",
+      "yearCaption": [
+
+      ],
+      "materialType": "book",
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+      "numberOfPieces": "1",
+      "circulationNotes": [
+
+      ],
+      "electronicAccess": [
+
+      ],
+      "holdingsRecordId": "d1125a4f-0cbd-5a4a-a248-d6ef47f67e78",
+      "itemDamagedStatus": null,
+      "permanentLoanType": "Can circulate",
+      "temporaryLoanType": null,
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+      "permanentLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "suppressFromDiscovery": false,
+      "effectiveShelvingOrder": "HV 46533 H3 W55 42022 13",
+      "effectiveCallNumberComponents": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "callNumber": "HV6533 .H3 W55 2022"
+      }
+    },
+    {
+      "id": "771eb80c-d464-5deb-bce0-c16e49979d1c",
+      "hrid": "ai14238203_2_1",
+      "notes": [
+
+      ],
+      "status": "Available",
+      "barcode": "36105232609540",
+      "_version": 1,
+      "location": {
+        "effectiveLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "temporaryLocation": null
+      },
+      "metadata": {
+        "createdDate": "2023-05-07T16:08:35.666Z",
+        "updatedDate": "2023-05-07T16:08:35.666Z",
+        "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+      },
+      "formerIds": [
+
+      ],
+      "callNumber": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "typeName": "Library of Congress classification",
+        "callNumber": "HV6533 .H3 W55 2022"
+      },
+      "copyNumber": "2",
+      "yearCaption": [
+
+      ],
+      "materialType": "book",
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+      "numberOfPieces": "1",
+      "circulationNotes": [
+
+      ],
+      "electronicAccess": [
+
+      ],
+      "holdingsRecordId": "d1125a4f-0cbd-5a4a-a248-d6ef47f67e78",
+      "itemDamagedStatus": null,
+      "permanentLoanType": "Can circulate",
+      "temporaryLoanType": null,
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+      "permanentLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "suppressFromDiscovery": false,
+      "effectiveShelvingOrder": "HV 46533 H3 W55 42022 12",
+      "effectiveCallNumberComponents": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "callNumber": "HV6533 .H3 W55 2022"
+      }
+    },
+    {
+      "id": "c5f7c564-2d33-51b7-9198-daf18cf3247a",
+      "hrid": "ai14238203_2_5",
+      "notes": [
+
+      ],
+      "status": "Available",
+      "barcode": "36105232530696",
+      "_version": 1,
+      "location": {
+        "effectiveLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "temporaryLocation": null
+      },
+      "metadata": {
+        "createdDate": "2023-05-07T16:08:35.666Z",
+        "updatedDate": "2023-05-07T16:08:35.666Z",
+        "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+      },
+      "formerIds": [
+
+      ],
+      "callNumber": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "typeName": "Library of Congress classification",
+        "callNumber": "HV6533 .H3 W55 2022"
+      },
+      "copyNumber": "4",
+      "yearCaption": [
+
+      ],
+      "materialType": "book",
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+      "numberOfPieces": "1",
+      "circulationNotes": [
+
+      ],
+      "electronicAccess": [
+
+      ],
+      "holdingsRecordId": "d1125a4f-0cbd-5a4a-a248-d6ef47f67e78",
+      "itemDamagedStatus": null,
+      "permanentLoanType": "Can circulate",
+      "temporaryLoanType": null,
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+      "permanentLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "suppressFromDiscovery": false,
+      "effectiveShelvingOrder": "HV 46533 H3 W55 42022 14",
+      "effectiveCallNumberComponents": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "callNumber": "HV6533 .H3 W55 2022"
+      }
+    },
+    {
+      "id": "d5ee639e-b029-50fc-befa-45d13b87df69",
+      "hrid": "ai14238203_1_1",
+      "notes": [
+
+      ],
+      "status": "Available",
+      "barcode": "36105232609045",
+      "_version": 1,
+      "location": {
+        "effectiveLocation": {
+          "id": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+          "code": "GRE-BENDER",
+          "name": "Green Library Bender Room",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": null,
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+          "code": "GRE-BENDER",
+          "name": "Green Library Bender Room",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": null,
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "temporaryLocation": null
+      },
+      "metadata": {
+        "createdDate": "2023-05-07T16:08:35.666Z",
+        "updatedDate": "2023-05-07T16:08:35.666Z",
+        "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+      },
+      "formerIds": [
+
+      ],
+      "callNumber": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "typeName": "Library of Congress classification",
+        "callNumber": "HV6533 .H3 W55 2022"
+      },
+      "copyNumber": "1",
+      "yearCaption": [
+
+      ],
+      "materialType": "book",
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+      "numberOfPieces": "1",
+      "circulationNotes": [
+
+      ],
+      "electronicAccess": [
+
+      ],
+      "holdingsRecordId": "dd7980cc-7c74-58e5-a361-a5c727783f66",
+      "itemDamagedStatus": null,
+      "permanentLoanType": "Non-circulating",
+      "temporaryLoanType": null,
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+      "permanentLoanTypeId": "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+      "permanentLocationId": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+      "suppressFromDiscovery": false,
+      "effectiveShelvingOrder": "HV 46533 H3 W55 42022 11",
+      "effectiveCallNumberComponents": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "callNumber": "HV6533 .H3 W55 2022"
+      }
+    }
+  ],
+  "pieces": [
+    null
+  ],
+  "courses": [
+    {
+      "id": "62724c26-182a-4455-8cde-056b3a28ab93",
+      "name": "Stanford and Its Worlds: 1885-present",
+      "courseNumber": "HISTORY-58E-01",
+      "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c",
+      "instructorObjects": [
+        {
+          "id": "822dd4c8-f9bd-4178-8f5e-9b20eaea3da8",
+          "name": "Emily Levine",
+          "userId": "4db86988-8b7d-46e5-8ecf-bb0d08a44258",
+          "barcode": "2554098706",
+          "metadata": {
+            "createdDate": "2023-04-17T18:32:12.884+00:00",
+            "updatedDate": "2023-04-17T18:32:12.884+00:00",
+            "createdByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0",
+            "updatedByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0"
+          },
+          "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c"
+        },
+        {
+          "id": "ec5774a6-04bb-42c3-ba8d-92f997c2866f",
+          "name": "Mitchell Stevens",
+          "userId": "0a924104-2f46-4aae-95fb-7bdbfe466106",
+          "barcode": "2553248588",
+          "metadata": {
+            "createdDate": "2023-04-17T18:32:53.986+00:00",
+            "updatedDate": "2023-04-17T18:32:53.986+00:00",
+            "createdByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0",
+            "updatedByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0"
+          },
+          "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c"
+        }
+      ]
+    },
+    {
+      "id": "b1cb64b7-7c55-4375-87ad-c04470aea283",
+      "name": "Stanford and Its Worlds: 1885-present",
+      "courseNumber": "EDUC-147-01",
+      "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c",
+      "instructorObjects": [
+        {
+          "id": "822dd4c8-f9bd-4178-8f5e-9b20eaea3da8",
+          "name": "Emily Levine",
+          "userId": "4db86988-8b7d-46e5-8ecf-bb0d08a44258",
+          "barcode": "2554098706",
+          "metadata": {
+            "createdDate": "2023-04-17T18:32:12.884+00:00",
+            "updatedDate": "2023-04-17T18:32:12.884+00:00",
+            "createdByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0",
+            "updatedByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0"
+          },
+          "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c"
+        },
+        {
+          "id": "ec5774a6-04bb-42c3-ba8d-92f997c2866f",
+          "name": "Mitchell Stevens",
+          "userId": "0a924104-2f46-4aae-95fb-7bdbfe466106",
+          "barcode": "2553248588",
+          "metadata": {
+            "createdDate": "2023-04-17T18:32:53.986+00:00",
+            "updatedDate": "2023-04-17T18:32:53.986+00:00",
+            "createdByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0",
+            "updatedByUserId": "a5dccba0-dd44-4d02-9ef9-067db83f1bd0"
+          },
+          "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c"
+        }
+      ]
+    }
+  ],
+  "holdings": [
+    {
+      "id": "d1125a4f-0cbd-5a4a-a248-d6ef47f67e78",
+      "hrid": "ah14238203_2",
+      "notes": [
+
+      ],
+      "_version": 1,
+      "location": {
+        "effectiveLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "4573e824-9273-4f13-972f-cff7bf504217",
+          "code": "GRE-STACKS",
+          "name": "Green Library Stacks",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "temporaryLocation": null
+      },
+      "metadata": {
+        "createdDate": "2023-05-07T16:01:11.347Z",
+        "updatedDate": "2023-05-07T16:01:11.347Z",
+        "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+      },
+      "sourceId": "f32d531e-df79-46b3-8932-cdd35f7a2264",
+      "formerIds": [
+
+      ],
+      "illPolicy": null,
+      "callNumber": "HV6533 .H3 W55 2022",
+      "instanceId": "8a8c02a9-e2dc-57de-906c-e707224a2921",
+      "holdingsType": {
+        "id": "03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+        "name": "Monograph",
+        "source": "folio"
+      },
+      "holdingsItems": [
+
+      ],
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "holdingsTypeId": "03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+      "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+      "electronicAccess": [
+
+      ],
+      "bareHoldingsItems": [
+
+      ],
+      "holdingsStatements": [
+
+      ],
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "permanentLocationId": "4573e824-9273-4f13-972f-cff7bf504217",
+      "suppressFromDiscovery": false,
+      "holdingsStatementsForIndexes": [
+
+      ],
+      "holdingsStatementsForSupplements": [
+
+      ]
+    },
+    {
+      "id": "dd7980cc-7c74-58e5-a361-a5c727783f66",
+      "hrid": "ah14238203_1",
+      "notes": [
+
+      ],
+      "_version": 1,
+      "location": {
+        "effectiveLocation": {
+          "id": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+          "code": "GRE-BENDER",
+          "name": "Green Library Bender Room",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": null,
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+          "code": "GRE-BENDER",
+          "name": "Green Library Bender Room",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": null,
+          "library": {
+            "id": "f6b5519e-88d9-413e-924d-9ed96255f72e",
+            "code": "GREEN",
+            "name": "Cecil H. Green"
+          },
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "temporaryLocation": null
+      },
+      "metadata": {
+        "createdDate": "2023-05-07T16:01:11.347Z",
+        "updatedDate": "2023-05-07T16:01:11.347Z",
+        "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+        "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+      },
+      "sourceId": "f32d531e-df79-46b3-8932-cdd35f7a2264",
+      "formerIds": [
+
+      ],
+      "illPolicy": null,
+      "callNumber": "HV6533 .H3 W55 2022",
+      "instanceId": "8a8c02a9-e2dc-57de-906c-e707224a2921",
+      "holdingsType": {
+        "id": "03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+        "name": "Monograph",
+        "source": "folio"
+      },
+      "holdingsItems": [
+
+      ],
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "holdingsTypeId": "03c9c400-b9e3-4a07-ac0e-05ab470233ed",
+      "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+      "electronicAccess": [
+
+      ],
+      "bareHoldingsItems": [
+
+      ],
+      "holdingsStatements": [
+
+      ],
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+      "permanentLocationId": "1af90de1-a5c0-4c46-bab1-2847d041f997",
+      "suppressFromDiscovery": false,
+      "holdingsStatementsForIndexes": [
+
+      ],
+      "holdingsStatementsForSupplements": [
+
+      ]
+    }
+  ],
+  "instance": {
+    "id": "8a8c02a9-e2dc-57de-906c-e707224a2921",
+    "hrid": "a14238203",
+    "notes": [
+      {
+        "note": "Includes bibliographical references and index",
+        "staffOnly": false,
+        "instanceNoteTypeId": "86b6e817-e1bc-42fb-bab0-70e7547de6c1"
+      },
+      {
+        "note": "Poland Spring Water -- Founding a university -- Quarrels -- A system of absolutism -- Travels toward a poisoning -- Death comes for Mrs. Stanford -- The investigation begins -- The investigation -- The cover-up -- Jane Stanford comes home -- Who killed her?",
+        "staffOnly": false,
+        "instanceNoteTypeId": "5ba8e385-0e27-462e-a571-ffa1fa34ea54"
+      },
+      {
+        "note": "\"A premier historian penetrates the fog of corruption and cover-up still surrounding the murder of a Stanford University founder to establish who did it, how, and why. In 1885 Jane and Leland Stanford cofounded a university to honor their recently deceased young son. After her husband's death in 1893, Jane Stanford, a devoted spiritualist who expected the university to inculcate her values, steered Stanford into eccentricity and public controversy for more than a decade. In 1905 she was murdered in Hawaii, a victim, according to the Honolulu coroner's jury, of strychnine poisoning. With her vast fortune the university's lifeline, the Stanford president and his allies quickly sought to foreclose challenges to her bequests by constructing a story of death by natural causes. The cover-up gained traction in the murky labyrinths of power, wealth, and corruption of Gilded Age San Francisco. The murderer walked. Deftly sifting the scattered evidence and conflicting stories of suspects and witnesses, Richard White gives us the first full account of Jane Stanford's murder and its cover-up. Against a backdrop of the city's machine politics, rogue policing, tong wars, and heated newspaper rivalries, White's search for the murderer draws us into Jane Stanford's imperious household and the academic enmities of the university. Although Stanford officials claimed that no one could have wanted to murder Jane, we meet several people who had the motives and the opportunity to do so. One of these, we discover, also had the means\"-- Provided by publisher",
+        "staffOnly": false,
+        "instanceNoteTypeId": "10e2e11b-450f-45c8-b09b-0f819999966e"
+      }
+    ],
+    "title": "Who killed Jane Stanford? : a gilded age tale of murder, deceit, spirits and the birth of a university / Richard White.",
+    "series": [
+
+    ],
+    "source": "MARC",
+    "_version": 2,
+    "editions": [
+      "First edition"
+    ],
+    "metadata": {
+      "createdDate": "2023-05-07T15:20:16.517Z",
+      "updatedDate": "2023-05-07T15:46:39.422Z",
+      "createdByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2",
+      "updatedByUserId": "3e2ed889-52f2-45ce-8a30-8767266f07d2"
+    },
+    "statusId": "9634a5ab-9228-4703-baf2-4d12ebc77d56",
+    "subjects": [
+      "Stanford, Jane Lathrop, 1828-1905",
+      "Murder Hawaii Case studies",
+      "Stanford University History",
+      "Conspiracy Hawaii",
+      "Meurtre Hawaii Études de cas",
+      "Complot Hawaii",
+      "SOCIAL SCIENCE / Sociology / General",
+      "Stanford University",
+      "Conspiracy",
+      "Murder",
+      "Hawaii",
+      "Genre: Case studies",
+      "Genre: History",
+      "Genre: True crime stories",
+      "Genre: Études de cas",
+      "Genre: Récits criminels"
+    ],
+    "languages": [
+      "eng"
+    ],
+    "indexTitle": "Who killed jane stanford? : a gilded age tale of murder, deceit, spirits and the birth of a university",
+    "identifiers": [
+      {
+        "value": "2022005007",
+        "identifierTypeId": "c858e4f2-2b6b-4385-842b-60732ee14abb"
+      },
+      {
+        "value": "9781324004332 (hardcover)",
+        "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+      },
+      {
+        "value": "1324004339 (hardcover)",
+        "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+      },
+      {
+        "value": "9781324004349 (epub)",
+        "identifierTypeId": "fcca2643-406a-482a-b760-7a7f8aec640e"
+      },
+      {
+        "value": "(OCoLC-M)1272854505",
+        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+      },
+      {
+        "value": "on1272854505",
+        "identifierTypeId": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef"
+      }
+    ],
+    "publication": [
+      {
+        "role": "Publication",
+        "place": "New York",
+        "publisher": "W.W. Norton & Company",
+        "dateOfPublication": "[2022]"
+      },
+      {
+        "role": "Copyright notice date",
+        "place": "",
+        "publisher": "",
+        "dateOfPublication": "©2022"
+      }
+    ],
+    "contributors": [
+      {
+        "name": "White, Richard, 1947-",
+        "primary": true,
+        "contributorTypeId": "6e09d47d-95e2-4d8a-831b-f777b8ef6d81",
+        "contributorTypeText": "Contributor",
+        "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+      }
+    ],
+    "catalogedDate": "2022-06-13",
+    "staffSuppress": false,
+    "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+    "previouslyHeld": false,
+    "classifications": [
+      {
+        "classificationNumber": "HV6533.H3 W55 2022",
+        "classificationTypeId": "ce176ace-a53e-4b4d-aa89-725ed7b2edac"
+      },
+      {
+        "classificationNumber": "364.152309969",
+        "classificationTypeId": "42471af9-7d25-4f3a-bf78-60d29dcf463b"
+      }
+    ],
+    "instanceFormats": [
+
+    ],
+    "electronicAccess": [
+
+    ],
+    "holdingsRecords2": [
+
+    ],
+    "modeOfIssuanceId": "9d18a02f-5897-4c31-9106-c9abb5c7ae8b",
+    "publicationRange": [
+
+    ],
+    "alternativeTitles": [
+
+    ],
+    "discoverySuppress": false,
+    "instanceFormatIds": [
+      "8d511d33-5e85-4c5d-9bce-6e3c9cd0c324"
+    ],
+    "statusUpdatedDate": "2023-05-07T15:46:32.227+0000",
+    "statisticalCodeIds": [
+
+    ],
+    "administrativeNotes": [
+      "MONORECUnit/13 June 2022/nwy"
+    ],
+    "physicalDescriptions": [
+      "xviii, 362 pages, 8 unnumbered pages of plates : illustrations ; 24 cm"
+    ],
+    "publicationFrequency": [
+
+    ],
+    "suppressFromDiscovery": false,
+    "natureOfContentTermIds": [
+
+    ]
+  },
+  "reserves": [
+    {
+      "id": null,
+      "itemId": null,
+      "courseListingId": null
+    },
+    {
+      "id": "7cc0e34a-d217-40c4-9252-c6e37aabe6b1",
+      "itemId": "771eb80c-d464-5deb-bce0-c16e49979d1c",
+      "courseListingId": "97722041-31e7-4830-be5c-5a686783ca2c"
+    }
+  ],
+  "source_record": [
+    {
+      "fields": [
+        {
+          "001": "a14238203"
+        },
+        {
+          "003": "SIRSI"
+        },
+        {
+          "005": "20220618011734.0"
+        },
+        {
+          "008": "220209t20222022nyuaf    b    001 0deng  "
+        },
+        {
+          "010": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "  2022005007"
+              }
+            ]
+          }
+        },
+        {
+          "015": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "GBC249134"
+              },
+              {
+                "2": "bnb"
+              }
+            ]
+          }
+        },
+        {
+          "016": {
+            "ind1": "7",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "020526080"
+              },
+              {
+                "2": "Uk"
+              }
+            ]
+          }
+        },
+        {
+          "020": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "9781324004332"
+              },
+              {
+                "q": "(hardcover)"
+              }
+            ]
+          }
+        },
+        {
+          "020": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "1324004339"
+              },
+              {
+                "q": "(hardcover)"
+              }
+            ]
+          }
+        },
+        {
+          "020": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "z": "9781324004349"
+              },
+              {
+                "q": "(epub)"
+              }
+            ]
+          }
+        },
+        {
+          "040": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "DLC"
+              },
+              {
+                "b": "eng"
+              },
+              {
+                "e": "rda"
+              },
+              {
+                "c": "DLC"
+              },
+              {
+                "d": "OCLCO"
+              },
+              {
+                "d": "OCLCF"
+              },
+              {
+                "d": "GK8"
+              },
+              {
+                "d": "OCLCO"
+              },
+              {
+                "d": "UKMGB"
+              },
+              {
+                "d": "TOH"
+              },
+              {
+                "d": "OMN"
+              },
+              {
+                "d": "GO6"
+              },
+              {
+                "d": "CGB"
+              },
+              {
+                "d": "IH9"
+              },
+              {
+                "d": "OJ4"
+              },
+              {
+                "d": "UtOrBLW"
+              }
+            ]
+          }
+        },
+        {
+          "042": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "pcc"
+              }
+            ]
+          }
+        },
+        {
+          "043": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "n-us-hi"
+              }
+            ]
+          }
+        },
+        {
+          "050": {
+            "ind1": "0",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "HV6533.H3"
+              },
+              {
+                "b": "W55 2022"
+              }
+            ]
+          }
+        },
+        {
+          "082": {
+            "ind1": "0",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "364.152/309969"
+              },
+              {
+                "2": "23/eng/20220209"
+              }
+            ]
+          }
+        },
+        {
+          "100": {
+            "ind1": "1",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "White, Richard,"
+              },
+              {
+                "d": "1947-"
+              },
+              {
+                "e": "author."
+              },
+              {
+                "0": "http://id.loc.gov/authorities/names/n79093584"
+              },
+              {
+                "=": "^A122081"
+              }
+            ]
+          }
+        },
+        {
+          "245": {
+            "ind1": "1",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Who killed Jane Stanford? :"
+              },
+              {
+                "b": "a gilded age tale of murder, deceit, spirits and the birth of a university /"
+              },
+              {
+                "c": "Richard White."
+              }
+            ]
+          }
+        },
+        {
+          "250": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "First edition."
+              }
+            ]
+          }
+        },
+        {
+          "264": {
+            "ind1": " ",
+            "ind2": "1",
+            "subfields": [
+              {
+                "a": "New York :"
+              },
+              {
+                "b": "W.W. Norton & Company,"
+              },
+              {
+                "c": "[2022]"
+              }
+            ]
+          }
+        },
+        {
+          "264": {
+            "ind1": " ",
+            "ind2": "4",
+            "subfields": [
+              {
+                "c": "©2022"
+              }
+            ]
+          }
+        },
+        {
+          "300": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "xviii, 362 pages, 8 unnumbered pages of plates :"
+              },
+              {
+                "b": "illustrations ;"
+              },
+              {
+                "c": "24 cm"
+              }
+            ]
+          }
+        },
+        {
+          "336": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "text"
+              },
+              {
+                "b": "txt"
+              },
+              {
+                "2": "rdacontent"
+              }
+            ]
+          }
+        },
+        {
+          "337": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "unmediated"
+              },
+              {
+                "b": "n"
+              },
+              {
+                "2": "rdamedia"
+              }
+            ]
+          }
+        },
+        {
+          "338": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "volume"
+              },
+              {
+                "b": "nc"
+              },
+              {
+                "2": "rdacarrier"
+              }
+            ]
+          }
+        },
+        {
+          "504": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Includes bibliographical references and index"
+              }
+            ]
+          }
+        },
+        {
+          "505": {
+            "ind1": "0",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Poland Spring Water -- Founding a university -- Quarrels -- A system of absolutism -- Travels toward a poisoning -- Death comes for Mrs. Stanford -- The investigation begins -- The investigation -- The cover-up -- Jane Stanford comes home -- Who killed her?"
+              }
+            ]
+          }
+        },
+        {
+          "520": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "\"A premier historian penetrates the fog of corruption and cover-up still surrounding the murder of a Stanford University founder to establish who did it, how, and why. In 1885 Jane and Leland Stanford cofounded a university to honor their recently deceased young son. After her husband's death in 1893, Jane Stanford, a devoted spiritualist who expected the university to inculcate her values, steered Stanford into eccentricity and public controversy for more than a decade. In 1905 she was murdered in Hawaii, a victim, according to the Honolulu coroner's jury, of strychnine poisoning. With her vast fortune the university's lifeline, the Stanford president and his allies quickly sought to foreclose challenges to her bequests by constructing a story of death by natural causes. The cover-up gained traction in the murky labyrinths of power, wealth, and corruption of Gilded Age San Francisco. The murderer walked. Deftly sifting the scattered evidence and conflicting stories of suspects and witnesses, Richard White gives us the first full account of Jane Stanford's murder and its cover-up. Against a backdrop of the city's machine politics, rogue policing, tong wars, and heated newspaper rivalries, White's search for the murderer draws us into Jane Stanford's imperious household and the academic enmities of the university. Although Stanford officials claimed that no one could have wanted to murder Jane, we meet several people who had the motives and the opportunity to do so. One of these, we discover, also had the means\"--"
+              },
+              {
+                "c": "Provided by publisher"
+              }
+            ]
+          }
+        },
+        {
+          "600": {
+            "ind1": "1",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Stanford, Jane Lathrop,"
+              },
+              {
+                "d": "1828-1905."
+              },
+              {
+                "0": "http://id.loc.gov/authorities/names/n50053711"
+              },
+              {
+                "=": "^A38324"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Murder"
+              },
+              {
+                "z": "Hawaii"
+              },
+              {
+                "v": "Case studies."
+              },
+              {
+                "=": "^A1041594"
+              }
+            ]
+          }
+        },
+        {
+          "610": {
+            "ind1": "2",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Stanford University"
+              },
+              {
+                "x": "History."
+              },
+              {
+                "=": "^A104006"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "0",
+            "subfields": [
+              {
+                "a": "Conspiracy"
+              },
+              {
+                "z": "Hawaii."
+              },
+              {
+                "=": "^A1007666"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "6",
+            "subfields": [
+              {
+                "a": "Meurtre"
+              },
+              {
+                "z": "Hawaii"
+              },
+              {
+                "v": "Études de cas."
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "6",
+            "subfields": [
+              {
+                "a": "Complot"
+              },
+              {
+                "z": "Hawaii."
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "SOCIAL SCIENCE / Sociology / General."
+              },
+              {
+                "2": "bisacsh"
+              }
+            ]
+          }
+        },
+        {
+          "600": {
+            "ind1": "1",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Stanford, Jane Lathrop,"
+              },
+              {
+                "d": "1828-1905."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst00017928"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/17928"
+              }
+            ]
+          }
+        },
+        {
+          "610": {
+            "ind1": "2",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Stanford University."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst00532770"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/532770"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Conspiracy."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst00875719"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/875719"
+              }
+            ]
+          }
+        },
+        {
+          "650": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Murder."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst01029781"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/1029781"
+              }
+            ]
+          }
+        },
+        {
+          "651": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Hawaii."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst01208724"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/1208724"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Case studies."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst01423765"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/1423765"
+              },
+              {
+                "=": "^A3607902"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "History."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst01411628"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/1411628"
+              },
+              {
+                "?": "UNAUTHORIZED"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "True crime stories."
+              },
+              {
+                "2": "fast"
+              },
+              {
+                "0": "(OCoLC)fst01919985"
+              },
+              {
+                "0": "http://id.worldcat.org/fast/1919985"
+              },
+              {
+                "=": "^A3351918"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Case studies."
+              },
+              {
+                "2": "lcgft"
+              },
+              {
+                "0": "http://id.loc.gov/authorities/genreForms/gf2017026140"
+              },
+              {
+                "=": "^A3607902"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "True crime stories."
+              },
+              {
+                "2": "lcgft"
+              },
+              {
+                "0": "http://id.loc.gov/authorities/genreForms/gf2014026203"
+              },
+              {
+                "=": "^A3351918"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Études de cas."
+              },
+              {
+                "2": "rvmgf"
+              },
+              {
+                "?": "UNAUTHORIZED"
+              }
+            ]
+          }
+        },
+        {
+          "655": {
+            "ind1": " ",
+            "ind2": "7",
+            "subfields": [
+              {
+                "a": "Récits criminels."
+              },
+              {
+                "2": "rvmgf"
+              },
+              {
+                "?": "UNAUTHORIZED"
+              }
+            ]
+          }
+        },
+        {
+          "776": {
+            "ind1": "0",
+            "ind2": "8",
+            "subfields": [
+              {
+                "i": "ebook version :"
+              },
+              {
+                "z": "9781324004349"
+              }
+            ]
+          }
+        },
+        {
+          "994": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Z0"
+              },
+              {
+                "b": "STF"
+              }
+            ]
+          }
+        },
+        {
+          "910": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "MONORECUnit/13 June 2022/nwy"
+              }
+            ]
+          }
+        },
+        {
+          "940": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Shelve in bender room, retain book jacket / kmr 6.7.2022"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "(OCoLC-M)1272854505"
+              }
+            ]
+          }
+        },
+        {
+          "596": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "1"
+              }
+            ]
+          }
+        },
+        {
+          "920": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "b": "In 1885 Jane and Leland Stanford co-founded a university to honour their recently deceased young son. After her husband's death in 1893, Jane Stanford, a devoted spiritualist who expected the university to inculcate her values, steered Stanford into eccentricity and public controversy for more than a decade. In 1905 she was murdered in Hawaii, a victim, according to the Honolulu coroner's jury, of strychnine poisoning.     With her vast fortune the university's lifeline, the Stanford president and his allies quickly sought to foreclose challenges to her bequests by constructing a story of death by natural causes. The cover-up gained traction in the murky labyrinths of power, wealth and corruption of Gilded Age San Francisco. The murderer walked.     Deftly sifting the scattered evidence and conflicting stories of suspects and witnesses, Richard White gives us the first full account of Jane Stanford's murder and its cover-up. Against a backdrop of the city's machine politics, rogue policing, tong wars and heated newspaper rivalries, White's search for the murderer draws us into Jane Stanford's imperious household and the academic enmities of the university. Although Stanford officials claimed that no one could have wanted to murder Jane, we meet several people who had the motives and the opportunity to do so. One of these, we discover, also had the means..."
+              },
+              {
+                "1": "Nielsen"
+              },
+              {
+                "x": "9781324004332"
+              },
+              {
+                "x": "20220621"
+              }
+            ]
+          }
+        },
+        {
+          "940": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "Retain dust-jacket for copy 2-3"
+              }
+            ]
+          }
+        },
+        {
+          "979": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "f": "BENDERRM"
+              },
+              {
+                "b": "druid:hd360gv1231"
+              },
+              {
+                "c": "hd360gv1231_00_0001.jp2"
+              },
+              {
+                "d": "Stanford Bookstore : Centennial"
+              }
+            ]
+          }
+        },
+        {
+          "979": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "f": "RHOADES"
+              },
+              {
+                "b": "druid:gc698jf6425"
+              },
+              {
+                "c": "gc698jf6425_00_0001.jp2"
+              },
+              {
+                "d": "John Skylstead and Carmel Cole Rhoades Fund for California History and the History of the North American West"
+              }
+            ]
+          }
+        },
+        {
+          "979": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "f": "SNEDDEN"
+              },
+              {
+                "b": "druid:rp450sf4120"
+              },
+              {
+                "c": "rp450sf4120_00_0001.jp2"
+              },
+              {
+                "d": "Donald Snedden Memorial Book Fund"
+              }
+            ]
+          }
+        },
+        {
+          "919": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "exclude from BorrowDirect"
+              },
+              {
+                "b": "reserve winter 2023"
+              }
+            ]
+          }
+        },
+        {
+          "919": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "exclude from BorrowDirect"
+              },
+              {
+                "b": "reserve spring 2023"
+              }
+            ]
+          }
+        },
+        {
+          "918": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "14238203"
+              }
+            ]
+          }
+        },
+        {
+          "035": {
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "a": "on1272854505"
+              }
+            ]
+          }
+        },
+        {
+          "999": {
+            "ind1": "f",
+            "ind2": "f",
+            "subfields": [
+              {
+                "i": "8a8c02a9-e2dc-57de-906c-e707224a2921"
+              },
+              {
+                "s": "efecf703-b4fa-5025-b1e8-836f56d9a9a5"
+              }
+            ]
+          }
+        }
+      ],
+      "leader": "06880cam a22007578i 4500"
+    }
+  ]
+}

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe 'FOLIO indexing' do
 
   before do
     allow(folio_record).to receive(:items_and_holdings).and_return(items_and_holdings)
+    allow(folio_record).to receive(:courses).and_return([])
   end
 
   it 'maps the record with sirsi fields' do

--- a/spec/lib/traject/config/folio_course_reserves_spec.rb
+++ b/spec/lib/traject/config/folio_course_reserves_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+RSpec.describe 'FOLIO course reserves config' do
+  include ResultHelpers
+  subject(:result) { indexer.map_record(record) }
+
+  let(:indexer) do
+    Traject::Indexer.new.tap do |i|
+      i.settings['reader_class_name'] = 'Traject::FolioJsonReader'
+      i.load_config_file('./lib/traject/config/folio_config.rb')
+    end
+  end
+
+  let(:fixture_name) { 'whodunit.json' }
+  let(:record) { FolioRecord.new(JSON.parse(file_fixture(fixture_name).read)) }
+
+  it 'indexes instructor names for searching' do
+    expect(result['crez_instructor_search']).to eq ['Emily Levine', 'Mitchell Stevens']
+  end
+
+  it 'indexes course names for searching' do
+    expect(result['crez_course_name_search']).to eq ['Stanford and Its Worlds: 1885-present']
+  end
+
+  it 'indexes course IDs for searching' do
+    expect(result['crez_course_id_search']).to eq %w[HISTORY-58E-01 EDUC-147-01]
+  end
+
+  it 'indexes course info by individual instructor and ID' do
+    expect(result['crez_course_info']).to eq [
+      'HISTORY-58E-01 -|- Stanford and Its Worlds: 1885-present -|- Emily Levine',
+      'HISTORY-58E-01 -|- Stanford and Its Worlds: 1885-present -|- Mitchell Stevens',
+      'EDUC-147-01 -|- Stanford and Its Worlds: 1885-present -|- Emily Levine',
+      'EDUC-147-01 -|- Stanford and Its Worlds: 1885-present -|- Mitchell Stevens'
+    ]
+  end
+end

--- a/spec/lib/traject/config/sirsi_course_reserves_spec.rb
+++ b/spec/lib/traject/config/sirsi_course_reserves_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Course reserves config' do
+RSpec.describe 'Sirsi course reserves config' do
   extend ResultHelpers
   subject(:result) { indexer.map_record(record) }
 


### PR DESCRIPTION
- Rename sirsi course reserves spec to distinguish it from FOLIO
- Index course reserve fields from FOLIO records

See #667, in particular the final comment, for an explanation of why we aren't modifying `item_display` and `building_facet` in FOLIO with crez info. If these assumptions are correct, then this finishes #667.

#833 should be merged first, otherwise the impact from this won't be visible because we'll still be using the logic from the sirsi config.