### PR TITLE
Also include holdings notes in MHLD statements 

### DIFF
--- a/lib/folio/mhld_builder.rb
+++ b/lib/folio/mhld_builder.rb
@@ -53,21 +53,21 @@ module Folio
 
     # @return [Array<String>] the list of statements
     def statements_for_holding(holding)
-      holding.fetch('holdingsStatements').select { |statement| statement.key?('statement') }.map do |statement|
-        if statement['note'].present?
-          "#{statement.fetch('statement')} #{statement.fetch('note')}"
-        else
-          statement.fetch('statement')
-        end
+      holding.fetch('holdingsStatements').select { |statement| statement.key?('statement') }.filter_map do |statement|
+        display_statement(statement)
       end + statments_for_index(holding) + statements_for_supplements(holding)
     end
 
     def statments_for_index(holding)
-      holding.fetch('holdingsStatementsForIndexes').filter_map { |statement| "Index: #{statement.fetch('statement')}" if statement.key?('statement') }
+      holding.fetch('holdingsStatementsForIndexes').filter_map { |statement| display_statement(statement) }.map { |v| "Index: #{v}" }
     end
 
     def statements_for_supplements(holding)
-      holding.fetch('holdingsStatementsForSupplements').filter_map { |statement| "Supplement: #{statement.fetch('statement')}" if statement.key?('statement') }
+      holding.fetch('holdingsStatementsForSupplements').filter_map { |statement| display_statement(statement) }.map { |v| "Supplement: #{v}" }
+    end
+
+    def display_statement(statement)
+      [statement['statement'], statement['note']].reject(&:blank?).join(' ').presence
     end
 
     # @return [String] the latest received piece for a holding

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -466,7 +466,7 @@ RSpec.describe 'FOLIO indexing' do
       let(:holdings_statements) do
         [{ 'staffNote' => 'Send to cataloging to receive and update holdings...', 'statement' => 'v.1, 11' }]
       end
-      it { is_expected.to eq ['EARTH-SCI -|- STACKS -|-  -|- v.1, 11 -|- '] }
+      it { is_expected.to eq ['EARTH-SCI -|- STACKS -|-  -|- v.1, 11 -|- ', 'EARTH-SCI -|- STACKS -|-  -|- Supplement: Library keeps latest only -|- '] }
     end
   end
 end


### PR DESCRIPTION
This creates parity with the current approach:

https://github.com/sul-dlss/searchworks_traject_indexer/blob/master/lib/traject/config/sirsi_config.rb#L2505-L2507

(`$a` is the statement, `$z` is the note)