### PR TITLE
Reorganize the shelfkey classes

### DIFF
--- a/lib/call_numbers/dewey_shelfkey.rb
+++ b/lib/call_numbers/dewey_shelfkey.rb
@@ -4,6 +4,9 @@ require 'call_numbers/shelfkey_base'
 
 module CallNumbers
   class DeweyShelfkey < ShelfkeyBase
+    delegate :scheme, :klass, :klass_number, :klass_decimal, :doon1, :doon2,
+             :cutter1, :cutter2, :cutter3, :folio, :rest, :serial, to: :call_number
+
     def to_shelfkey
       [
         call_number.scheme,

--- a/lib/call_numbers/lc.rb
+++ b/lib/call_numbers/lc.rb
@@ -70,7 +70,7 @@ module CallNumbers
     private
 
     def shelfkey_class
-      CallNumbers::Shelfkey
+      CallNumbers::LcShelfkey
     end
   end
 end

--- a/lib/call_numbers/lc_shelfkey.rb
+++ b/lib/call_numbers/lc_shelfkey.rb
@@ -2,6 +2,9 @@
 
 module CallNumbers
   class LcShelfkey < ShelfkeyBase
+    delegate :scheme, :klass, :klass_number, :klass_decimal, :doon1, :doon2, :doon3,
+             :cutter1, :cutter2, :cutter3, :folio, :rest, :serial, to: :call_number
+
     def to_shelfkey
       [
         call_number.scheme,

--- a/lib/call_numbers/lc_shelfkey.rb
+++ b/lib/call_numbers/lc_shelfkey.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module CallNumbers
-  class Shelfkey < ShelfkeyBase
+  class LcShelfkey < ShelfkeyBase
     def to_shelfkey
       [
         call_number.scheme,

--- a/lib/call_numbers/other.rb
+++ b/lib/call_numbers/other.rb
@@ -43,22 +43,10 @@ module CallNumbers
       lopped_call_number
     end
 
-    # shortcutting a shelfkey class as we just need the normalization/reverse methods
-    def to_shelfkey
-      [shelfkey_scheme, CallNumbers::ShelfkeyBase.pad_all_digits(call_number), CallNumbers::ShelfkeyBase.pad_all_digits(volume_info)].filter_map(&:presence).join(' ')
-    end
-
-    def to_reverse_shelfkey
-      CallNumbers::ShelfkeyBase.reverse(to_shelfkey).ljust(50, '~')
-    end
-
     private
 
-    # this transfomation only applies when generating shelfkeys
-    def shelfkey_scheme
-      return 'sudoc' if scheme == 'SUDOC'
-
-      'other'
+    def shelfkey_class
+      CallNumbers::OtherShelfkey
     end
   end
 end

--- a/lib/call_numbers/other_shelfkey.rb
+++ b/lib/call_numbers/other_shelfkey.rb
@@ -2,6 +2,8 @@
 
 module CallNumbers
   class OtherShelfkey < ShelfkeyBase
+    delegate :scheme, to: :call_number
+
     # shortcutting a shelfkey class as we just need the normalization/reverse methods
     def to_shelfkey
       [

--- a/lib/call_numbers/other_shelfkey.rb
+++ b/lib/call_numbers/other_shelfkey.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module CallNumbers
+  class OtherShelfkey < ShelfkeyBase
+    # shortcutting a shelfkey class as we just need the normalization/reverse methods
+    def to_shelfkey
+      [
+        shelfkey_scheme,
+        CallNumbers::ShelfkeyBase.pad_all_digits(call_number.call_number),
+        CallNumbers::ShelfkeyBase.pad_all_digits(call_number.volume_info)
+      ].filter_map(&:presence).join(' ')
+    end
+
+    def to_reverse_shelfkey
+      CallNumbers::ShelfkeyBase.reverse(to_shelfkey).ljust(50, '~')
+    end
+
+    private
+
+    # this transfomation only applies when generating shelfkeys
+    def shelfkey_scheme
+      return 'sudoc' if scheme == 'SUDOC'
+
+      'other'
+    end
+  end
+end

--- a/lib/call_numbers/shelfkey_base.rb
+++ b/lib/call_numbers/shelfkey_base.rb
@@ -21,9 +21,6 @@ module CallNumbers
       '-' => '~'
     )
 
-    delegate :scheme, :klass, :klass_number, :klass_decimal, :doon1, :doon2, :doon3,
-             :cutter1, :cutter2, :cutter3, :folio, :rest, :serial, to: :call_number
-
     attr_reader :call_number
 
     def initialize(call_number)

--- a/spec/lib/call_numbers/lc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/lc_shelfkey_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe CallNumbers::Shelfkey do
+RSpec.describe CallNumbers::LcShelfkey do
   describe 'sorting by generated key' do
     it 'sorts classifications properly' do
       call_number_strings = [

--- a/spec/lib/call_numbers/other_spec.rb
+++ b/spec/lib/call_numbers/other_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe CallNumbers::Other do
     before { I18n.config.available_locales = :en } # No idea why this is needed
     let(:reverse_shelfkey) { described_class.new('ZDVD 1234').to_reverse_shelfkey }
 
-    it 'uses CallNumbers::Shelfkey.reverse to reverse' do
+    it 'uses CallNumbers::ShelfkeyBase.reverse to reverse' do
       expect(reverse_shelfkey).to start_with('b6il8')
       expect(reverse_shelfkey).to include('0m4m')
       expect(reverse_shelfkey).to include('zzyxwv')

--- a/spec/lib/traject/config/preferred_barcode_spec.rb
+++ b/spec/lib/traject/config/preferred_barcode_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe 'All_search config' do
           build(:dewey_holding, barcode: 'Dewey2', call_number: '505 .N285B', enumeration: 'V.241-245 1973', permanent_location_code: 'LOCATION')
         ]
       end
-      it { is_expected.to eq ['Dewey1'] }
+      it { is_expected.to eq ['Dewey2'] }
     end
 
     context 'with sudoc' do
@@ -261,7 +261,6 @@ RSpec.describe 'All_search config' do
         ]
       end
       specify do
-        pending 'Waiting for some decision about how items should be sorted within a lopped call number set'
         expect(result[field]).to eq ['lc1']
       end
     end


### PR DESCRIPTION
This attempts to get some consistency in our shelfkey classes. It's a little extra code (for the moment), but this will make it easier to junk the `CallNumbers::LC`, `CallNumbers::Dewey`, etc classes soon.