### PR TITLE
Refactor mhld_display indexing and remove duplicated notes display

### DIFF
--- a/lib/mhld_field.rb
+++ b/lib/mhld_field.rb
@@ -3,29 +3,6 @@
 ##
 # Class used for containing mhld display information
 class MhldField
-  attr_accessor :fields866, :fields867, :fields868, :patterns853,
-                :most_recent863link_num, :most_recent863seq_num,
-                :most_recent863, :library, :location, :public_note,
-                :df852has_equals_sf, :library_has
-
-  def initialize
-    @fields866 = []
-    @fields867 = []
-    @fields868 = []
-    @patterns853 = {}
-    @most_recent863link_num = 0
-    @most_recent863seq_num = 0
-    @most_recent863 = nil
-  end
-
-  def latest_received
-    get863display_value(patterns853[most_recent863link_num]) if most_recent_has_been_updated
-  end
-
-  def most_recent_has_been_updated
-    most_recent863 && most_recent863link_num != 0
-  end
-
   ##
   # Ported over algorithm from solrmarc-sw
   # MHLD records put the pattern of the enumeration in an 853, and the values
@@ -33,13 +10,13 @@ class MhldField
   # captions from the 853 must be applied to the values in the 863. NOTE: the
   # match between the 853 and 863 linkage numbers should be done before
   # calling this method.
-  def get863display_value(pattern853)
+  def get863display_value(pattern853, marc863)
     return unless pattern853
 
     result = String.new
     [*'a'..'f'].map do |char|
       caption = pattern853.subfields.select { |sf| sf.code == char }.collect(&:value).first
-      value = most_recent863.subfields.select { |sf| sf.code == char }.collect(&:value).first
+      value = marc863.subfields.select { |sf| sf.code == char }.collect(&:value).first
       break unless caption && value
 
       result += ':' unless result.empty?
@@ -48,7 +25,7 @@ class MhldField
     alt_scheme = String.new
     [*'g'..'h'].map do |char|
       caption = pattern853.subfields.select { |sf| sf.code == char }.collect(&:value).first
-      value = most_recent863.subfields.select { |sf| sf.code == char }.collect(&:value).first
+      value = marc863.subfields.select { |sf| sf.code == char }.collect(&:value).first
       break unless caption && value
 
       alt_scheme += ', ' if char != 'g'
@@ -60,7 +37,7 @@ class MhldField
     chronology = String.new
     [*'i'..'m'].map do |char|
       caption = pattern853.subfields.select { |sf| sf.code == char }.collect(&:value).first
-      value = most_recent863.subfields.select { |sf| sf.code == char }.collect(&:value).first
+      value = marc863.subfields.select { |sf| sf.code == char }.collect(&:value).first
       break unless caption && value
 
       case caption
@@ -114,13 +91,5 @@ class MhldField
          .gsub('22', 'Summer')
          .gsub('23', 'Autumn')
          .gsub('24', 'Winter')
-  end
-
-  def display(latest_received)
-    [
-      library, location,
-      public_note, library_has,
-      latest_received
-    ].join(' -|- ')
   end
 end

--- a/spec/lib/traject/config/holdings_spec.rb
+++ b/spec/lib/traject/config/holdings_spec.rb
@@ -386,7 +386,7 @@ RSpec.describe 'Holdings config' do
           let(:fixture_name) { 'mhldDisplay868.mrc' }
           it do
             expect(select_by_id('keep868ind0')[field]).to include 'GREEN -|- CURRENTPER -|- keep 868 -|- v.194(2006)- -|- '
