### PR TITLE
Filter out staff-only instance notes; fixes #1045

### DIFF
--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -183,7 +183,9 @@ module Traject
                                     ELSE
                                        '[]'::jsonb
                                     END,
-                'administrativeNotes', '[]'::jsonb
+                'administrativeNotes', '[]'::jsonb,
+                'notes', COALESCE((SELECT jsonb_agg(e) FROM jsonb_array_elements(vi.jsonb -> 'notes') AS e WHERE NOT COALESCE((e ->> 'staffOnly')::bool, false)), '[]'::jsonb)
+
               ),
             'source_record', COALESCE(jsonb_agg(DISTINCT mr."content"), '[]'::jsonb),
             'items',


### PR DESCRIPTION
We previously filtered out notes from items + holdings (#983) but it turns out instances also have staff-only notes.