### PR TITLE
Remove NoExport subfields from MARC

### DIFF
--- a/lib/folio/marc_record_mapper.rb
+++ b/lib/folio/marc_record_mapper.rb
@@ -9,6 +9,10 @@ module Folio
         next unless field.respond_to? :subfields
 
         field.subfields.delete_if { |subfield| subfield.code == '0' && subfield.value.start_with?('(SIRSI)') }
+
+        # Scrub any "NoExport" subfields; currently only used by Lane?
+        # See: https://searchworks.stanford.edu/view/L81154
+        field.subfields.delete_if { |subfield| subfield.value == 'NoExport' }
       end
 
       # Copy FOLIO Holdings electronic access data to an 856 (used by Lane)

--- a/spec/lib/traject/config/genre_spec.rb
+++ b/spec/lib/traject/config/genre_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Format physical config' do
+RSpec.describe 'Genre config' do
   subject(:value) { result[field] }
   let(:indexer) do
     Traject::Indexer.new.tap do |i|
@@ -723,6 +723,20 @@ RSpec.describe 'Format physical config' do
 
     it 'has no noGenre' do
       expect(select_by_id('NoGenre')).not_to include(field)
+    end
+  end
+
+  context 'with a 655a NoExport value' do
+    let(:marc_record) do
+      MARC::Record.new.tap do |r|
+        r.leader = '04473cam a2200313Ia 4500'
+        r.append(MARC::DataField.new('655', ' ', ' ',
+                                     MARC::Subfield.new('a', 'NoExport')))
+      end
+    end
+
+    it 'does not include NoExport' do
+      expect(result[field]).to be_nil
     end
   end
 end


### PR DESCRIPTION
Fixes #1252

This scrubs any subfields with the value NoExport, so they don't
get indexed or displayed in any way in SearchWorks. Unclear who
is using this other than Lane, but it seemed like a safe interpretation
of "NoExport" to mean "pretend it doesn't exist in a discovery
environment".
