### PR TITLE
Restore kafka/statsd consumer stats reporting

### DIFF
--- a/lib/traject/readers/kafka_folio_reader.rb
+++ b/lib/traject/readers/kafka_folio_reader.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'kafka'
+require 'kafka/statsd'
+
 # Reads messages out of Kafka and yields FolioRecords
 class Traject::KafkaFolioReader
   attr_reader :settings

--- a/lib/traject/readers/kafka_purl_fetcher_reader.rb
+++ b/lib/traject/readers/kafka_purl_fetcher_reader.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'kafka'
+require 'kafka/statsd'
+
 class Traject::KafkaPurlFetcherReader
   attr_reader :input_stream, :settings
 


### PR DESCRIPTION
Maybe there's a zeitwerk way to do this, but it'd be really nice to get the stats reporting back before trying to dig into that.