-            expect(select_by_id('keep868ind0')[field]).to include 'GREEN -|- CURRENTPER -|- keep 868 -|- Index: keep me (868) -|- '
+            expect(select_by_id('keep868ind0')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- Index: keep me (868) -|- '
           end
         end
         describe '852 w/ 867' do
@@ -412,9 +412,9 @@ RSpec.describe 'Holdings config' do
         it do
           expect(select_by_id('111')[field].length).to eq 4
           expect(select_by_id('111')[field][0]).to eq 'lib1 -|- loc1 -|- comment1 -|- 866a1open- -|- v.417:no.11 (2011:March 25)'
-          expect(select_by_id('111')[field][1]).to eq 'lib1 -|- loc1 -|- comment1 -|- 866a2closed -|- '
-          expect(select_by_id('111')[field][2]).to eq 'lib1 -|- loc1 -|- comment1 -|- 866a3closed -|- '
-          expect(select_by_id('111')[field][3]).to eq 'lib1 -|- loc1 -|- comment1 -|- 866a4closed -|- '
+          expect(select_by_id('111')[field][1]).to eq 'lib1 -|- loc1 -|-  -|- 866a2closed -|- '
+          expect(select_by_id('111')[field][2]).to eq 'lib1 -|- loc1 -|-  -|- 866a3closed -|- '
+          expect(select_by_id('111')[field][3]).to eq 'lib1 -|- loc1 -|-  -|- 866a4closed -|- '
         end
       end
       describe '866 and 867' do
@@ -435,23 +435,21 @@ RSpec.describe 'Holdings config' do
         #  is skipped if 866 has ind2 of 0 and 852 has a sub =
         let(:fixture_name) { 'mhldDisplay86x.mrc' }
         it do
-          start = 'GREEN -|- CURRENTPER -|- Latest yr. (or vol.) in CURRENT PERIODICALS; earlier in STACKS -|- '
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 1A (JAN 2011) -|- "
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 4A (FEB 2011) -|- "
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 5A (FEB 2011) -|- "
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 20A (JUN 2011) -|- "
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 21A (JUN 2011) -|- "
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 22A (JUN 2011) -|- "
-          expect(select_by_id('362573')[field]).to include "#{start}V. 417 NO. 23A (JUN 2011) -|- "
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 1A (JAN 2011) -|- '
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 4A (FEB 2011) -|- '
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 5A (FEB 2011) -|- '
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 20A (JUN 2011) -|- '
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 21A (JUN 2011) -|- '
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 22A (JUN 2011) -|- '
+          expect(select_by_id('362573')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- V. 417 NO. 23A (JUN 2011) -|- '
         end
       end
       describe 'ensure all (non-skipped) 867s are output correctly' do
         let(:fixture_name) { 'mhldDisplay867.mrc' }
         it do
           expect(select_by_id('keep867ind0')[field]).to eq ['GREEN -|- CURRENTPER -|- keep 867 -|- Supplement: keep me (867) -|- ']
-          start = 'GREEN -|- STACKS -|- Supplement -|- Supplement: '
-          expect(select_by_id('multKeep867ind0')[field][0]).to eq "#{start}keep me 1 (867) -|- "
-          expect(select_by_id('multKeep867ind0')[field][1]).to eq "#{start}keep me 2 (867) -|- "
+          expect(select_by_id('multKeep867ind0')[field][0]).to eq 'GREEN -|- STACKS -|- Supplement -|- Supplement: keep me 1 (867) -|- '
+          expect(select_by_id('multKeep867ind0')[field][1]).to eq 'GREEN -|- STACKS -|-  -|- Supplement: keep me 2 (867) -|- '
         end
       end
       describe '867 no 866' do
@@ -484,7 +482,8 @@ RSpec.describe 'Holdings config' do
         let(:fixture_name) { 'mhldDisplay868.mrc' }
         # keep if 2nd indicator "0" and no 852 sub =
         it do
-          expect(select_by_id('keep868ind0')[field]).to include 'GREEN -|- CURRENTPER -|- keep 868 -|- Index: keep me (868) -|- '
+          expect(select_by_id('keep868ind0')[field]).to include 'GREEN -|- CURRENTPER -|- keep 868 -|- v.194(2006)- -|- '
+          expect(select_by_id('keep868ind0')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- Index: keep me (868) -|- '
           expect(select_by_id('multKeep868ind0')[field]).to include 'MUSIC -|- MUS-NOCIRC -|-  -|- Index: keep me 1 (868) -|- '
           expect(select_by_id('multKeep868ind0')[field]).to include 'MUSIC -|- MUS-NOCIRC -|-  -|- Index: keep me 2 (868) -|- '
         end
@@ -505,8 +504,8 @@ RSpec.describe 'Holdings config' do
         #  is skipped if 868 has ind2 of 0 and 852 has a sub =
         let(:fixture_name) { 'mhldDisplay868.mrc' }
         it do
-          start = 'GREEN -|- CURRENTPER -|- skip 868 -|- Index: '
-          expect(select_by_id('skip868ind0')[field]).to include "#{start}skip me (868) -|- "
+          expect(select_by_id('skip868ind0')[field]).to include 'GREEN -|- CURRENTPER -|- skip 868 -|- v.194(2006)- -|- '
+          expect(select_by_id('skip868ind0')[field]).to include 'GREEN -|- CURRENTPER -|-  -|- Index: skip me (868) -|- '
           start = 'MUSIC -|- MUS-NOCIRC -|-  -|- Index: '
           expect(select_by_id('multSkip868ind0')[field]).to include "#{start}skip me 1 (868) -|- "
           expect(select_by_id('multSkip868ind0')[field]).to include "#{start}skip me 2 (868) -|- "


### PR DESCRIPTION
Part of https://github.com/sul-dlss/SearchWorks/issues/1974. Per JV, we shouldn't duplicate the display of latest received or public note. 

I've ignored the FOLIO MHLD indexing for the moment; a future ticket will cover the remaining differences, but hopefully this PR makes it a little clearer what we are currently doing and brings us closer to displaying the data the way we want to..