### PR TITLE
Install foreman as part of the deploy.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -64,6 +64,12 @@ task :jruby_bundle_install do
   end
 end
 
+task :install_foreman do
+  on roles(:app) do
+    execute :gem, 'install', 'foreman', '-v', '~> 0.87.0'
+  end
+end
+
 namespace :deploy do
   desc "config for monitoring the deployment's traject workers"
   before :cleanup, :start_workers do
@@ -74,3 +80,4 @@ namespace :deploy do
 end
 
 before 'bundler:install', 'jruby_bundle_install'
+after 'bundler:install', 'install_foreman'


### PR DESCRIPTION
Replaces #915 

Foreman says it shouldn't be added to the Gemfile (although I'm not personally convinced?), but it seems like we should want it installed as part of the deploy to ensure it is available.