### PR TITLE
Guard against blank 856u values

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -922,7 +922,7 @@ to_field 'url_fulltext' do |record, accumulator|
     accumulator.concat extractor.collect_subfields(field, spec)
   end
 
-  accumulator.reject! { |v| MarcLinks::GSB_URL_REGEX.match?(v) }
+  accumulator.reject! { |v| v.blank? || MarcLinks::GSB_URL_REGEX.match?(v) }
 end
 
 # returns the URLs for supplementary information (rather than fulltext)

--- a/spec/lib/traject/config/url_spec.rb
+++ b/spec/lib/traject/config/url_spec.rb
@@ -82,6 +82,27 @@ RSpec.describe 'Access config' do
       end
     end
 
+    describe 'Blank subfield u' do
+      let(:records) do
+        [
+          MARC::Record.new.tap do |r|
+            r.append(
+              MARC::DataField.new(
+                '856',
+                '4',
+                nil,
+                MARC::Subfield.new('u', '')
+              )
+            )
+          end
+        ]
+      end
+
+      it 'are not considered full text' do
+        expect(results.first[field]).to be_blank
+      end
+    end
+
     describe '2nd indicators of 3' do
       let(:records) do
         [


### PR DESCRIPTION
E.g. https://gryphon-search.stanford.edu/view/10452961.. presumably a data error, but we ended up with many of them in the FOLIO migration.