### PR TITLE
Tweak when we're generating stub FOLIO items

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -119,7 +119,7 @@ class FolioRecord
   end
 
   def eresource_holdings
-    return [] if items.any?
+    return [] if items.any? || holdings.select { |holding| holding['boundWith'].present? }
 
     Folio::EresourceHoldingsBuilder.build(hrid, holdings, marc_record)
   end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -125,7 +125,7 @@ class FolioRecord
   end
 
   def on_order_stub_holdings
-    return [] if items.any?
+    return [] if all_items.any? || eresource_holdings
 
     on_order_holdings = holdings.select do |holding|
       pieces.any? { |p| p['holdingId'] == holding['id'] && p['receivingStatus'] == 'Expected' && !p['discoverySuppress'] }
@@ -168,9 +168,13 @@ class FolioRecord
   end
 
   def items
-    @items ||= load('items').reject do |item|
+    all_items.reject do |item|
       item['suppressFromDiscovery']
     end
+  end
+
+  def all_items
+    @all_items ||= load('items')
   end
 
   def holdings

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2341,27 +2341,6 @@ to_field 'item_display_struct' do |record, accumulator, context|
   end
 end
 
-to_field 'item_display_struct' do |record, accumulator, context|
-  next if holdings(record, context).any?
-
-  # If there are no items, but this item appears to be a bound-with, we don't want to add the placeholder
-  next if record.fields('590').any? { |f| f['a'] && f['c'] }
-
-  order_libs = Traject::MarcExtractor.cached('596a', alternate_script: false).extract(record)
-  translation_map = Traject::TranslationMap.new('library_on_order_map')
-
-  lib_codes = order_libs.flat_map { |l| l.split(' ') }.map { |order_lib| translation_map[order_lib] }.uniq
-  # exclude generic SUL if there's a more specific library
-  lib_codes -= ['SUL'] if lib_codes.length > 1
-  lib_codes.each do |lib|
-    accumulator << {
-      library: lib,
-      home_location: 'ON-ORDER',
-      current_location: 'ON-ORDER'
-    }
-  end
-end
-
 ##
 # Skip records for missing `item_display` field
 each_record do |_record, context|

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -302,28 +302,23 @@ RSpec.describe FolioRecord do
     end
   end
 
-  describe '#bound_with_holdings' do
-    context 'when the holding is not a bound-with child' do
-      let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_basic.json'))), client) }
-      it 'does not return any bound-with holdings' do
-        expect(folio_record.bound_with_holdings).to be_empty
-      end
-    end
-    context 'when the bound with child is not in SAL3' do
-      let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_child.json'))), client) }
-      it 'does not add SEE-OTHER as the home_location' do
-        expect(folio_record.bound_with_holdings.first.home_location).not_to eq('SEE-OTHER')
-      end
-    end
-    context 'when the bound with child is in SAL3' do
-      let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_child_see-other.json'))), client) }
-      it 'adds SEE-OTHER as the home_location' do
-        expect(folio_record.bound_with_holdings.first.home_location).to eq('SEE-OTHER')
-      end
-    end
-  end
-
   describe '#sirsi_holdings' do
+    context 'bound-withs' do
+      context 'when the bound with child is not in SAL3' do
+        let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_child.json'))), client) }
+        it 'does not add SEE-OTHER as the home_location' do
+          expect(folio_record.sirsi_holdings.first.home_location).not_to eq('SEE-OTHER')
+        end
+      end
+
+      context 'when the bound with child is in SAL3' do
+        let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_child_see-other.json'))), client) }
+        it 'adds SEE-OTHER as the home_location' do
+          expect(folio_record.sirsi_holdings.first.home_location).to eq('SEE-OTHER')
+        end
+      end
+    end
+
     context 'with an item with a temporary location' do
       let(:record) do
         {


### PR DESCRIPTION
We always want to generate item records for FOLIO items (that aren't suppressed) and FOLIO bound-with holdings.

We should fall-back on generating a stub record for eResources, and if there aren't eResources fall back on an on-order record (either because there is an PO line or a `596a`  in the MARC (for now...))

This refactor hopefully makes that relationship clearer, and gets rid of the implicitly created on-order stub.

