### PR TITLE
Include course reserves data for suppressed items

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -123,7 +123,7 @@ class FolioRecord
   # Course information for any courses that have this record's items on reserve
   # @return [Array<Hash>] course information
   def courses
-    item_courses = items.flat_map do |item|
+    item_courses = all_items.flat_map do |item|
       item.fetch('courses', []).map do |course|
         {
           course_name: course['name'],

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -685,4 +685,23 @@ RSpec.describe FolioRecord do
       end
     end
   end
+
+  describe '#courses' do
+    context 'with a suppressed e-resource' do
+      let(:record) do
+        {
+          'items' => [{
+            'suppressedFromDiscovery' => true,
+            'courses' => [{
+              'name' => 'CHEM 31A'
+            }]
+          }]
+        }
+      end
+
+      it 'returns the course for the suppressed item' do
+        expect(folio_record.courses).to match_array(hash_including(course_name: 'CHEM 31A'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is a work-around so e-resources show up as a course reserve.

Fixes https://github.com/sul-dlss/SearchWorks/issues/3689