### PR TITLE
Don't return a holding when there is a migration error

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -99,7 +99,7 @@ class FolioRecord
         public_note: item['notes']&.map { |n| ".#{n['itemNoteTypeName']&.upcase}. #{n['note']}" }&.join("\n"),
         tag: item
       )
-    end.concat(bound_with_holdings).concat(eresource_holdings).concat(on_order_stub_holdings)
+    end.compact.concat(bound_with_holdings).concat(eresource_holdings).concat(on_order_stub_holdings)
   end
 
   # since FOLIO Bound-with records don't have items, we generate a SirsiHolding using data from the parent item and child holding


### PR DESCRIPTION
Previously if the location ended with MIGRATE-ERR, it would add a nil into the list of sirsi_holdings.  This later cause a NoMethodError when iterating over this list.  Since the nil is not meaningful, we can compact them from the array.

Fixes #1001