### PR TITLE
Move require to boot

### DIFF
--- a/config/boot.rb
+++ b/config/boot.rb
@@ -35,6 +35,7 @@ require 'call_numbers/dewey_shelfkey'
 
 require 'constants'
 require 'folio_client'
+require 'folio_holding'
 require 'folio_record'
 require 'folio/eresource_holdings_builder'
 require 'folio/holdings'

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -2,7 +2,6 @@
 
 require 'active_support/core_ext/module/delegation'
 require 'active_support/core_ext/enumerable'
-require 'folio_holding'
 
 # rubocop:disable Metrics/ClassLength
 class FolioRecord


### PR DESCRIPTION
This fixes <internal:/Users/jcoyne85/.rbenv/versions/3.2.2/lib/ruby/site_ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:148:in `require': cannot load such file -- folio_holding (LoadError) when doing folio_download_record.rb"