### PR TITLE
Update collection_struct to use the source 'marc' instead of 'sirsi'

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2373,7 +2373,7 @@ to_field 'collection_struct' do |record, accumulator|
                              alternate_script: false).collect_matching_lines(record) do |field, spec, extractor|
     struct = {
       title: extractor.collect_subfields(field, spec).join(' '),
-      source: 'sirsi'
+      source: 'marc'
     }
 
     if field['6']
@@ -2388,7 +2388,7 @@ to_field 'collection_struct' do |record, accumulator|
 
   vern_fields.select { |f| parse_linkage(f)[:number] == '00' }.each do |f|
     accumulator << {
-      source: 'sirsi',
+      source: 'marc',
       vernacular: f.select { |sub| sub.code == 'a' || sub.code == 'p' }.map(&:value).join(' ')
     }
   end

--- a/spec/lib/traject/config/subject_spec.rb
+++ b/spec/lib/traject/config/subject_spec.rb
@@ -1074,8 +1074,8 @@ RSpec.describe 'Subject config' do
     end
 
     it 'includes the collection title and subtitle' do
-      expect(result[field]).to eq [{ title: 'Main title A subtitle', source: 'sirsi' },
-                                   { source: 'sirsi', vernacular: 'Vernacular title' }].map(&:to_json)
+      expect(result[field]).to eq [{ title: 'Main title A subtitle', source: 'marc' },
+                                   { source: 'marc', vernacular: 'Vernacular title' }].map(&:to_json)
     end
   end
 end


### PR DESCRIPTION
The only use I can see downstream is:

> fetch(:collection_struct, []).reject { |collection| collection[:source] == 'SDR-PURL' }
