### PR TITLE
Simplify generated bound-with 590 logic

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -42,19 +42,16 @@ class FolioRecord
       record ||= MARC::Record.new_from_hash(stripped_marc_json || instance_derived_marc_record)
 
       # if 590 with Bound-with related subfields are present, return the record as is
-      field590 = record.find { |f| f.tag == '590' }
-      subfield_a = field590&.find { |sf| sf.code == 'a' }
-      subfield_c = field590&.find { |sf| sf.code == 'c' }
-      unless field590 && subfield_a && subfield_c
+      unless record.fields('590').any? { |f| f['a'] && f['c'] }
         # if 590 or one of its Bound-with related subfields is missing, and FOLIO says this record is Bound-with, append the relevant data from FOLIO
         parents ||= bound_with_parents
         # if Bound-with parents are found, edit the marc record
         if parents&.any?
           # append a new 590 and/or its subfields if not present
           parents.each do |parent|
-            field590 = MARC::DataField.new('590', ' ', ' ') if field590.nil?
-            field590.subfields << MARC::Subfield.new('a', "#{parent['childHoldingCallNumber']} bound with #{parent['parentInstanceTitle']}") if subfield_a.nil?
-            field590.subfields << MARC::Subfield.new('c', "#{parent['parentInstanceId']} (parent record)") if subfield_c.nil?
+            field590 = MARC::DataField.new('590', ' ', ' ')
+            field590.subfields << MARC::Subfield.new('a', "#{parent['childHoldingCallNumber']} bound with #{parent['parentInstanceTitle']}")
+            field590.subfields << MARC::Subfield.new('c', "#{parent['parentInstanceId']} (parent record)")
             record.append(field590)
           end
         end

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -5,23 +5,24 @@ require 'folio_record'
 require 'sirsi_holding'
 
 RSpec.describe FolioRecord do
