### PR TITLE
Report indexing status to SDR during geo indexing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,4 +42,5 @@ end
 gem 'activesupport', '~> 7.0'
 gem 'slop'
 
+gem 'dor-event-client'
 gem 'factory_bot', '~> 6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,7 @@ GEM
       public_suffix (>= 2.0.2, < 6.0)
     airbrussh (1.5.1)
       sshkit (>= 1.6.1, != 1.7.0)
+    amq-protocol (2.3.2)
     ast (2.4.2)
     base64 (0.2.0)
     bigdecimal (3.1.6)
@@ -38,6 +39,9 @@ GEM
     bundler-audit (0.9.1)
       bundler (>= 1.2.0, < 3)
       thor (~> 1.0)
+    bunny (2.22.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
+      sorted_set (~> 1, >= 1.0.2)
     capistrano (3.18.0)
       airbrussh (>= 1.0.0)
       i18n
@@ -81,6 +85,10 @@ GEM
       capistrano-shared_configs
     docile (1.4.0)
     domain_name (0.6.20240107)
+    dor-event-client (1.0.0)
+      activesupport (>= 4.2, < 8)
+      bunny (~> 2.17)
+      zeitwerk (~> 2.1)
     dor-rights-auth (1.8.0)
       nokogiri
     dot-properties (0.1.4)
@@ -228,6 +236,7 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.1.0)
+    rbtree (0.4.6)
     rdoc (6.6.2)
       psych (>= 4.0.0)
     regexp_parser (2.9.0)
@@ -266,6 +275,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     scrub_rb (1.0.1)
+    set (1.1.0)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -273,6 +283,9 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
     slop (4.10.1)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
     sshkit (1.22.0)
       mutex_m
       net-scp (>= 1.1.2)
@@ -336,6 +349,7 @@ DEPENDENCIES
   debouncer
   debug
   dlss-capistrano
+  dor-event-client
   dor-rights-auth
   factory_bot (~> 6.2)
   honeybadger

--- a/README.md
+++ b/README.md
@@ -154,6 +154,9 @@ the sirsi traject config uses the special setting `SKIP_EMPTY_ITEM_DISPLAY`, whi
 ### SDR
 The indexing machines also have scheduled cron tasks for loading data from purl-fetcher into a kafka topic. This task records a state file (in `./tmp`) that contains the timestamp of the most recent entry from purl-fetcher that was processed. Every minute, the cron task runs, retrieves the purl-fetcher changes since that most recent timestamp, and adds the message to a kafka topic.
 
