### PR TITLE
Update FolioPostgresReader to accept 'addl_from' clauses for filtering

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,3 +41,4 @@ group :deployment do
 end
 
 gem 'activesupport', '~> 7.0'
+gem 'slop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,6 +296,7 @@ DEPENDENCIES
   rubocop
   ruby-kafka
   simplecov
+  slop
   stanford-mods (~> 3.0)
   statsd-ruby
   traject (~> 3.0)

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -14,7 +14,7 @@ module Traject
       @updated_after = @settings['folio.updated_after']
       @statement_timeout = @settings.fetch('statement_timeout', 'DEFAULT') # Timeout value in milliseconds
 
-      @sql_filters = [@settings['postgres.sql_filters']].compact
+      @sql_filters = [@settings['postgres.sql_filters']].flatten.compact
       @addl_from = @settings['postgres.addl_from']
     end
 

--- a/script/load_folio_postgres_full.sh
+++ b/script/load_folio_postgres_full.sh
@@ -9,6 +9,6 @@ SCRIPT_FULL_PATH=$(dirname "$0")
 (
 flock -n 200 || exit 0
 
-bundle exec ruby script/process_folio_postgres_to_kafka.rb full > $LOG_FILE.log
+bundle exec ruby script/process_folio_postgres_to_kafka.rb --full > $LOG_FILE.log
 
 ) 200>tmp/.load_folio_postgres.lock


### PR DESCRIPTION
```
usage: script/process_folio_postgres_to_kafka.rb [options]
    --help           
    --kafka-topic    The kafka topic used for writing records
    --verbose        
    --processes      Number of parallel processes to spawn to handle querying

State management
    --state-file     
    --no-state-file  do not use the state file to track the current query time
    --full           enable full indexing (vs delta indexing, that uses the modified timestamp from the state file)

SQL query options
    --sql-query      a list of additional SQL filters to apply to the query
    --sql-join       an additional SQL join query to apply to the underlying query
```