### PR TITLE
Skip FOLIO records with only suppressed items

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -144,6 +144,10 @@ class FolioRecord
     @items ||= load('items').reject { |item| item['suppressFromDiscovery'] }
   end
 
+  def items_all_suppressed?
+    load('items').any? && load('items').all? { |item| item['suppressFromDiscovery'] }
+  end
+
   def holdings
     @holdings ||= load('holdings').reject { |item| item['suppressFromDiscovery'] }
   end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -141,11 +141,11 @@ class FolioRecord
   end
 
   def items
-    @items ||= load_unsuppressed('items')
+    @items ||= load('items').reject { |item| item['suppressFromDiscovery'] }
   end
 
   def holdings
-    @holdings ||= load_unsuppressed('holdings')
+    @holdings ||= load('holdings').reject { |item| item['suppressFromDiscovery'] }
   end
 
   def pieces
@@ -184,9 +184,9 @@ class FolioRecord
   private
 
   # @param [String] type either 'items' or 'holdings'
-  # @return [Array] list of records, of the specified type excluding those that are suppressed
-  def load_unsuppressed(type)
-    (record[type] || items_and_holdings&.dig(type) || []).compact.reject { |item| item['suppressFromDiscovery'] }
+  # @return [Array] list of records, of the specified type
+  def load(type)
+    (record[type] || items_and_holdings&.dig(type) || []).compact
   end
 
   def items_and_holdings

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -39,6 +39,11 @@ def reserves_lookup = {}
 
 load_config_file(File.expand_path('sirsi_config.rb', __dir__))
 
+# Skip records that only have suppressed items
+each_record do |record, context|
+  context.skip!('Only suppressed items') if record.items_all_suppressed?
+end
+
 def call_number_for_holding(record, holding, context)
   context.clipboard[:call_number_for_holding] ||= {}
   context.clipboard[:call_number_for_holding][holding] ||= begin


### PR DESCRIPTION
These are "shadowed" in symphony at the item level and don't make it to our Symphony-based indexer at all.