### PR TITLE
Fix bug with identifying electronic holdings locations; fixes #1346

### DIFF
--- a/lib/folio/eresource_holdings_builder.rb
+++ b/lib/folio/eresource_holdings_builder.rb
@@ -60,7 +60,7 @@ module Folio
     # This approach works fine unless there are records with multiple
     # e-resource holdings associated with different locations.
     def electronic_holding_location
-      @electronic_holding_location ||= holdings&.find { |h| (h.dig('holdingsType', 'name') || h.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName')) == 'Electronic' }
+      @electronic_holding_location ||= holdings&.find { |h| h.dig('holdingsType', 'name') == 'Electronic' || h.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName') == 'Electronic' }
     end
   end
 end

--- a/spec/lib/folio/eresource_holdings_builder_spec.rb
+++ b/spec/lib/folio/eresource_holdings_builder_spec.rb
@@ -104,6 +104,7 @@ RSpec.describe Folio::EresourceHoldingsBuilder do
             { 'code' => 'LANE-EDATA' },
             'effectiveLocation' =>
             { 'code' => 'LANE-EDATA', 'library' => { 'code' => 'LANE' }, 'details' => { 'holdingsTypeName' => 'Electronic' } } },
+            'holdingsType' => { 'name' => 'Monograph' },
             'suppressFromDiscovery' => false,
             'id' => '81a56270-e8dd-5759-8083-5cc96cdf0045',
             'holdingsStatements' => [] }] }


### PR DESCRIPTION
Lane wasn't using holdings types in their migrated data, but their newly created resources seem to have it (although they still don't use the "Electronic" value..)