### PR TITLE
Add the foreman gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,8 @@ group :deployment do
   gem 'capistrano-rvm'
   gem 'capistrano-shared_configs'
   gem 'dlss-capistrano'
+
+  gem 'foreman'
 end
 
 gem 'activesupport', '~> 7.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    foreman (0.87.2)
     hashdiff (1.0.1)
     hashie (5.0.0)
     honeybadger (5.2.1)
@@ -277,6 +278,7 @@ DEPENDENCIES
   debug
   dlss-capistrano
   dor-rights-auth
+  foreman
   honeybadger
   http
   i18n


### PR DESCRIPTION
This is a required dependency as of #809. ~I'm not sure if there's a reason to omit it from the Gemfile~ (there is: Foreman says not to), but this should help streamline deployments.