### PR TITLE
Don't prettify downloaded JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ another option is to use the `JsonWriter` to pipe output directly to somewhere e
 ```sh
 SOLR_URL=http://localhost:8983/solr/core-name bundle exec traject -c lib/traject/config/config_name.rb -w Traject::JsonWriter my_marc_file.marc | tail -n +2 | jq '.pub_country'
 ```
-when working with non-MARC data held locally (e.g. JSON exports from FOLIO), you can use the `FolioJsonReader` to pipe output into traject from stdin:
+when working with non-MARC data held locally (e.g. JSON exports from FOLIO), you can use the `FolioJsonReader` to pipe output into traject from stdin. Note that `FolioJsonReader` must handle newline-delimited JSON (not prettified).
 ```sh
 cat record.json | bundle exec traject -c lib/traject/config/folio_config.rb -s reader_class_name=Traject::FolioJsonReader --stdin --debug-mode
 ```

--- a/lib/traject/readers/folio_json_reader.rb
+++ b/lib/traject/readers/folio_json_reader.rb
@@ -5,7 +5,7 @@ module Traject
   # @example An export can be produced by doing:
   #  bin/console
   #  record = Traject::FolioPostgresReader.find_by_catkey('a14238203', 'postgres.url' => ENV['DATABASE_URL']
-  #  File.write("a14238203.json", JSON.pretty_generate(record.as_json))
+  #  File.write("a14238203.json", record.to_json)
   class FolioJsonReader < Traject::NDJReader
     def each(&)
       return enum_for(:each) unless block_given?

--- a/script/download_folio_record.rb
+++ b/script/download_folio_record.rb
@@ -9,4 +9,4 @@ require_relative '../config/boot'
 record = Traject::FolioPostgresReader.find_by_catkey(ARGV[0], 'postgres.url' => postgres_url)
 raise "No record found for catkey #{ARGV[0]}" unless record
 
-puts JSON.pretty_generate(record.as_json)
+puts record.to_json


### PR DESCRIPTION
Using the pretty JSON, this script to download a file produced pretty JSON that `Traject::FolioJsonReader` was unable to handle. Then running this README recipe failed due to syntax.

`cat record.json | bundle exec traject -c lib/traject/config/folio_config.rb -s reader_class_name=Traject::FolioJsonReader --stdin --debug-mode` 