### PR TITLE
Add `browse_nearby_struct` seam

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2315,6 +2315,18 @@ to_field 'item_display_struct' do |record, accumulator, context|
   end
 end
 
+# TODO: After this field is fully populated and Searchworks is using it to drive browse-nearby, the shelfkey
+# logic in the item_display_struct field can move down here.
+to_field 'browse_nearby_struct' do |_record, accumulator, context|
+  next unless context.output_hash['item_display_struct']
+
+  browseable_items = context.output_hash['item_display_struct'].select { |v| v[:shelfkey].present? && v[:reverse_shelfkey].present? && %w[LC DEWEY ALPHANUM].include?(v[:scheme]) }
+
+  accumulator.concat(browseable_items.sort_by { |v| v[:shelfkey] }.uniq { |v| v[:shelfkey] }.map do |v|
+    v.slice(:lopped_callnumber, :shelfkey, :reverse_shelfkey, :callnumber, :scheme).merge(item_id: v[:id])
+  end)
+end
+
 ##
 # Skip records for missing `item_display` field
 each_record do |_record, context|

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -110,12 +110,43 @@ each_record do |record, context|
   context.skip!('Incomplete record') if record['245'] && record['245']['a'] == '**REQUIRED FIELD**'
 end
 
-# rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+def call_number_object(call_number, call_number_type, holdings_items: [], serial: false)
+  calculated_call_number_type = case call_number_type
+                                when 'LC'
+                                  if call_number.valid_lc?
+                                    'LC'
+                                  elsif call_number.dewey?
+                                    'DEWEY'
+                                  else
+                                    'OTHER'
+                                  end
+                                when 'DEWEY'
+                                  'DEWEY'
+                                else
+                                  'OTHER'
+                                end
+
+  case calculated_call_number_type
+  when 'LC'
+    CallNumbers::LC.new(call_number.base_call_number.to_s, call_number.volume_info, serial:)
+  when 'DEWEY'
+    CallNumbers::Dewey.new(call_number.base_call_number.to_s, call_number.volume_info, serial:)
+  else
+    call_numbers_in_location = holdings_items.map(&:call_number).map(&:to_s)
+
+    CallNumbers::Other.new(
+      call_number.base_call_number.to_s,
+      call_number.volume_info,
+      longest_common_prefix: Utils.longest_common_prefix(*call_numbers_in_location),
+      scheme: call_number_type == 'LC' ? 'OTHER' : call_number_type
+    )
+  end
+end
+
 def call_number_for_item(record, item, context)
   context.clipboard[:call_number_for_item] ||= {}
+  context.clipboard[:call_number_for_item][item] ||= OpenStruct.new(scheme: item.call_number_type) if item.on_order? || item.in_process?
   context.clipboard[:call_number_for_item][item] ||= begin
-    return OpenStruct.new(scheme: item.call_number_type) if item.on_order? || item.in_process?
-
     serial = (context.output_hash['format_main_ssim'] || []).include?('Journal/Periodical')
 
     separate_browse_call_num = []
@@ -132,52 +163,23 @@ def call_number_for_item(record, item, context)
       end
     end
 
-    return separate_browse_call_num.first if separate_browse_call_num.any?
+    separate_browse_call_num.first
+  end
 
-    return OpenStruct.new(
-      scheme: 'OTHER',
-      call_number: item.call_number.to_s,
-      to_lopped_shelfkey: item.call_number.to_s,
-      to_volume_sort: CallNumbers::ShelfkeyBase.pad_all_digits("other #{item.call_number}")
-    ) if item.bad_lc_lane_call_number?
-    return OpenStruct.new(scheme: item.call_number_type) if item.internet_resource?
-    return OpenStruct.new(scheme: item.call_number_type) if item.ignored_call_number?
+  context.clipboard[:call_number_for_item][item] ||= OpenStruct.new(
+    scheme: 'OTHER',
+    call_number: item.call_number.to_s,
+    to_lopped_shelfkey: item.call_number.to_s,
+    to_volume_sort: CallNumbers::ShelfkeyBase.pad_all_digits("other #{item.call_number}")
+  ) if item.bad_lc_lane_call_number?
+  context.clipboard[:call_number_for_item][item] ||= OpenStruct.new(scheme: item.call_number_type) if item.internet_resource?
+  context.clipboard[:call_number_for_item][item] ||= OpenStruct.new(scheme: item.call_number_type) if item.ignored_call_number?
 
