### PR TITLE
Junk MHLD data from the MARC bib records

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -223,6 +223,7 @@ module Constants
 
   # Stripped from MARC when indexing
   JUNK_TAGS = %w[
+    852 853 863 866 867 868
     901 910 918 923 924 930 935 940 948 949 950 955 960 962 980 981 983 990 993 998
   ]
 end


### PR DESCRIPTION
Gryphon-search approved stripping out MHLD data from FOLIO MARC bib records; these were already stripped as part of the Symphony -> Searchworks bib dump (but that indexer also received MARC MHLD data).

In FOLIO, we're only looking at the  holdings records holdings statements, not MHLD MARC records, so any MHLD data in the bib records isn't of value.