### PR TITLE
Skip items with a suppressing or migrate-err holdings record

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -47,6 +47,8 @@ class FolioRecord
   def sirsi_holdings
     @sirsi_holdings ||= items.filter_map do |item|
       holding = holdings.find { |holding| holding['id'] == item['holdingsRecordId'] }
+      next unless holding
+
       item_location_code = item.dig('location', 'permanentLocation', 'code')
       item_location_code ||= holding.dig('location', 'effectiveLocation', 'code')
 

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -481,6 +481,7 @@ RSpec.describe 'FOLIO indexing' do
       let(:items) do
         [{ 'id' => '7fdf7094-d30a-5f70-b23e-bc420a82a1d7',
            'hrid' => 'ai645341_1_1',
+           'holdingsRecordId' => '9c7b3dca-1619-5210-9bd1-6df775986b81',
            'notes' => [],
            'status' => 'Awaiting pickup',
            'barcode' => '36105080746311',


### PR DESCRIPTION
After #1054, we can get items without a corresponding holding record when it's in the migrate-err location. 

Fixes #1072 1072