### PR TITLE
Omit the on-order placeholder for incomplete bound-with records

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -980,6 +980,9 @@ to_field 'access_facet' do |record, accumulator, context|
     end
   end
 
+  # Bound-withs are, by definition, at the library
+  accumulator << 'At the Library' if accumulator.empty? && record.fields('590').any? { |f| f['a'] && f['c'] }
+
   accumulator << 'On order' if accumulator.empty?
   accumulator << 'Online' if context.output_hash['url_fulltext']
   accumulator << 'Online' if context.output_hash['url_sfx']
@@ -2394,6 +2397,9 @@ end
 
 to_field 'item_display' do |record, accumulator, context|
   next if holdings(record, context).any?
+
+  # If there are no items, but this item appears to be a bound-with, we don't want to add the placeholder
+  next if record.fields('590').any? { |f| f['a'] && f['c'] }
 
   order_libs = Traject::MarcExtractor.cached('596a', alternate_script: false).extract(record)
   translation_map = Traject::TranslationMap.new('library_on_order_map')

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -51,6 +51,20 @@ RSpec.describe 'Access config' do
     specify { expect(result[field]).to eq ['Online'] }
   end
 
+  describe 'with a bound-with without any holdings' do
+    let(:record) do
+      MARC::Record.new.tap do |r|
+        r.leader = '00988nas a2200193z  4500'
+        r.append(MARC::ControlField.new('008', '071214uuuuuuuuuxx uu |ss    u|    |||| d'))
+        r.append(MARC::DataField.new('590', '4', '0',
+                                     MARC::Subfield.new('a', 'Bound-with'),
+                                     MARC::Subfield.new('c', '123456789')))
+      end
+    end
+
+    specify { expect(result[field]).to eq ['At the Library'] }
+  end
+
   describe 'when the url is that of a GSB request' do
     it 'is considered at the library' do
       expect(select_by_id('123http')[field]).to eq ['At the Library']

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -139,6 +139,23 @@ RSpec.describe 'ItemInfo config' do
       it { expect(result[field]).to match_array([match('-|- GREEN -|-'), match('-|- ART -|-')]) }
     end
 
+    context 'when an item is bound-with' do
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          r.append(
+            MARC::DataField.new(
+              '590', ' ', ' ',
+              MARC::Subfield.new('a', 'bound with something else'),
+              MARC::Subfield.new('c', '1234 (parent catkey)')
+            )
+          )
+        end
+      end
+
+      it 'omits the on-order placeholder' do
+        expect(result[field]).to be_nil
+      end
+    end
     describe 'field is populated correctly, focusing on building/library' do
       let(:fixture_name) { 'buildingTests.mrc' }
 


### PR DESCRIPTION
fixes #930

- [x] deal with the on-order placeholder entry in `item_display` 
- [x] deal with the `access_facet` entry