-  subject(:folio_record) { described_class.new_from_source_record(record, client) }
+  subject(:folio_record) { described_class.new(record, client) }
   let(:client) { instance_double(FolioClient) }
   let(:record) do
     {
-      'parsedRecord' => {
-        'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
-        'content' => {
-          'fields' => [
-            { '001' => 'a14154194' },
-            { '918' => {
-              'subfields' => [
-                { 'a' => '14154194' }
-              ]
-            } }
-          ]
-        }
-      }
+      'instance' => {
+        'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+      },
+      'holdings' => [],
+      'source_record' => [{
+        'fields' => [
+          { '001' => 'a14154194' },
+          { '918' => {
+            'subfields' => [
+              { 'a' => '14154194' }
+            ]
+          } }
+        ]
+      }]
     }
   end
 
@@ -38,102 +39,45 @@ RSpec.describe FolioRecord do
   describe 'the 590 field' do
     context 'when record has existing 590 in its MARC' do
       context 'when 590 has subfield a' do
-        let(:folio_record) do
-          described_class.new_from_source_record(
-            {
-              'parsedRecord' => {
-                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
-                'content' => {
-                  'fields' => [
-                    { '001' => 'a14154194' },
-                    { '590' => {
-                      'subfields' => [
-                        { 'a' => 'Cataloged info about the Bound-with' }
-                      ]
-                    } }
-                  ]
-                }
-              }
+        let(:record) do
+          {
+            'instance' => {
+              'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
             },
-            client
-          )
+            'holdings' => [],
+            'source_record' => [{
+              'fields' => [
+                { '001' => 'a14154194' },
+                { '590' => {
+                  'subfields' => [
+                    { 'a' => 'Cataloged info about the Bound-with' }
+                  ]
+                } }
+              ]
+            }]
+          }
         end
-        it 'does not overwrite existing 590a' do
+        it 'does not overwrite existing 590s' do
           expect(folio_record.marc_record['590']['a']).to eq('Cataloged info about the Bound-with')
-        end
-      end
-      context 'when 590 has subfield c' do
-        let(:folio_record) do
-          described_class.new_from_source_record(
-            {
-              'parsedRecord' => {
-                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
-                'content' => {
-                  'fields' => [
-                    { '001' => 'a14154194' },
-                    { '590' => {
-                      'subfields' => [
-                        { 'c' => 'Cataloged info about the parent id' }
-                      ]
-                    } }
-                  ]
-                }
-              }
-            }, client
-          )
-        end
-        it 'does not overwrite existing 590c' do
-          expect(folio_record.marc_record['590']['c']).to eq('Cataloged info about the parent id')
-        end
-      end
-      context 'when 590 has subfield d' do
-        let(:folio_record) do
-          described_class.new_from_source_record(
-            {
-              'parsedRecord' => {
-                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
-                'content' => {
-                  'fields' => [
-                    { '001' => 'a14154194' },
-                    { '590' => {
-                      'subfields' => [
-                        { 'd' => 'Cataloged info totally unrelated to Bound-withs' }
-                      ]
-                    } }
-                  ]
-                }
-              }
-            },
-            client
-          )
-        end
-        it 'does not overwrite existing 590d' do
-          expect(folio_record.marc_record['590']['d']).to eq('Cataloged info totally unrelated to Bound-withs')
         end
       end
 
       context 'when 590 exists but is missing subfield a, c, or d, and has Bound-with parents via FOLIO APIs' do
-        let(:folio_record) do
-          described_class.new_from_source_record(
-            {
-              'parsedRecord' => {
-                'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
-                'content' => {
-                  'fields' => [
-                    { '001' => 'a84564' },
-                    { '590' => {
-                      'subfields' => []
-                    } }
-                  ]
-                }
-              }
+        let(:record) do
+          {
+            'instance' => {
+              'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
             },
-            client
-          )
-        end
-        before do
-          allow(folio_record).to receive(:bound_with_parents).and_return(
-            [
+            'holdings' => [],
+            'source_record' => [{
+              'fields' => [
+                { '001' => 'a14154194' },
+                { '590' => {
+                  'subfields' => []
+                } }
+              ]
+            }],
+            'boundWithParents' => [
               {
                 'parentInstanceId' => '134624',
                 'parentInstanceTitle' => 'Mursilis Sprachlähmung',
@@ -142,66 +86,64 @@ RSpec.describe FolioRecord do
                 'childHoldingCallNumber' => '064.8 .D191H'
               }
             ]
-          )
+          }
         end
-        it 'writes to 590a' do
-          expect(folio_record.marc_record['590']['a']).to eq('064.8 .D191H bound with Mursilis Sprachlähmung')
-        end
-        it 'writes to 590c' do
-          expect(folio_record.marc_record['590']['c']).to eq('134624 (parent record)')
-        end
-        it 'does not write to 590d' do
-          expect(folio_record.marc_record['590']['d']).to be_nil
+        it 'writes a new 590' do
+          expect(folio_record.marc_record['590'].subfields).to match_array([
+                                                                             have_attributes(code: 'a', value: '064.8 .D191H bound with Mursilis Sprachlähmung'),
+                                                                             have_attributes(code: 'c', value: '134624 (parent record)')
+                                                                           ])
         end
       end
     end
     context 'when record does not have existing 590 in its MARC' do
-      let(:folio_record) do
-        described_class.new_from_source_record(
-          {
-            'parsedRecord' => {
-              'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d',
-              'content' => {
-                'fields' => [
-                  { '001' => 'a84564' }
-                ]
-              }
-            }
+      let(:record) do
+        {
+          'instance' => {
+            'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
           },
-          client
-        )
-      end
-      context 'when FOLIO returns Bound-with data' do
-        before do
-          allow(folio_record).to receive(:bound_with_parents).and_return(
-            [
-              {
-                'parentInstanceId' => '134624',
-                'parentInstanceTitle' => 'Mursilis Sprachlähmung',
-                'parentItemId' => 'd1eece03-e4b6-5bd3-b6be-3d76ae8cf96d',
-                'parentItemBarcode' => '36105018739321',
-                'childHoldingCallNumber' => '064.8 .D191H'
-              }
+          'holdings' => [],
+          'source_record' => [{
+            'fields' => [
+              { '001' => 'a14154194' }
             ]
-          )
-        end
-        it 'creates a new 590 field' do
-          expect(folio_record.marc_record['590']).to be_a MARC::DataField
-        end
-        it 'writes to 590a' do
-          expect(folio_record.marc_record['590']['a']).to eq('064.8 .D191H bound with Mursilis Sprachlähmung')
-        end
-        it 'writes to 590c' do
-          expect(folio_record.marc_record['590']['c']).to eq('134624 (parent record)')
-        end
-        it 'does not write to 590d' do
-          expect(folio_record.marc_record['590']['d']).to be_nil
+          }],
+          'boundWithParents' => [
+            {
+              'parentInstanceId' => '134624',
+              'parentInstanceTitle' => 'Mursilis Sprachlähmung',
+              'parentItemId' => 'd1eece03-e4b6-5bd3-b6be-3d76ae8cf96d',
+              'parentItemBarcode' => '36105018739321',
+              'childHoldingCallNumber' => '064.8 .D191H'
+            }
+          ]
+        }
+      end
+
+      context 'when FOLIO returns Bound-with data' do
+        it 'writes a new 590' do
+          expect(folio_record.marc_record['590'].subfields).to match_array([
+                                                                             have_attributes(code: 'a', value: '064.8 .D191H bound with Mursilis Sprachlähmung'),
+                                                                             have_attributes(code: 'c', value: '134624 (parent record)')
+                                                                           ])
         end
       end
       context 'when FOLIO does not return Bound-with data' do
-        before do
-          allow(folio_record).to receive(:bound_with_parents).and_return([])
+        let(:record) do
+          {
+            'instance' => {
+              'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+            },
+            'holdings' => [],
+            'source_record' => [{
+              'fields' => [
+                { '001' => 'a14154194' }
+              ]
+            }],
+            'boundWithParents' => []
+          }
         end
+
         it 'does not create a new 590 field' do
           expect(folio_record.marc_record['590']).to be_nil
         end


### PR DESCRIPTION
The current implementation can inject data into an existing 590 field. I think we actually want the logic to be more like:

- if there's already a bound-with 590 (e.g. it has both a subfield a + c), do nothing.
- otherwise, if there's bound-with data from FOLIO, add a new 590 field for each bound-with parent
- leave any other 590 fields alone (e.g. the 590 field with a subfield 'a' with "MARCit brief record" that's not giving bound-with information)