### PR TITLE
Move MIGRATE-ERR suppression into FolioRecord#sirsi_holdings instead of in the query

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -81,6 +81,8 @@ class FolioRecord
       holding = holdings.find { |holding| holding['id'] == item['holdingsRecordId'] }
       item_location_code = item.dig('location', 'permanentLocation', 'code')
       item_location_code ||= holding.dig('location', 'permanentLocation', 'code')
+      next if item_location_code&.end_with? 'MIGRATE-ERR'
+
       library_code, home_location_code = LocationsMap.for(item_location_code)
       _current_library, current_location = LocationsMap.for(item.dig('location', 'location', 'code'))
       current_location ||= folio_status_to_location(item['status'])

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -21,12 +21,7 @@ module Traject
     end
 
     def default_filters
-      [suppress_shadowed_items, @settings['postgres.sql_filters']].compact
-    end
-
-    # exclude things that are shadowed in symphony, which are in locations that don't get mapped and thus end up in the "migration error" locations.
-    def suppress_shadowed_items
-      "item.effectivelocationid NOT IN (SELECT id from location WHERE jsonb ->> 'code' like '%MIGRATE-ERR')"
+      [@settings['postgres.sql_filters']].compact
     end
 
     def queries


### PR DESCRIPTION
Items aren't guaranteed to have location data (we also have to check holdings locations).

I think it's also a little confusing for debugging to suppress the data at the query level. It also seems like we probably don't want to go down the eresources path for instances with migrate-err holdings (which we do for any instance without items), so it's probably safer to filter these out after doing the query.