+#### Reporting events
+Indexers for SDR content can report the status of indexing events to [dor-services-app](https://github.com/sul-dlss/dor-services-app) using the [dor-event-client](https://github.com/sul-dlss/dor-event-client) gem. When the feature is enabled and configured in `settings.yml` or via environment variables, the indexer will create events for each record that is indexed, skipped, deleted, etc. These events are visible in the Argo UI and can be used to troubleshoot items released from SDR that are not appearing in search indices.
+
 ### FOLIO
 Data is read directly from the postgres database underlying FOLIO, using a custom SQL query stored in the `FolioPostgresReader`. To mimic this activity in local development, one can SSH tunnel to the FOLIO database and use the `#find_by_catkey` helper method:
 ```rb

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,14 @@
 kafka:
   hosts: localhost:9092
 
+sdr_events:
+  enabled: false
+  mq:
+    vhost: /
+    hostname: localhost
+    username: guest
+    password: guest
+
 environments:
   folio_test:
     database_url: <%= ENV['FOLIO_TEST_DATABASE_URL'] || ENV['DATABASE_URL'] %>

--- a/lib/sdr_events.rb
+++ b/lib/sdr_events.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'socket'
+
+# Reports indexing events to SDR via message queue
+# See: https://github.com/sul-dlss/dor-event-client
+# See also the HTTP API: https://sul-dlss.github.io/dor-services-app/#tag/events
+class SdrEvents
+  class << self
+    def configure(
+      hostname: ENV.fetch('SDR_EVENTS_MQ_HOSTNAME', ::Settings.sdr_events.mq.hostname),
+      vhost: ENV.fetch('SDR_EVENTS_MQ_VHOST', ::Settings.sdr_events.mq.vhost),
+      username: ENV.fetch('SDR_EVENTS_MQ_USERNAME', ::Settings.sdr_events.mq.username),
+      password: ENV.fetch('SDR_EVENTS_MQ_PASSWORD', ::Settings.sdr_events.mq.password)
+    )
+      Dor::Event::Client.configure(hostname:, vhost:, username:, password:)
+    end
+
+    def enabled?
+      ::Settings.sdr_events.enabled == true
+    end
+
+    # Item was added/updated in the index
+    def report_indexing_success(druid)
+      create_event(druid:, type: 'indexing_success')
+    end
+
+    # Item was removed from the index (e.g. via unrelease)
+    def report_indexing_deleted(druid)
+      create_event(druid:, type: 'indexing_deleted')
+    end
+
+    # Item has missing or inappropriately formatted metadata
+    def report_indexing_skipped(druid, message:)
+      create_event(druid:, type: 'indexing_skipped', data: { message: })
+    end
+
+    # Exception was raised during indexing; provides optional context
+    def report_indexing_errored(druid, message:, context: nil)
+      create_event(druid:, type: 'indexing_errored', data: { message:, context: }.compact)
+    end
+
+    private
+
+    # Generic event creation; prefer more specific methods
+    def create_event(druid:, type:, data: {})
+      Dor::Event::Client.create(
+        druid: "druid:#{druid}",
+        type:,
+        data: base_data.merge(data)
+      ) if enabled?
+    end
+
+    # Logged with every event
+    def base_data
+      @base_data ||= {
+        host: Socket.gethostname,
+        invoked_by: 'indexer'
+      }
+    end
+  end
+end

--- a/spec/lib/sdr_events_spec.rb
+++ b/spec/lib/sdr_events_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe SdrEvents do
+  let(:druid) { 'ab123cd4567' }
+
+  before do
+    allow(Settings.sdr_events).to receive(:enabled).and_return(true)
+    allow(Dor::Event::Client).to receive(:create)
+  end
+
+  describe '#report_indexing_success' do
+    it 'creates an event' do
+      SdrEvents.report_indexing_success(druid)
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
+        type: 'indexing_success',
+        data: { host: Socket.gethostname, invoked_by: 'indexer' }
+      )
+    end
+  end
+
+  describe '#report_indexing_deleted' do
+    it 'creates an event' do
+      SdrEvents.report_indexing_deleted(druid)
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
+        type: 'indexing_deleted',
+        data: { host: Socket.gethostname, invoked_by: 'indexer' }
+      )
+    end
+  end
+
+  describe '#report_indexing_skipped' do
+    it 'creates an event with message' do
+      SdrEvents.report_indexing_skipped(druid, message: 'Problem with metadata')
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
+        type: 'indexing_skipped',
+        data: { host: Socket.gethostname, invoked_by: 'indexer', message: 'Problem with metadata' }
+      )
+    end
+  end
+
+  describe '#report_indexing_errored' do
+    it 'creates an event with message and context' do
+      SdrEvents.report_indexing_errored(druid, message: 'Indexing errored', context: 'stack trace')
+      expect(Dor::Event::Client).to have_received(:create).with(
+        druid: "druid:#{druid}",
+        type: 'indexing_errored',
+        data: { host: Socket.gethostname, invoked_by: 'indexer', message: 'Indexing errored', context: 'stack trace' }
+      )
+    end
+  end
+end


### PR DESCRIPTION
Closes #1299 

I tested this with some geo content in argo-stage. Druid [bd882yq4680](https://argo-stage.stanford.edu/view/druid:bd882yq4680) successfully received a message from the indexer:

<img width="783" alt="Screenshot 2024-01-29 at 15 15 06" src="https://github.com/sul-dlss/searchworks_traject_indexer/assets/4924494/25b4af7f-4512-4d64-a24b-98eee01be25e">

Druid [yy029tb6261](https://argo-stage.stanford.edu/view/druid:yy029tb6261) was not indexed because the indexer couldn't transform its bounding box into valid data at index-time, and it received an appropriate message:

<img width="804" alt="Screenshot 2024-01-29 at 15 18 10" src="https://github.com/sul-dlss/searchworks_traject_indexer/assets/4924494/5262f782-c1db-4940-906f-8c20587ed191">
