### PR TITLE
Revert using zeitwerk

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ gem 'ruby-kafka'
 gem 'stanford-mods', '~> 3.0'
 gem 'statsd-ruby'
 gem 'whenever'
-gem 'zeitwerk'
 
 group :deployment do
   gem 'capistrano', '~> 3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,7 +301,6 @@ DEPENDENCIES
   traject_plus
   webmock
   whenever
-  zeitwerk
 
 BUNDLED WITH
    2.3.20

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-$LOAD_PATH << File.expand_path('../lib', __dir__)
 require 'rubygems'
 require 'bundler/setup'
 
@@ -13,10 +12,40 @@ end
 
 Config.load_and_set_settings(Config.setting_files(__dir__, ENV.fetch('TRAJECT_ENV', nil)))
 
-loader = Zeitwerk::Loader.new
-loader.inflector.inflect(
-  'lc' => 'LC'
-)
-loader.collapse("#{__dir__}/../lib/traject/*")
-loader.push_dir("#{__dir__}/../lib")
-loader.setup
+# jRuby 9.4.1.0 does not yet support zeitwerk
+# See: https://github.com/jruby/jruby/issues/6781
+# loader = Zeitwerk::Loader.new
+# loader.inflector.inflect(
+#   'lc' => 'LC'
+# )
+# loader.collapse("#{__dir__}/../lib/traject/*")
+# loader.push_dir("#{__dir__}/../lib")
+# loader.setup
+
+$LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
+
+require 'call_numbers/call_number_base'
+require 'call_numbers/shelfkey_base'
+require 'call_numbers/shelfkey'
+require 'call_numbers/other'
+require 'call_numbers/lc'
+require 'call_numbers/dewey'
+require 'call_numbers/dewey_shelfkey'
+
+require 'constants'
+require 'folio_client'
+require 'folio_record'
+require 'folio/eresource_holdings_builder'
+require 'folio/mhld_builder'
+require 'locations_map'
+require 'marc_links'
+require 'mhld_field'
+require 'public_xml_record'
+require 'sirsi_holding'
+require 'utils'
+require 'traject/readers/druid_reader'
+require 'traject/readers/kafka_purl_fetcher_reader'
+require 'traject/readers/kafka_marc_reader'
+require 'traject/readers/marc_combining_reader'
+require 'traject/writers/solr_better_json_writer'
+require 'traject/common/marc_utils'


### PR DESCRIPTION
Currently jruby does not support zeitwerk when loading a singleton (such as LocationMap) 

See https://github.com/jruby/jruby/issues/6781

This was causing errors like `NameError: uninitialized constant CallNumbers::ShelfkeyBase` when running in production (but not in tests sadly). (https://app.honeybadger.io/projects/57331/faults/97129515) 