### PR TITLE
Ensure we disable old course reserves lookup during indexing

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -39,10 +39,10 @@ each_record do |record, context|
   end
 end
 
+load_config_file(File.expand_path('sirsi_config.rb', __dir__))
+
 # Disable Sirsi reserves lookup from file in favor of FOLIO data
 def reserves_lookup = {}
-
-load_config_file(File.expand_path('sirsi_config.rb', __dir__))
 
 # Skip records that only have suppressed items
 each_record do |record, context|


### PR DESCRIPTION
Because we load the sirsi config after overriding reserves_lookup,
we weren't actually turning off the lookup of old course reserve
data, so it was being used at index time to populate item_display
and other fields.

This changes the order so that we override the method after loading
the sirsi_config.
