### PR TITLE
Don't skip records just because it has no unsuppressed items; some of…

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -120,11 +120,6 @@ each_record do |record, context|
   end
 end
 
-# Skip records that only have suppressed items
-each_record do |record, context|
-  context.skip!('Only suppressed items') if record.items_all_suppressed?
-end
-
 each_record do |record, context|
   context.skip!('Incomplete record') if record['245'] && record['245']['a'] == '**REQUIRED FIELD**'
 end


### PR DESCRIPTION
… these are also e-resources.

We're checking if there are no items or full-text URLs after we've processed the record; there's no need to double-up on that check (although someday it'd be nice to check if the record will be indexed before we do all the hard work...).