### PR TITLE
Guard against nil values for electronicAccess

### DIFF
--- a/lib/folio/marc_record_mapper.rb
+++ b/lib/folio/marc_record_mapper.rb
@@ -13,7 +13,7 @@ module Folio
 
       # Copy FOLIO Holdings electronic access data to an 856 (used by Lane)
       # overwriting any existing 856 fields (to avoid having to reconcile/merge data)
-      eholdings = holdings.flat_map { |h| h['electronicAccess'] }
+      eholdings = holdings.flat_map { |h| h['electronicAccess'] }.compact
 
       if eholdings.any?
         record.fields.delete_if { |field| field.tag == '856' }

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -299,6 +299,34 @@ RSpec.describe FolioRecord do
       expect(folio_record.marc_record['856'].subfields).to include(have_attributes(code: '3', value: 'Provider'), have_attributes(code: 'u', value: 'http://example.com/2'))
       expect(folio_record.marc_record['856'].subfields).not_to include(have_attributes(code: 'y'), have_attributes(code: 'z'))
     end
+
+    context 'with nil electronicAccess data' do
+      let(:record) do
+        {
+          'instance' => {
+            'id' => '0e050e3f-b160-5f5d-9fdb-2d49305fbb0d'
+          },
+          'holdings' => [{
+            'electronicAccess' => nil
+          }],
+          'source_record' => [{
+            'fields' => [
+              { '001' => 'a14154194' },
+              { '856' => {
+                'subfields' => [
+                  { 'u' => 'http://example.com/1' }
+                ]
+              } }
+            ]
+          }]
+        }
+      end
+
+      it 'does nothing with the 856 field data' do
+        expect(folio_record.marc_record.fields('856').length).to eq(1)
+        expect(folio_record.marc_record['856'].subfields).to include(have_attributes(code: 'u', value: 'http://example.com/1'))
+      end
+    end
   end
 
   describe '#sirsi_holdings' do


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/searchworks_traject_indexer/issues/1196

It's unclear how objects come to be in this state (and the graphql schema seems to think it's invalid too), but 🤷‍♂️ 