### PR TITLE
Remove a call number type that can not be expressed in Folio

### DIFF
--- a/lib/sirsi_holding.rb
+++ b/lib/sirsi_holding.rb
@@ -43,8 +43,7 @@ class SirsiHolding
   end
 
   def skipped?
-    ([home_location, current_location] & SKIPPED_LOCS).any? ||
-      type == 'EDI-REMOVE'
+    ([home_location, current_location] & SKIPPED_LOCS).any?
   end
 
   def shelved_by_location?

--- a/spec/lib/traject/config/callnum_facet_spec.rb
+++ b/spec/lib/traject/config/callnum_facet_spec.rb
@@ -64,9 +64,6 @@ RSpec.describe 'Call Number Facet' do
       # skipped location
       expect(record_with_999(call_number: 'M123 .M234', home_location: 'BENDER-S', scheme: 'LC',
                              indexer:)[field]).to be_nil
-      # skipped type
-      expect(record_with_999(call_number: 'M123 .M234', type: 'EDI-REMOVE', scheme: 'LC',
-                             indexer:)[field]).to be_nil
     end
 
     it 'handles weird LC callnum from Lane-Med (by not including them)' do


### PR DESCRIPTION
All callnumber types are from FolioRecord#call_number_type_map and EDI-REMOVE is not one of the returned values