### PR TITLE
Add the instance id + hrid to the item display struct

### DIFF
--- a/lib/folio_holding.rb
+++ b/lib/folio_holding.rb
@@ -16,19 +16,23 @@ class FolioHolding
   SKIPPED_LOCS = %w[BORROWDIR CDPSHADOW SHADOW SSRC-FIC-S STAFSHADOW TECHSHADOW WITHDRAWN].freeze
   TEMP_CALLNUM_PREFIX = 'XX('
 
-  attr_reader :item, :holding, :bound_with_holding, :id, :scheme, :type, :barcode, :course_reserves
+  attr_reader :item, :holding, :instance, :bound_with_holding,
+              :id, :scheme, :type, :barcode, :course_reserves
 
   # rubocop:disable Metrics/ParameterLists
-  def initialize(item: nil, holding: nil, bound_with_holding: nil, course_reserves: [],
+  def initialize(item: nil, holding: nil, instance: nil,
+                 bound_with_holding: nil,
+                 course_reserves: [],
                  call_number: nil, type: nil,
                  library: nil, home_location: nil, current_location: nil,
                  # to deprecate
                  scheme: nil, barcode: nil, public_note: nil)
     @item = item
     @holding = holding
+    @instance = instance
     @bound_with_holding = bound_with_holding
     @id = id || @item&.dig('id')
-    @provided_call_number = call_number || ([@item.dig('callNumber', 'callNumber'), @item['volume'], @item['enumeration'], @item['chronology']].compact.join(' ') if @item) || @bound_with_holding&.dig('callNumber') || @holding&.dig('callNumber')
+    @provided_call_number = call_number || @bound_with_holding&.dig('callNumber') || ([@item.dig('callNumber', 'callNumber'), @item['volume'], @item['enumeration'], @item['chronology']].compact.join(' ') if @item) || @holding&.dig('callNumber')
     @current_location = current_location
     @home_location = home_location
     @library = library
@@ -171,6 +175,8 @@ class FolioHolding
       current_location:,
       type:,
       note: public_note.presence,
+      instance_id: instance&.dig('id'),
+      instance_hrid: instance&.dig('hrid'),
       # FOLIO item data to replace library/home_location/current_location some day
       temporary_location_code: temporary_location&.dig('code'),
       permanent_location_code: permanent_location&.dig('code'),

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -152,6 +152,7 @@ class FolioRecord
       FolioHolding.new(
         item:,
         holding:,
+        instance:,
         course_reserves: courses.select { |c| c[:listing_id] == item['courseListingId'] }
       )
     end
@@ -169,6 +170,7 @@ class FolioRecord
       FolioHolding.new(
         item: parent_item,
         holding: parent_holding,
+        instance: holding.dig('boundWith', 'instance'),
         bound_with_holding: holding
       )
     end
@@ -186,6 +188,7 @@ class FolioRecord
     on_order_holdings.uniq { |holding| holding.dig('location', 'effectiveLocation', 'code') }.map do |holding|
       FolioHolding.new(
         holding:,
+        instance:,
         current_location: 'ON-ORDER'
       )
     end
@@ -200,6 +203,7 @@ class FolioRecord
     lib_codes -= ['SUL'] if lib_codes.length > 1
     lib_codes.map do |lib|
       FolioHolding.new(
+        instance:,
         library: lib,
         home_location: 'ON-ORDER',
         current_location: 'ON-ORDER'

--- a/spec/lib/folio_holding_spec.rb
+++ b/spec/lib/folio_holding_spec.rb
@@ -58,5 +58,50 @@ RSpec.describe FolioHolding do
         )
       end
     end
+
+    context 'with a bound-with holding' do
+      subject(:hash) { described_class.new(item:, holding:, instance:, bound_with_holding:).to_item_display_hash }
+      let(:item) do
+        {
+          id: 'uuid',
+          barcode: '36105000',
+          status: 'Available',
+          materialTypeId: 'mt-uuid',
+          temporaryLoanTypeId: 'tlt-uuid',
+          permanentLoanTypeId: 'plt-uuid',
+          location: {
+            temporaryLocation: { code: 'GRE-STACKS' }
+          }
+        }.with_indifferent_access
+      end
+      let(:holding) do
+        {
+          location: {
+            effectiveLocation: { code: 'SAL3-STACKS' }
+          }
+        }.with_indifferent_access
+      end
+      let(:instance) do
+        {
+          id: 'instance-uuid',
+          hrid: 'instance-hrid'
+        }.with_indifferent_access
+      end
+      let(:bound_with_holding) do
+        {
+          callNumber: 'bound-with-callnumber'
+        }.with_indifferent_access
+      end
+
+      it 'maps the available holdings data' do
+        expect(hash).to include(
+          barcode: '36105000',
+          permanent_location_code: 'SAL3-STACKS',
+          temporary_location_code: 'GRE-STACKS',
+          instance_id: 'instance-uuid',
+          instance_hrid: 'instance-hrid'
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
This is especially useful for bound-with availability lookup.

The data is redundant for normal holdings, but included for consistency.