### PR TITLE
stop indexing collection if they aren't public

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -123,7 +123,7 @@ Metrics/BlockNesting:
 # Offense count: 3
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 127
+  Max: 140
 
 # Offense count: 25
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/public_xml_record.rb
+++ b/lib/public_xml_record.rb
@@ -20,6 +20,8 @@ class PublicXmlRecord
   end
 
   def searchworks_id
+    return nil unless collection_in_searchworks?
+
     catkey.nil? ? druid : catkey
   end
 
@@ -31,7 +33,19 @@ class PublicXmlRecord
 
   # @return objectLabel value from the DOR identity_metadata, or nil if there is no barcode
   def label
+    return nil unless collection_in_searchworks?
+
     get_value(public_xml_doc.xpath('/publicObject/identityMetadata/objectLabel'))
+  end
+
+  def collection_in_searchworks?
+    return true unless collection?
+
+    if public_xml_doc.xpath('/publicObject/releaseData').present?
+      get_value(public_xml_doc.xpath('/publicObject/releaseData/release[@to="Searchworks"]')) == 'true'
+    else
+      false
+    end
   end
 
   def get_value(node)


### PR DESCRIPTION
From what I can tell this is working on sw. It will not fix the issue with currently indexed items but it will stop this issue from re-occuring. I have been using https://searchworks-preview-stage.stanford.edu/view/bh250xv2418 + https://argo-stage.stanford.edu/view/druid:qr592gj5093 to test that this works. It looks like you can release/withdraw a collection without its objects and the items will get reindex. Be warned, it can take a while to reindex.

Closes https://github.com/sul-dlss/SearchWorks/issues/3840

If a argo collection has not been released to Searchworks, the solr index with not provide the id in the collection field. It still provides collection_with_title which becomes -|- which I thought would be good to keep to let us know that there is a non public collection associated with the record but Searchworks doesn't display those non viewable collections.