### PR TITLE
Fetch documents to index by instance id before retrieving the full document to index

### DIFF
--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -113,7 +113,7 @@ module Traject
               'locationId', cl.jsonb ->> 'locationId',
               'courseNumber', cc.jsonb ->> 'courseNumber',
               'instructorNames', (SELECT jsonb_agg(instructor ->> 'name') FROM jsonb_array_elements(cl.jsonb #> '{instructorObjects}') AS instructor)
-              )
+              ) AS jsonb
             FROM sul_mod_courses.coursereserves_reserves cr
             LEFT JOIN sul_mod_courses.coursereserves_courselistings cl ON cl.id = cr.courselistingid
             LEFT JOIN sul_mod_courses.coursereserves_courses cc ON cc.courselistingid = cl.id
@@ -165,7 +165,7 @@ module Traject
 
               item['request']['pickupServicePoint'] = service_points[item['request']['pickupServicePointId']] if item['request']
 
-              item['courses'] = course_reserves[item['id']]
+              item['courses'] = course_reserves[item['id']] || []
 
               item['courses'].each do |course|
                 course['locationCode'] = locations.dig(course['locationId'], 'code')

--- a/script/process_folio_postgres_to_kafka.rb
+++ b/script/process_folio_postgres_to_kafka.rb
@@ -55,7 +55,7 @@ File.open(state_file, 'r+') do |f|
   Utils.logger.info "Found last_date in #{state_file}: #{last_date}" if last_date
 
   last_response_date = Traject::FolioPostgresReader.new(nil,
-                                                        'postgres.url': Utils.env_config.database_url).last_response_date
+                                                        'postgres.url': Utils.env_config.database_url).sql_server_current_time
 
   processes = opts[:processes]
   processes ||= Utils.env_config.full_dump_processes if opts[:full]
@@ -83,7 +83,8 @@ File.open(state_file, 'r+') do |f|
       reader = Traject::FolioPostgresReader.new(nil, 'folio.updated_after': last_date&.utc&.iso8601,
                                                      'postgres.url': Utils.env_config.database_url,
                                                      'postgres.sql_filters': opts[:sql_query] + [sql_filter],
-                                                     'postgres.addl_from': opts[:sql_join])
+                                                     'postgres.addl_from': opts[:sql_join],
+                                                     'cursor_type' => opts[:full] ? 'docs' : 'ids')
 
       Utils.logger.info reader.queries if opts[:sql_debug]
       Traject::FolioKafkaExtractor.new(reader:, kafka: Utils.kafka, topic: opts[:kafka_topic]).process!


### PR DESCRIPTION
As of November 2023, postgres seems like it isn't coming up with a great query plan for our massive indexing query. Splitting it into 2 parts (ids to index / the full json blob) seems to persuade the postgres to make a better plan. It's unclear what changed postgres from filtering and then retrieving to "construct the big blobs of JSON for every instance and then filter out the ~200 that are actually relevant", but here we are.

Future work may include:
- building a kafka topic of changed ids and then consuming that list (better parallelization for handling deltas?)
- revisiting this partition if/when FOLIO cascades updated timestamps so query conditions are a little more straightforward
- figure out the right query plan hints to get postgres to do the right thing
- ??

Compared to performance from August, this introduces some additional overhead (25-33%?) so we probably want to avoid using it for full dumps, but so far (24 hours in) we're not seeing the delta query failures or large pauses.