### PR TITLE
Add stub on-order holdings for FOLIO for instances with only on-order holdings

### DIFF
--- a/lib/sirsi_holding.rb
+++ b/lib/sirsi_holding.rb
@@ -87,7 +87,7 @@ class SirsiHolding
   def temp_call_number?
     return false if library == 'HV-ARCHIVE' # Call numbers in HV-ARCHIVE are not temporary
 
-    call_number.to_s.start_with?(TEMP_CALLNUM_PREFIX)
+    call_number.to_s.blank? || call_number.to_s.start_with?(TEMP_CALLNUM_PREFIX)
   end
 
   def e_call_number?

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -257,4 +257,43 @@ RSpec.describe FolioRecord do
       end
     end
   end
+
+  describe '#sirsi_holdings' do
+    context 'with Symphony migrated data without on-order item records' do
+      let(:record) do
+        {
+          'instance' => {
+            'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+          },
+          'pieces' => [{ 'id' => '3b0c1675-b3ec-4bc4-888d-2519fb72b71f',
+                         'holdingId' => '1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2',
+                         'receivingStatus' => 'Expected',
+                         'displayOnHolding' => false }],
+          'holdings' => [{
+            'id' => '1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2',
+            'location' => {
+              'effectiveLocation' => {
+                'code' => 'GRE-STACKS'
+              }
+            }
+          }],
+          'items' => [],
+          'source_record' => [{
+            'fields' => [
+              { '001' => 'a14154194' }
+            ]
+          }]
+        }
+      end
+
+      it 'creates a stub on-order item' do
+        expect(folio_record.sirsi_holdings.first).to have_attributes(
+          barcode: '',
+          current_location: 'ON-ORDER',
+          home_location: 'ON-ORDER',
+          library: 'GREEN'
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This starts to handle one of the ways the FOLIO on-order data is modeled for migrated data.

Open questions (probably for future work) include:
- [ ] should we use the holdings location to populate the home location (parity with Symphony 999 records for ON-ORDER items), call numbers, etc, or is populating the library sufficient (parity with Symphony 596a data)
- [ ] should we create on-order items only when there are no other holdings (to ensure the record indexes, again parity with the 596a implementation) or for any holding without items (possibly more like natively created FOLIO on-order items)?
- [ ] do we need to handle unlinked on-order pieces (which only have a locationId, not a connection to a particular holding record)?

Part of #768 , at least sufficient to get instances with only on-order data indexed.