-    calculated_call_number_type = case item.call_number_type
-                                  when 'LC'
-                                    if item.valid_lc?
-                                      'LC'
-                                    elsif item.dewey?
-                                      'DEWEY'
-                                    else
-                                      'OTHER'
-                                    end
-                                  when 'DEWEY'
-                                    'DEWEY'
-                                  else
-                                    'OTHER'
-                                  end
-
-    case calculated_call_number_type
-    when 'LC'
-      CallNumbers::LC.new(item.call_number.base_call_number.to_s, item.call_number.volume_info, serial:)
-    when 'DEWEY'
-      CallNumbers::Dewey.new(item.call_number.base_call_number.to_s, item.call_number.volume_info, serial:)
-    else
-      non_skipped_or_ignored_items = context.clipboard[:non_skipped_or_ignored_items_by_library_location_call_number_type]
-
-      call_numbers_in_location = (non_skipped_or_ignored_items[[item.library, item.display_location&.dig('name'), item.call_number_type]] || []).map(&:call_number).map(&:to_s)
-
-      CallNumbers::Other.new(
-        item.call_number.base_call_number.to_s,
-        item.call_number.volume_info,
-        longest_common_prefix: Utils.longest_common_prefix(*call_numbers_in_location),
-        scheme: item.call_number_type == 'LC' ? 'OTHER' : item.call_number_type
-      )
-    end
+  context.clipboard[:call_number_for_item][item] ||= begin
+    holdings_items = context.clipboard[:non_skipped_or_ignored_items_by_library_location_call_number_type][[item.library, item.display_location&.dig('name'), item.call_number_type]] || []
+    call_number_object(item.call_number, item.call_number_type, holdings_items:, serial:)
   end
 end
-# rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
 def items(record, context)
   context.clipboard[:item] ||= record.index_items

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -447,6 +447,16 @@ RSpec.describe 'FOLIO indexing' do
                                                                                          hash_including('id' => '5362817d-f2df-503c-aa20-b2287c64ae25')
                                                                                        ])
       end
+
+      it 'includes the item in the browse_nearby_struct' do
+        expect(result['browse_nearby_struct'].map { |x| JSON.parse(x) }).to match_array(hash_including(
+                                                                                          'item_id' => '5362817d-f2df-503c-aa20-b2287c64ae25',
+                                                                                          'callnumber' => 'HV6432.7 .R57 2011',
+                                                                                          'shelfkey' => 'lc hv  6432.700000 r0.570000 002011',
+                                                                                          'reverse_shelfkey' => 'en~i4~~tvwx}szzzzz~8z}uszzzz~zzxzyy~~~~~~~~~~~~~~~',
+                                                                                          'scheme' => 'LC'
+                                                                                        ))
+      end
     end
 
     context 'item status is in-transit' do

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -229,6 +229,15 @@ RSpec.describe 'FOLIO indexing' do
       )
     }
 
+    it 'includes the item in the browse_nearby_struct' do
+      expect(result['browse_nearby_struct'].map { |x| JSON.parse(x) }).to match_array(hash_including(
+                                                                                        'callnumber' => 'PR3562 .L385 2014',
+                                                                                        'lopped_call_number' => 'PR3562 .L385 2014',
+                                                                                        'shelfkey' => 'lc pr  3562.000000 l0.385000 002014',
+                                                                                        'reserve_shelfkey' => 'en~a8~~wutx}zzzzzz~ez}wruzzz~zzxzyv~~~~~~~~~~~~~~~',
+                                                                                        'scheme' => 'LC'
+                                                                                      ))
+    end
     it { expect(result['access_facet']).to eq ['Online'] }
     it { expect(result['shelfkey']).to eq ['lc pr  3562.000000 l0.385000 002014'] }
     it { expect(result['building_facet']).to be_nil }

--- a/spec/lib/traject/config/preferred_barcode_spec.rb
+++ b/spec/lib/traject/config/preferred_barcode_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe 'All_search config' do
           build(:dewey_holding, barcode: 'Dewey2', call_number: '505 .N285B', enumeration: 'V.241-245 1973', permanent_location_code: 'LOCATION')
         ]
       end
-      it { is_expected.to eq ['Dewey1'] }
+      it { is_expected.to eq ['Dewey2'] }
     end
 
     context 'with sudoc' do
@@ -261,7 +261,6 @@ RSpec.describe 'All_search config' do
         ]
       end
       specify do
-        pending 'Waiting for some decision about how items should be sorted within a lopped call number set'
         expect(result[field]).to eq ['lc1']
       end
     end


### PR DESCRIPTION
This gives us a seam to extract browse nearby information from the `item_display_struct`, and should allow us to separate the items for "At the library" from the spines used for browsing. 

https://github.com/sul-dlss/SearchWorks/pull/4041 is the related Searchworks PR to use this data.

When we switch to using the FOLIO holding's call number data, we'll be able to clean up + consolidate the different types of call number objects floating around the indexer, and hopefully `call_number_object` + `call_number_for_item` will go away entirely. 
