### PR TITLE
Treat some temporary locations as if they were the permanent locations

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -49,7 +49,8 @@ class FolioRecord
       holding = holdings.find { |holding| holding['id'] == item['holdingsRecordId'] }
       next unless holding
 
-      item_location_code = item.dig('location', 'permanentLocation', 'code')
+      item_location_code = item.dig('location', 'temporaryLocation', 'code') if item.dig('location', 'temporaryLocation', 'details', 'searchworksTreatTemporaryLocationAsPermanentLocation') == 'true'
+      item_location_code ||= item.dig('location', 'permanentLocation', 'code')
       item_location_code ||= holding.dig('location', 'effectiveLocation', 'code')
 
       library_code, home_location_code = LocationsMap.for(item_location_code)
@@ -90,7 +91,9 @@ class FolioRecord
     @bound_with_holdings ||= holdings.select { |holding| holding['boundWith'].present? }.map do |holding|
       parent_item = holding.dig('boundWith', 'item')
       parent_holding = holding.dig('boundWith', 'holding')
-      item_location_code = parent_item.dig('location', 'permanentLocation', 'code')
+
+      item_location_code = parent_item.dig('location', 'temporaryLocation', 'code') if parent_item.dig('location', 'temporaryLocation', 'details', 'searchworksTreatTemporaryLocationAsPermanentLocation') == 'true'
+      item_location_code ||= parent_item.dig('location', 'permanentLocation', 'code')
       item_location_code ||= parent_holding.dig('location', 'effectiveLocation', 'code')
 
       library_code, home_location_code = LocationsMap.for(item_location_code)

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -344,7 +344,7 @@ RSpec.describe FolioRecord do
             'holdingsRecordId' => '1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2',
             'location' => {
               'temporaryLocation' => {
-                'code' => 'GRE-CRES'
+                'code' => 'GRE-SSRC'
               }
             }
           }],
@@ -358,8 +358,53 @@ RSpec.describe FolioRecord do
 
       it 'uses the temp location as the current location' do
         expect(folio_record.sirsi_holdings.first).to have_attributes(
-          current_location: 'GRE-CRES',
+          current_location: 'SSRC',
           home_location: 'STACKS',
+          library: 'GREEN'
+        )
+      end
+    end
+
+    context 'with an item with a courese reserves-like location' do
+      let(:record) do
+        {
+          'instance' => {
+            'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+          },
+          'pieces' => [{ 'id' => '3b0c1675-b3ec-4bc4-888d-2519fb72b71f',
+                         'holdingId' => '1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2',
+                         'receivingStatus' => 'Expected',
+                         'displayOnHolding' => false }],
+          'holdings' => [{
+            'id' => '1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2',
+            'location' => {
+              'effectiveLocation' => {
+                'code' => 'SAL3-STACKS'
+              }
+            }
+          }],
+          'items' => [{
+            'holdingsRecordId' => '1146c4fa-5798-40e1-9b8e-92ee4c9f2ee2',
+            'location' => {
+              'temporaryLocation' => {
+                'code' => 'GRE-CRES',
+                'details' => {
+                  'searchworksTreatTemporaryLocationAsPermanentLocation' => 'true'
+                }
+              }
+            }
+          }],
+          'source_record' => [{
+            'fields' => [
+              { '001' => 'a14154194' }
+            ]
+          }]
+        }
+      end
+
+      it 'uses the temp location as the home location' do
+        expect(folio_record.sirsi_holdings.first).to have_attributes(
+          home_location: 'GRE-CRES',
           library: 'GREEN'
         )
       end


### PR DESCRIPTION
e.g. course reserves desks. This should allow us to display FOLIO data more like Symphony:

Current behavior:
![Screenshot 2023-08-16 at 11 41 01](https://github.com/sul-dlss/searchworks_traject_indexer/assets/111218/606b5cc7-5478-4d5f-b5c0-eb4fcbf1a80c)

Symphony behavior:
![Screenshot 2023-08-16 at 11 41 16](https://github.com/sul-dlss/searchworks_traject_indexer/assets/111218/2f54ab39-cc25-4311-a717-78959457f36f)

