### PR TITLE
Reduce memory needs for FOLIO indexing

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -41,7 +41,7 @@ settings do
 
     provide 'kafka.hosts', ::Settings.kafka.hosts
     provide 'kafka.client', Kafka.new(self['kafka.hosts'], logger: Utils.logger)
-    consumer = self['kafka.client'].consumer(group_id: self['kafka.consumer_group_id'] || 'traject')
+    consumer = self['kafka.client'].consumer(group_id: self['kafka.consumer_group_id'] || 'traject', fetcher_max_queue_size: 25)
     consumer.subscribe(self['kafka.topic'])
     provide 'kafka.consumer', consumer
   elsif self['postgres.url']


### PR DESCRIPTION
This reduces the kafka fetch queue size from 100 to 25 (so we're only buffering 1/4 the number of FOLIO records). This appears to reduce the memory needd without impacting throughput.