### PR TITLE
Derive MARC 856 field data from FOLIO electronic access statements

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -204,6 +204,7 @@ class FolioRecord
     end
   end
 
+  # rubocop:disable Metrics/AbcSize
   def instance_derived_marc_record
     MARC::Record.new.tap do |marc|
       marc.append(MARC::ControlField.new('001', hrid))
@@ -252,16 +253,25 @@ class FolioRecord
       record.dig('instance', 'series').each do |series|
         marc.append(MARC::DataField.new('490', '0', '', ['a', series]))
       end
-      # 856 stuff
-
       record.dig('instance', 'subjects').each do |subject|
         marc.append(MARC::DataField.new('653', '', '', ['a', subject]))
       end
+
+      # 856 stuff
+      record.dig('instance', 'electronicAccess')&.each do |eresource|
+        marc.append(MARC::DataField.new('856', '4', '0', ['u', eresource['uri']]))
+      end
+
+      holdings.flat_map { |h| h['electronicAccess'] }.each do |eresource|
+        marc.append(MARC::DataField.new('856', '4', '0', ['u', eresource['uri']]))
+      end
+
       # nature of content
       marc.append(MARC::DataField.new('999', '', '', ['i', record.dig('instance', 'id')]))
       # date creaetd
       # date updated
     end.to_hash
   end
+  # rubocop:enable Metrics/AbcSize
 end
 # rubocop:enable Metrics/ClassLength

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -85,10 +85,10 @@ class FolioRecord
   # since FOLIO Bound-with records don't have items, we generate a SirsiHolding using data from the parent item and child holding
   # TODO: remove this when we stop using SirsiHoldings
   def bound_with_holdings
-    return [] unless record['boundWithParents']
+    return [] unless bound_with_parents
 
     @bound_with_holdings ||= holdings.filter { |holding| holding['holdingsType'].is_a?(Hash) ? holding.dig('holdingsType', 'name') == 'Bound-with' : holding['holdingsType'] == 'Bound-with' }.filter_map do |holding|
-      parent_item = record['boundWithParents'].find { |parent| parent['childHoldingId'] == holding['id'] }
+      parent_item = bound_with_parents.find { |parent| parent['childHoldingId'] == holding['id'] }
       next unless parent_item
 
       parent_item_perm_location = parent_item.dig('parentItemLocation', 'permanentLocation', 'code')

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -23,6 +23,8 @@ settings do
     provide 'reader_class_name', 'Traject::FolioReader'
     provide 'folio.client', FolioClient.new(url: self['okapi.url'] || ENV.fetch('OKAPI_URL', nil))
   end
+
+  provide 'skip_empty_item_display', -1
 end
 
 ##
@@ -222,4 +224,12 @@ end
 
 to_field 'bound_with_parents_struct' do |record, accumulator|
   accumulator << record.bound_with_parents.to_json
+end
+
+##
+# Skip records for missing `item_display` field
+each_record do |record, context|
+  if context.output_hash['item_display'].blank? && context.output_hash['url_fulltext'].blank? && record.bound_with_parents.blank?
+    context.skip!('No item_display or url_fulltext field')
+  end
 end

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -81,7 +81,8 @@ module Traject
           jsonb_build_object(
             'instance',
               vi.jsonb || jsonb_build_object(
-                'suppressFromDiscovery', COALESCE((vi.jsonb ->> 'discoverySuppress')::bool, false)
+                'suppressFromDiscovery', COALESCE((vi.jsonb ->> 'discoverySuppress')::bool, false),
+                'electronicAccess', COALESCE(sul_mod_inventory_storage.getElectronicAccessName(COALESCE(vi.jsonb #> '{electronicAccess}', '[]'::jsonb)), '[]'::jsonb)
               ),
             'source_record', COALESCE(jsonb_agg(DISTINCT mr."content"), '[]'::jsonb),
             'items',

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -168,6 +168,36 @@ RSpec.describe FolioRecord do
     end
   end
 
+  describe 'derived 856 fields' do
+    let(:record) do
+      {
+        'instance' => {
+          'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+        },
+        'holdings' => [{
+          'electronicAccess' => [
+            { 'uri' => 'http://example.com/2', 'name' => 'Resource' }
+          ]
+        }],
+        'source_record' => [{
+          'fields' => [
+            { '001' => 'a14154194' },
+            { '856' => {
+              'subfields' => [
+                { 'u' => 'http://example.com/1' }
+              ]
+            } }
+          ]
+        }]
+      }
+    end
+
+    it 'replaces any 856 field data with a derived values from the electronic access statement in the FOLIO holdings' do
+      expect(folio_record.marc_record.fields('856').length).to eq(1)
+      expect(folio_record.marc_record['856'].subfields).to include(have_attributes(code: 'u', value: 'http://example.com/2'))
+    end
+  end
+
   describe '#bound_with_holdings' do
     context 'when the holding is not a bound-with child' do
       let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_basic.json'))), client) }


### PR DESCRIPTION
Fixes #921 

Lane is currently storing their electronic access in a MARC MHLD record. In FOLIO, they'd like to use FOLIO's native electronic access statements stored on their holdings record. We can ignore any data in the MARC bib records (so we don't have to have complicated merge logic).



