### PR TITLE
Expand TEMP_CALLNUM_PREFIX to match the actual migrated data

### DIFF
--- a/lib/sirsi_holding.rb
+++ b/lib/sirsi_holding.rb
@@ -14,7 +14,7 @@ class SirsiHolding
   SHELBY_LOCS = %w[BUS-PER BUS-MAKENA SHELBYTITL SHELBYSER].freeze
   SKIPPED_CALL_NUMS = ['NO CALL NUMBER'].freeze
   SKIPPED_LOCS = %w[BORROWDIR CDPSHADOW SHADOW SSRC-FIC-S STAFSHADOW TECHSHADOW WITHDRAWN].freeze
-  TEMP_CALLNUM_PREFIX = 'XX'.freeze
+  TEMP_CALLNUM_PREFIX = 'XX('.freeze
 
   attr_reader :id, :current_location, :home_location, :library, :scheme, :type, :barcode, :public_note, :course_reserves
 
@@ -80,8 +80,6 @@ class SirsiHolding
   end
 
   def temp_call_number?
-    return false if library == 'HV-ARCHIVE' # Call numbers in HV-ARCHIVE are not temporary
-
     call_number.to_s.blank? || call_number.to_s.start_with?(TEMP_CALLNUM_PREFIX)
   end
 


### PR DESCRIPTION
Confirmed HILA has call numbers that start with XX, e.g.

```
"a4086108","XX015"
"a4086131","XX048"
"a4086140","XX058"
"a4086148","XX066"
"a4086151","XX069"
"a4086163","XX090"
"a4086200","XX136"
```

(But `HILA` also has the normal `XX(` temp call numbers too)

It looks like all the true "temp" call numbers start with `XX(`, so... we just use that?