### PR TITLE
Ensure correct record id is set to enable deletion from geoblacklight

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -165,7 +165,11 @@ each_record do |record, context|
   next unless record.is_a?(Hash) && record[:delete]
 
   druid = record[:id].sub('druid:', '')
-  context.output_hash['id'] = [druid]
+
+  # This id must be the same value as layer_slug_s, which is the key used to
+  # delete records form the index
+  context.output_hash['id'] = ["stanford-#{druid}"]
+
   SdrEvents.report_indexing_deleted(druid)
   context.skip!("Delete: #{druid}")
 end
@@ -176,7 +180,7 @@ each_record do |record, context|
 
   message = 'Item is in processing or does not exist'
   SdrEvents.report_indexing_skipped(record.druid, message:)
-  context.skip!("#{message}: #{context.output_hash['id']}")
+  context.skip!("#{message}: #{record.druid}")
 end
 
 # Skip records with content types that we can't index
@@ -185,7 +189,7 @@ each_record do |record, context|
 
   message = "Item content type \"#{record.dor_content_type}\" is not supported"
   SdrEvents.report_indexing_skipped(record.druid, message:)
-  context.skip!("#{message}: #{context.output_hash['id']}")
+  context.skip!("#{message}: #{record.druid}")
 end
 
 to_field 'dc_identifier_s' do |record, accumulator|

--- a/spec/integration/geo_config_spec.rb
+++ b/spec/integration/geo_config_spec.rb
@@ -206,6 +206,16 @@ describe 'EarthWorks indexing' do
     end
   end
 
+  context 'when the item was deleted' do
+    subject(:context) { indexer.process_record(record) }
+
+    let(:record) { { id: "druid:#{druid}", delete: true } }
+
+    it 'sets the id in the output to match the layer unique key in solr' do
+      expect(context.output_hash['id']).to eq ['stanford-dc482zx1528']
+    end
+  end
+
   context 'when no envelope is present' do
     let(:druid) { 'bk264hq9320' }
 


### PR DESCRIPTION
GeoBlacklight records don't have an id field like SearchWorks ones
do - instead they have the layer_id_s field (in v1.0 schema), which
is set to the prefixed druid. This has to be set in the traject
context so that the indexer issues a delete using the id that the
record will actually have.

Fixes #597
