### PR TITLE
Strip subfield 0 data that starts with (SIRSI)

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -44,6 +44,12 @@ class FolioRecord
     @marc_record ||= begin
       record ||= MARC::Record.new_from_hash(stripped_marc_json || instance_derived_marc_record)
 
+      record.fields.each do |field|
+        next unless field.respond_to? :subfields
+
+        field.subfields.delete_if { |subfield| subfield.code == '0' && subfield.value.start_with?('(SIRSI)') }
+      end
+
       # Copy FOLIO Holdings electronic access data to an 856 (used by Lane)
       # overwriting any existing 856 fields (to avoid having to reconcile/merge data)
       eholdings = holdings.flat_map { |h| h['electronicAccess'] }

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -34,6 +34,33 @@ RSpec.describe FolioRecord do
     it 'preserves non-junk tags' do
       expect(folio_record.marc_record['001']).to have_attributes(tag: '001', value: 'a14154194')
     end
+
+    context 'with subfield 0 data that used to be in the subfield =' do
+      let(:record) do
+        {
+          'instance' => {
+            'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+          },
+          'holdings' => [],
+          'source_record' => [{
+            'fields' => [
+              { '264' => {
+                'subfields' => [
+                  { '0' => '(SIRSI)blah' },
+                  { '0' => 'http://example.com' }
+                ]
+              } }
+            ]
+          }]
+        }
+      end
+
+      it 'strips only that migrated data' do
+        expect(folio_record.marc_record['264'].subfields).to match_array([
+                                                                           have_attributes(code: '0', value: 'http://example.com')
+                                                                         ])
+      end
+    end
   end
 
   describe 'the 590 field' do


### PR DESCRIPTION
These aren't present in the Symphony MARC record and make looking for indexing differences annoying.