### PR TITLE
Access the FOLIO database url through the environment settings

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -7,5 +7,6 @@ environments:
   morison:
     kafka_topic: marc_morison
   folio_test:
+    database_url: <%= ENV['DATABASE_URL'] %>
     processes: 1
     kafka_topic: marc_folio_test

--- a/script/process_folio_postgres_to_kafka.rb
+++ b/script/process_folio_postgres_to_kafka.rb
@@ -27,7 +27,7 @@ File.open(state_file, 'r+') do |f|
   Utils.logger.info "Found last_date in #{state_file}: #{last_date}" if last_date
 
   last_response_date = Traject::FolioPostgresReader.new(nil,
-                                                        'postgres.url': ENV.fetch('DATABASE_URL')).last_response_date
+                                                        'postgres.url': Utils.env_config.database_url).last_response_date
 
   shards = if Utils.env_config.processes.to_i > 1
              step = Utils.env_config.step_size || 0x0100
@@ -43,7 +43,7 @@ File.open(state_file, 'r+') do |f|
     attempts ||= 1
     begin
       reader = Traject::FolioPostgresReader.new(nil, 'folio.updated_after': last_date&.utc&.iso8601,
-                                                     'postgres.url': ENV.fetch('DATABASE_URL'), 'postgres.sql_filters': sql_filter)
+                                                     'postgres.url': Utils.env_config.database_url, 'postgres.sql_filters': sql_filter)
       Traject::FolioKafkaExtractor.new(reader:, kafka: Utils.kafka, topic: Utils.env_config.kafka_topic).process!
     rescue PG::Error => e
       raise(e) if attempts > 5


### PR DESCRIPTION
This is a stepping stone to switching puppet to set the right settings variable (e.g. `SETTINGS__enviornments__folio_test__database_url`?) instead of DATABASE_URL so we can easily support different FOLIO environments.