### PR TITLE
Add volume + chronology to the generated item callnumber 

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -91,7 +91,7 @@ class FolioRecord
                            end
 
       SirsiHolding.new(
-        call_number: [item.dig('callNumber', 'callNumber'), item['enumeration']].compact.join(' '),
+        call_number: [item.dig('callNumber', 'callNumber'), item['volume'], item['enumeration'], item['chronology']].compact.join(' '),
         current_location: (current_location unless current_location == home_location_code),
         home_location: home_location_code,
         library: library_code,


### PR DESCRIPTION
…to better match the FOLIO UI's notion:

https://github.com/folio-org/stripes-util/blob/54db030221abd25b202bdcdbe7e34d9e396ff7dc/lib/effectiveCallNumber.js#L27-L35

Note that we're deliberately omitting the copy number.

Fixes https://github.com/sul-dlss/searchworks_traject_indexer/issues/954