### PR TITLE
FOLIO barcodes are nil-able and ruby doesn't like sorting strings vs nil

### DIFF
--- a/lib/traject/config/sirsi_config.rb
+++ b/lib/traject/config/sirsi_config.rb
@@ -2222,10 +2222,12 @@ to_field 'preferred_barcode' do |record, accumulator, context|
   end.last if checking_for_ties_holdings.length > 1
 
   # Prefer items with the first volume sort key
+
   holding_with_the_most_recent_shelfkey = callnumber_with_the_most_items.min_by do |holding|
     call_number_object = call_number_for_holding(record, holding, context)
-    [call_number_object.to_volume_sort, holding.barcode]
+    [call_number_object.to_volume_sort, holding.barcode || '']
   end
+
   accumulator << holding_with_the_most_recent_shelfkey.barcode
 end
 


### PR DESCRIPTION
Fixes:

```
     ArgumentError:
       comparison of Array with Array failed
     Shared Example Group: "records match" called from ./spec/integration/compare_sirsi_and_folio_spec.rb:146
     # ./lib/traject/config/sirsi_config.rb:2226:in `each'
     # ./lib/traject/config/sirsi_config.rb:2226:in `min_by'
```



