### PR TITLE
Remove MARC 999 reference from genre_spec

### DIFF
--- a/spec/lib/traject/config/genre_spec.rb
+++ b/spec/lib/traject/config/genre_spec.rb
@@ -38,21 +38,6 @@ RSpec.describe 'Format physical config' do
       specify { expect(result[field]).to include 'Conference proceedings' }
     end
 
-    context 'with a database' do
-      let(:record) do
-        MARC::Record.new.tap do |r|
-          r.leader = '01515cas a2200385Ma 4500'
-          r.append(MARC::ControlField.new('008', '000208c199u9999nyu x   s     0    0eng d'))
-          r.append(MARC::DataField.new('650', ' ', '0',
-                                       MARC::Subfield.new('a', 'subject'),
-                                       MARC::Subfield.new('v', 'Congresses')))
-          r.append(MARC::DataField.new('999', ' ', ' ', MARC::Subfield.new('t', 'DATABASE')))
-        end
-      end
-
-      specify { expect(result[field]).to include 'Conference proceedings' }
-    end
-
     context 'with a manuscript' do
       let(:record) do
         MARC::Record.new.tap do |r|


### PR DESCRIPTION
Thought I would try an easy 999 removal first. I was ready to rewrite this test, but I fail to see how it's relevant to the genre field at all. The test right above it is almost exactly the same. There is no reference to 999 in the `genre_ssim` code in `folio_config`.