### PR TITLE
Allow indexing of holdings and items in MIGRATE-ERR locations

### DIFF
--- a/lib/folio/mhld_builder.rb
+++ b/lib/folio/mhld_builder.rb
@@ -28,8 +28,7 @@ module Folio
 
     private
 
-    # Remove suppressed records, electronic records, records that have a location matching *-MIGRATE-ERR and
-    # records with no holdings statement
+    # Remove suppressed records, electronic records, and records with no holdings statement
     def filtered_holdings
       holdings.filter_map do |holding|
         no_holding_statements = (holding.fetch('holdingsStatements') +
@@ -37,8 +36,7 @@ module Folio
                                  holding.fetch('holdingsStatementsForSupplements')).compact.empty?
         next if no_holding_statements || holding['suppressFromDiscovery'] ||
                 (holding.dig('holdingsType', 'name') ||
-                 holding.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName')) == 'Electronic' ||
-                holding.dig('location', 'effectiveLocation', 'code').end_with?('MIGRATE-ERR')
+                 holding.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName')) == 'Electronic'
 
         note = holding.fetch('holdingsStatements').compact.find { |statement| statement.key?('note') && !statement.key?('statement') }&.fetch('note')
 

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -168,8 +168,7 @@ class FolioRecord
 
   def items
     @items ||= load('items').reject do |item|
-      loc = item.dig('location', 'permanentLocation', 'code')
-      item['suppressFromDiscovery'] || loc&.end_with?('MIGRATE-ERR')
+      item['suppressFromDiscovery']
     end
   end
 
@@ -179,8 +178,7 @@ class FolioRecord
 
   def holdings
     @holdings ||= load('holdings').reject do |holding|
-      loc = holding.dig('location', 'effectiveLocation', 'code')
-      holding['suppressFromDiscovery'] || loc&.end_with?('MIGRATE-ERR')
+      holding['suppressFromDiscovery']
     end
   end
 

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -172,10 +172,6 @@ class FolioRecord
     end
   end
 
-  def items_all_suppressed?
-    load('items').any? && load('items').all? { |item| item['suppressFromDiscovery'] }
-  end
-
   def holdings
     @holdings ||= load('holdings').reject do |holding|
       holding['suppressFromDiscovery']

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -120,11 +120,6 @@ each_record do |record, context|
   end
 end
 
-# Skip records that only have suppressed items
-each_record do |record, context|
-  context.skip!('Only suppressed items') if record.items_all_suppressed?
-end
-
 each_record do |record, context|
   context.skip!('Incomplete record') if record['245'] && record['245']['a'] == '**REQUIRED FIELD**'
 end

--- a/spec/lib/folio/mhld_builder_spec.rb
+++ b/spec/lib/folio/mhld_builder_spec.rb
@@ -327,7 +327,7 @@ RSpec.describe Folio::MhldBuilder do
       it { is_expected.to be_empty }
     end
 
-    context 'with MIGRATE-ERR locations' do
+    context 'when the holding is suppressed from discovery' do
       let(:holding) do
         { 'id' => '4a3a0693-f2a5-4d79-8603-5659ed121ae2',
           'notes' => [],
@@ -347,7 +347,7 @@ RSpec.describe Folio::MhldBuilder do
           'receivingHistory' => { 'entries' => [] },
           'statisticalCodes' => [],
           'holdingsStatements' => holdings_statements,
-          'suppressFromDiscovery' => false,
+          'suppressFromDiscovery' => true,
           'holdingsStatementsForIndexes' => index_statements,
           'holdingsStatementsForSupplements' => supplement_statements }
       end


### PR DESCRIPTION
- Don't filter out holdings and items in *-MIGRATE-ERR locations
- Remove check for skipping indexing of records with all suppressed items
