### PR TITLE
Write a test that shows that the query is valid

### DIFF
--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -12,6 +12,8 @@ module Traject
       @connection = PG.connect(@settings['postgres.url'])
       @page_size = @settings['postgres.page_size'] || 100
       @updated_after = @settings['folio.updated_after']
+      @statement_timeout = @settings.fetch('statement_timeout', 'DEFAULT') # Timeout value in milliseconds
+
       @sql_filters = default_filters
     end
 
@@ -68,6 +70,7 @@ module Traject
         # These settings seem to hint postgres to a better query plan
         @connection.exec('SET join_collapse_limit = 64')
         @connection.exec('SET from_collapse_limit = 64')
+        @connection.exec("SET statement_timeout = #{@statement_timeout}")
 
         # declare a cursor
         @connection.exec("DECLARE folio CURSOR FOR (#{queries})")

--- a/spec/lib/traject/readers/folio_postgres_reader_spec.rb
+++ b/spec/lib/traject/readers/folio_postgres_reader_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'traject/readers/folio_postgres_reader'
+
+RSpec.describe Traject::FolioPostgresReader, if: ENV.key?('DATABASE_URL') do
+  before do
+    WebMock.enable_net_connect!
+  end
+  let(:date) { Time.now.advance(days: -1) }
+  let(:timeout_in_milliseconds) { 1000 * 60 * 3 } # Three minutes
+  subject(:reader) do
+    described_class.new(nil, 'folio.updated_after' => date,
+                             'postgres.url' => ENV.fetch('DATABASE_URL'),
+                             'statement_timeout' => timeout_in_milliseconds)
+  end
+
+  # This test enables us to benchmark the query speed.  Against the folio-test db, I see results in 30-90s on 2023-07-18
+  it 'creates FolioRecords' do
+    begin
+      result = reader.first
+    rescue PG::QueryCanceled
+      raise "Query took too longer than #{timeout_in_milliseconds} milliseconds."
+    end
+    expect(result).to be_a FolioRecord # This may not pass if no records have been updated since `date`
+  end
+end


### PR DESCRIPTION
This also gives us a way to benchmark in order to see if we've adversely impacted the performance of the query.