### PR TITLE
Don't index summary_struct when there is no data

### DIFF
--- a/lib/traject/common/marc_utils.rb
+++ b/lib/traject/common/marc_utils.rb
@@ -346,6 +346,7 @@ module Traject
       end
     end
 
+    # @return [Array]
     def get_unmatched_vernacular(marc, tag)
       return [] unless marc['880']
 
@@ -366,7 +367,7 @@ module Traject
         fields << text.join(' ') unless text.empty?
       end
 
-      fields unless fields.empty?
+      fields
     end
 
     # INDEX-142 NOTE: Lane Medical adds (Print) or (Digital) descriptors to their ISSNs

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -1582,10 +1582,8 @@ to_field 'toc_struct' do |marc, accumulator|
   end
 
   unmatched_vern_fields = get_unmatched_vernacular(marc, '505')
-  unless unmatched_vern_fields.nil?
-    unmatched_vern_fields.each do |vern_field|
-      unmatched_vern << vern_field.split(/[^\S]--[^\S]/).map { |w| w.strip unless w.strip.empty? }.compact
-    end
+  unmatched_vern_fields.each do |vern_field|
+    unmatched_vern << vern_field.split(/[^\S]--[^\S]/).map { |w| w.strip unless w.strip.empty? }.compact
   end
 
   new_vern = vern unless vern.empty?
@@ -1630,6 +1628,7 @@ end
 
 def accumulate_summary_struct_fields(matching_fields, tag, label, marc, accumulator)
   fields = []
+  unmatched_vern = []
   if matching_fields.any?
     matching_fields.each do |field|
       field_text = []
@@ -1649,7 +1648,7 @@ def accumulate_summary_struct_fields(matching_fields, tag, label, marc, accumula
   end
 
   accumulator << { label:, fields:,
-                   unmatched_vernacular: unmatched_vern } unless fields.empty? && unmatched_vern.nil?
+                   unmatched_vernacular: unmatched_vern } if !fields.empty? || !unmatched_vern.empty?
 end
 
 to_field 'context_search', extract_marc('518a', alternate_script: false)

--- a/spec/lib/traject/config/note_fields_spec.rb
+++ b/spec/lib/traject/config/note_fields_spec.rb
@@ -591,6 +591,14 @@ RSpec.describe 'Folio config' do
       end
     end
 
+    context 'without a 520 or 880' do
+      let(:result) { indexer.map_record(marc_to_folio(record)) }
+      let(:record) { MARC::Record.new }
+      subject(:result_field) { result[field] }
+
+      it { is_expected.to be_nil }
+    end
+
     context 'with Nielson data' do
       let(:fixture_name) { 'nielsenTests.jsonl' }
       it 'maps the right fields' do


### PR DESCRIPTION
This avoids useless data like this:

```ruby
[{:fields=>[], :label=>"Summary", :unmatched_vernacular=>[]}, {:fields=>[], :label=>"Content advice", :unmatched_vernacular=>[]}]
```

As seen on records like https://searchworks.stanford.edu/view/2472159