### PR TITLE
Allow non-geo content types to point to source collection

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -402,7 +402,6 @@ to_field 'solr_year_i' do |record, accumulator|
 end
 
 to_field 'dc_source_sm' do |record, accumulator|
-  next unless record.dor_content_type == 'geo'
   next unless record.collections&.any?
 
   record.collections.uniq.each do |collection|

--- a/spec/integration/geo_config_spec.rb
+++ b/spec/integration/geo_config_spec.rb
@@ -64,6 +64,10 @@ describe 'EarthWorks indexing' do
     it 'contains date' do
       expect(result['solr_year_i']).to eq [1603]
     end
+
+    it 'contains a reference to the source collection' do
+      expect(result['dc_source_sm']).to include('stanford-bf420qj4978')
+    end
   end
   context 'image map book content without dc:type' do
     let(:druid) { 'ny179kk3075' }


### PR DESCRIPTION
This fixes #1305, which will restore the relations widget in
Earthworks for scanned map content once it is reindexed.
