### PR TITLE
Downcase the provided hrid/catkey value when searching

### DIFF
--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -19,7 +19,7 @@ module Traject
 
     # Return a single record by catkey by temporarily applying a SQL filter
     def self.find_by_catkey(catkey, settings = {})
-      new(nil, settings.merge!('postgres.sql_filters' => "lower(sul_mod_inventory_storage.f_unaccent(vi.jsonb ->> 'hrid'::text)) = '#{catkey}'")).first
+      new(nil, settings.merge!('postgres.sql_filters' => "lower(sul_mod_inventory_storage.f_unaccent(vi.jsonb ->> 'hrid'::text)) = '#{catkey.downcase}'")).first
     end
 
     def default_filters


### PR DESCRIPTION
Copy/pasted HRIDs can have uppercase letters (e.g. L123), but the query wants lower-case values only.