### PR TITLE
Extract FolioHolding

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,6 +20,11 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*_spec.rb'
 
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/folio_holding.rb'
+    - 'lib/sirsi_holding.rb'
+
 Gemspec/DeprecatedAttributeAssignment: # new in 1.30
   Enabled: true
 Gemspec/DevelopmentDependencies: # new in 1.44

--- a/lib/folio/eresource_holdings_builder.rb
+++ b/lib/folio/eresource_holdings_builder.rb
@@ -48,7 +48,7 @@ module Folio
     end
 
     def sirsi_holding(index)
-      SirsiHolding.new(
+      FolioHolding.new(
         call_number: CALL_NUMBER,
         barcode: barcode(index),
         home_location: home_location_code,

--- a/lib/folio/eresource_holdings_builder.rb
+++ b/lib/folio/eresource_holdings_builder.rb
@@ -51,26 +51,13 @@ module Folio
       FolioHolding.new(
         call_number: CALL_NUMBER,
         barcode: barcode(index),
-        home_location: home_location_code,
-        library: library_code,
+        holding: electronic_holding_location,
         type: TYPE
       )
     end
 
     def barcode(index)
       "#{hrid.sub(/^a/, '')}-#{(1000 + index + 1).to_s.rjust(4, '0')}"
-    end
-
-    def home_location_code
-      mapped_location_codes.last
-    end
-
-    def library_code
-      mapped_location_codes.first
-    end
-
-    def mapped_location_codes
-      @mapped_location_codes ||= LocationsMap.for(electronic_holding_location.dig('location', 'effectiveLocation', 'code'))
     end
 
     # This finds the first holding matching an online location code.

--- a/lib/folio_holding.rb
+++ b/lib/folio_holding.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+class FolioHolding
+  extend Forwardable
+
+  delegate %i[dewey? valid_lc?] => :call_number
+
+  BUSINESS_SHELBY_LOCS = %w[NEWS-STKS].freeze
+  ECALLNUM = 'INTERNET RESOURCE'.freeze
+  GOV_DOCS_LOCS = %w[BRIT-DOCS CALIF-DOCS FED-DOCS INTL-DOCS SSRC-DOCS SSRC-FICHE SSRC-NWDOC].freeze
+  LOST_OR_MISSING_LOCS = %w[MISSING].freeze
+  SHELBY_LOCS = %w[BUS-PER BUS-MAKENA SHELBYTITL SHELBYSER].freeze
+  SKIPPED_CALL_NUMS = ['NO CALL NUMBER'].freeze
+  SKIPPED_LOCS = %w[BORROWDIR CDPSHADOW SHADOW SSRC-FIC-S STAFSHADOW TECHSHADOW WITHDRAWN].freeze
+  TEMP_CALLNUM_PREFIX = 'XX'.freeze
+
+  attr_reader :id, :current_location, :home_location, :library, :scheme, :type, :barcode, :public_note, :course_reserves
+
+  # rubocop:disable Metrics/ParameterLists
+  def initialize(call_number:, home_location:, library:, barcode:, scheme: nil, current_location: nil,
+                 id: nil, type: nil, public_note: nil, course_reserves: {})
+    @id = id
+    @call_number = call_number
+    @current_location = current_location
+    @home_location = home_location
+    @library = library
+    @scheme = scheme
+    @type = type
+    @barcode = barcode
+    @public_note = public_note
+    @course_reserves = course_reserves
+  end
+  # rubocop:enable Metrics/ParameterLists
+
+  def call_number
+    @call_number_obj ||= CallNumber.new(normalize_call_number(@call_number))
+  end
+
+  def skipped?
+    ([home_location, current_location] & SKIPPED_LOCS).any?
+  end
+
+  def shelved_by_location?
+    if library == 'BUSINESS'
+      ([home_location, current_location] & BUSINESS_SHELBY_LOCS).any?
+    else
+      ([home_location, current_location] & SHELBY_LOCS).any?
+    end
+  end
+
+  def call_number_type
+    case scheme
+    when /^LC/
+      'LC'
+    when /^DEWEY/
+      'DEWEY'
+    when 'SUDOC'
+      'SUDOC'
+    when 'ALPHANUM'
+      'ALPHANUM'
+    else
+      'OTHER'
+    end
+  end
+
+  def bad_lc_lane_call_number?
+    return false if valid_lc?
+    return false if library != 'LANE-MED'
+    return false if dewey?
+
+    call_number_type == 'LC'
+  end
+
+  def ignored_call_number?
+    SKIPPED_CALL_NUMS.include?(call_number.to_s) ||
+      e_call_number? ||
+      temp_call_number?
+  end
+
+  def temp_call_number?
+    return false if library == 'HV-ARCHIVE' # Call numbers in HV-ARCHIVE are not temporary
+
+    call_number.to_s.blank? || call_number.to_s.start_with?(TEMP_CALLNUM_PREFIX)
+  end
+
+  def e_call_number?
+    call_number.to_s.start_with?(ECALLNUM)
+  end
+
+  def lost_or_missing?
+    ([home_location, current_location] & LOST_OR_MISSING_LOCS).any?
+  end
+
+  def gov_doc_loc?
+    ([home_location, current_location] & GOV_DOCS_LOCS).any?
+  end
+
+  def in_process?
+    temp_call_number? && (current_location == 'INPROCESS' || (!current_location.nil? && home_location != 'ON-ORDER'))
+  end
+
+  def on_order?
+    temp_call_number? && (current_location == 'ON-ORDER' || (!current_location.nil? && home_location == 'ON-ORDER'))
+  end
+
+  def ==(other)
+    other.is_a?(self.class) and
+      other.call_number == @call_number and
+      other.current_location == @current_location and
+      other.home_location == @home_location and
+      other.library == @library and
+      other.scheme == @scheme and
+      other.type == @type and
+      other.barcode == @barcode
+  end
+
+  alias eql? ==
+
+  def hash
+    @call_number.hash ^ @current_location.hash ^ @home_location.hash ^ @library.hash ^ @scheme.hash ^ @type.hash ^ @barcode.hash
+  end
+
+  def to_item_display_hash
+    current_location = self.current_location.presence
+    current_location = 'ON-ORDER' if on_order? && current_location && !current_location.empty? && home_location != 'ON-ORDER' && home_location != 'INPROCESS'
+
+    {
+      id:,
+      barcode:,
+      library:,
+      home_location:,
+      current_location:,
+      type:,
+      note: public_note.presence
+    }.merge(course_reserves)
+  end
+
+  private
+
+  # Call number normalization ported from solrmarc code
+  def normalize_call_number(call_number)
+    return call_number unless call_number && %w[LC DEWEY].include?(call_number_type) # Normalization only applied to LC/Dewey
+
+    call_number = call_number.strip.gsub(/\s\s+/, ' ') # reduce multiple whitespace chars to a single space
+    call_number = call_number.gsub('. .', ' .') # reduce double periods to a single period
+    call_number = call_number.gsub(/(\d+\.) ([A-Z])/, '\1\2') # remove space after a period if period is after digits and before letters
+    call_number.sub(/\.$/, '') # remove trailing period
+  end
+
+  class CallNumber
+    BEGIN_CUTTER_REGEX = %r{( +|(\.[A-Z])| */)}
+    VALID_DEWEY_REGEX = /^\d{1,3}(\.\d+)? *\.? *[A-Z]\d{1,3} *[A-Z]*+.*/
+    VALID_LC_REGEX = /(^[A-Z&&[^IOWXY]]{1}[A-Z]{0,2} *\d+(\.\d*)?( +([\da-z]\w*)|([A-Z]\D+\w*))?) *\.?[A-Z]\d+.*/
+
+    attr_reader :call_number
+
+    # NOTE: call_number may be nil (when used for an on-order item)
+    def initialize(call_number)
+      @call_number = call_number
+    end
+
+    def <=>(other)
+      to_s <=> other.to_s
+    end
+
+    def to_s
+      call_number.to_s
+    end
+
+    def dewey?
+      call_number&.match?(VALID_DEWEY_REGEX)
+    end
+
+    def valid_lc?
+      call_number&.match?(VALID_LC_REGEX)
+    end
+
+    def with_leading_zeros
+      raise ArgumentError unless dewey?
+
+      decimal_index = before_cutter.index('.') || 0
+      call_number_class = if decimal_index > 0
+                            call_number[0, decimal_index].strip
+                          else
+                            before_cutter
+                          end
+
+      case call_number_class.length
+      when 1
+        "00#{call_number}"
+      when 2
+        "0#{call_number}"
+      else
+        call_number
+      end
+    end
+
+    def normalized_lc
+      return unless call_number
+
+      call_number.gsub(/\s\s+/, ' ') # change all multiple whitespace chars to a single space
+                 .gsub(/\s?\.\s?/, '.') # remove a space before or after a period
+                 .gsub(/^([A-Z][A-Z]?[A-Z]?) ([0-9])/, '\1\2') # remove space between class letters and digits
+    end
+
+    def before_cutter
+      call_number[/^.*(?=#{BEGIN_CUTTER_REGEX})/].to_s.strip
+    end
+  end
+end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -170,7 +170,7 @@ class FolioRecord
         loan_period: item['temporaryLoanType']&.gsub('reserve', 'loan')
       } if course
 
-      SirsiHolding.new(
+      FolioHolding.new(
         id: item['id'],
         call_number: [item.dig('callNumber', 'callNumber'), item['volume'], item['enumeration'], item['chronology']].compact.join(' '),
         current_location: (current_location unless current_location == home_location_code).presence,
@@ -202,7 +202,7 @@ class FolioRecord
       _current_library, current_location = LocationsMap.for(parent_item.dig('location', 'temporaryLocation', 'code'))
       current_location ||= Folio::StatusCurrentLocation.new(parent_item).current_location
 
-      SirsiHolding.new(
+      FolioHolding.new(
         id: parent_item['id'],
         call_number: holding['callNumber'],
         scheme: call_number_type_map(holding.dig('callNumberType', 'name')),
@@ -232,7 +232,7 @@ class FolioRecord
     on_order_holdings.uniq { |holding| holding.dig('location', 'effectiveLocation', 'code') }.map do |holding|
       library_code, home_location_code = LocationsMap.for(holding.dig('location', 'effectiveLocation', 'code'))
 
-      SirsiHolding.new(
+      FolioHolding.new(
         barcode: nil,
         call_number: holding['callNumber'],
         scheme: call_number_type_map(holding.dig('callNumberType', 'name')),
@@ -251,7 +251,7 @@ class FolioRecord
     # exclude generic SUL if there's a more specific library
     lib_codes -= ['SUL'] if lib_codes.length > 1
     lib_codes.map do |lib|
-      SirsiHolding.new(
+      FolioHolding.new(
         barcode: nil,
         call_number: nil,
         scheme: nil,

--- a/spec/lib/folio/eresource_holdings_builder_spec.rb
+++ b/spec/lib/folio/eresource_holdings_builder_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Folio::EresourceHoldingsBuilder do
   end
 
   it { expect(holdings.count).to eq 1 }
-  it { expect(holdings.first).to be_a SirsiHolding }
+  it { expect(holdings.first).to be_a FolioHolding }
   it { expect(holdings.first.call_number.call_number).to eq 'INTERNET RESOURCE' }
   it { expect(holdings.first.home_location).to eq 'INTERNET' }
   it { expect(holdings.first.library).to eq 'SUL' }

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -313,6 +313,7 @@ RSpec.describe FolioRecord do
       context 'when the bound with child is in SAL3' do
         let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_child_see-other.json'))), client) }
         it 'adds SEE-OTHER as the home_location' do
+          skip('Nah')
           expect(folio_record.sirsi_holdings.first.home_location).to eq('SEE-OTHER')
         end
       end
@@ -345,8 +346,8 @@ RSpec.describe FolioRecord do
         it 'creates a stub bound-with item' do
           expect(folio_record.sirsi_holdings.first).to have_attributes(
             id: nil,
-            barcode: '14154194-1001',
-            home_location: 'SEE-OTHER',
+            # barcode: '14154194-1001',
+            # home_location: 'SEE-OTHER',
             library: 'EARTH-SCI'
           )
         end

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -313,7 +313,7 @@ RSpec.describe FolioRecord do
       context 'when the bound with child is in SAL3' do
         let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_child_see-other.json'))), client) }
         it 'adds SEE-OTHER as the home_location' do
-          skip('Nah')
+          skip('Unclear whether we need to preserve this behavior in FOLIO')
           expect(folio_record.sirsi_holdings.first.home_location).to eq('SEE-OTHER')
         end
       end


### PR DESCRIPTION
I think the two functional changes are:

- bound-withs are no longer necessarily SEE-OTHER (which... turns out not to be true in Symphony for some `GREEN/FED-DOCS`). Searchworks is figuring out something is bound-with from the holdings type, so the location code can be whatever.
- barcodes are optional; I think we resolved anything downstream in searchworks that required a barcode?

Fixes https://github.com/sul-dlss/searchworks_traject_indexer/issues/1058