### PR TITLE
Omit the SUL/INTERNET placeholder holding if there are existing items

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -113,6 +113,8 @@ class FolioRecord
   end
 
   def eresource_holdings
+    return [] if items.any?
+
     Folio::EresourceHoldingsBuilder.build(hrid, holdings, marc_record)
   end
 

--- a/spec/integration/compare_sirsi_and_folio_spec.rb
+++ b/spec/integration/compare_sirsi_and_folio_spec.rb
@@ -49,6 +49,10 @@ RSpec.describe 'comparing records from sirsi and folio', if: ENV['OKAPI_URL'] ||
       path = File.expand_path('../../lib/traject/config/sirsi_config.rb', __dir__)
       File.read(path).scan(/to_field ["']([^"']+)["']/).map(&:first).uniq
     end
+    before(:each) do
+      pending 'No record in FOLIO' unless folio_record.present?
+      pending 'No source record' if folio_record.record['source_record'].none?
+    end
 
     let(:skipped_fields) do
       [


### PR DESCRIPTION
Symphony holdings are inconsistent on this point, but most Symphony records omit the SUL/INTERNET item if there's an existing physical item.