### PR TITLE
Provide volume_info to each call number class as a separate arg

### DIFF
--- a/lib/call_numbers/dewey.rb
+++ b/lib/call_numbers/dewey.rb
@@ -3,9 +3,10 @@
 module CallNumbers
   class Dewey < CallNumberBase
     attr_reader :call_number, :serial,
-                :klass_number, :klass_decimal, :doon1, :doon2, :doon3, :cutter1, :cutter2, :cutter3, :folio, :rest, :potential_stuff_to_lop
+                :klass_number, :klass_decimal, :doon1, :doon2, :doon3, :cutter1, :cutter2, :cutter3, :folio, :rest, :potential_stuff_to_lop,
+                :volume_info
 
-    def initialize(call_number, serial: false)
+    def initialize(call_number, volume_info = '', serial: false)
       match_data = %r{
         (?<klass_number>\d{1,3})(?<klass_decimal>\.?\d+)?\s*
         (?<doon1>(\d{1,4})(?:ST|ND|RD|TH|D)?\s+)?\s*
@@ -32,6 +33,7 @@ module CallNumbers
       @rest = match_data[:rest]
       @potential_stuff_to_lop = match_data[:potential_stuff_to_lop]
       @serial = serial
+      @volume_info = volume_info
     end
 
     def scheme

--- a/lib/call_numbers/dewey_shelfkey.rb
+++ b/lib/call_numbers/dewey_shelfkey.rb
@@ -14,20 +14,12 @@ module CallNumbers
         normalize_dewey_cutter(cutter2),
         normalize_dewey_cutter(cutter3),
         (folio || '').downcase.strip,
-        rest_with_serial_behavior
-      ].compact.reject(&:empty?).join(' ').strip
+        self.class.pad_all_digits(rest),
+        volume_info_with_serial_behavior
+      ].filter_map(&:presence).join(' ').strip
     end
 
     private
-
-    # Unit tests inidcate that serial deweys don't get reversed years justified with tildes
-    def rest_with_serial_behavior
-      return unless rest
-      return if rest.empty? && (call_number.scheme == 'lc' || call_number.scheme == 'dewey')
-      return self.class.pad_all_digits(rest) unless serial
-
-      self.class.reverse(self.class.pad_all_digits(rest)).strip.ljust(50, '~')
-    end
 
     def klass_number_and_decimal
       [

--- a/lib/call_numbers/lc.rb
+++ b/lib/call_numbers/lc.rb
@@ -3,9 +3,10 @@
 module CallNumbers
   class LC < CallNumberBase
     attr_reader :call_number, :serial,
-                :klass, :klass_number, :klass_decimal, :doon1, :doon2, :doon3, :cutter1, :cutter2, :cutter3, :folio, :rest, :potential_stuff_to_lop
+                :klass, :klass_number, :klass_decimal, :doon1, :doon2, :doon3, :cutter1, :cutter2, :cutter3, :folio, :rest, :potential_stuff_to_lop,
+                :volume_info
 
-    def initialize(call_number, serial: false)
+    def initialize(call_number, volume_info = '', serial: false)
       match_data = /
         (?<klass>[A-Z]{0,3})\s*
         (?<klass_number>\d+)?(?<klass_decimal>\.?\d+)?\s*
@@ -33,6 +34,7 @@ module CallNumbers
       @folio = match_data[:folio]
       @rest = match_data[:rest]
       @potential_stuff_to_lop = match_data[:potential_stuff_to_lop]
+      @volume_info = volume_info
       @serial = serial
     end
 

--- a/lib/call_numbers/other.rb
+++ b/lib/call_numbers/other.rb
@@ -9,10 +9,11 @@ module CallNumbers
       'os folder', 'small folder', 'small map folder', 'suppl', 'tube', 'series'
     ]
 
-    attr_reader :call_number, :longest_common_prefix, :serial, :scheme
+    attr_reader :call_number, :longest_common_prefix, :serial, :scheme, :volume_info
 
-    def initialize(call_number, longest_common_prefix: '', serial: false, scheme: '')
+    def initialize(call_number, volume_info = '', longest_common_prefix: '', serial: false, scheme: '')
       @call_number = call_number
+      @volume_info = volume_info
       @longest_common_prefix = longest_common_prefix
       @serial = serial
       @scheme = scheme
@@ -44,7 +45,7 @@ module CallNumbers
 
     # shortcutting a shelfkey class as we just need the normalization/reverse methods
     def to_shelfkey
-      [shelfkey_scheme, CallNumbers::ShelfkeyBase.pad_all_digits(call_number)].join(' ')
+      [shelfkey_scheme, CallNumbers::ShelfkeyBase.pad_all_digits(call_number), CallNumbers::ShelfkeyBase.pad_all_digits(volume_info)].filter_map(&:presence).join(' ')
     end
 
     def to_reverse_shelfkey

--- a/lib/call_numbers/shelfkey.rb
+++ b/lib/call_numbers/shelfkey.rb
@@ -14,18 +14,9 @@ module CallNumbers
         pad_all_digits(doon3),
         pad_cutter(cutter3),
         (folio || '').downcase.strip,
-        rest_with_serial_behavior
-      ].compact.reject(&:empty?).join(' ').strip
-    end
-
-    private
-
-    def rest_with_serial_behavior
-      return unless rest
-      return if rest.empty? && (call_number.scheme == 'lc' || call_number.scheme == 'dewey')
-      return self.class.pad_all_digits(rest) unless serial
-
-      self.class.reverse(self.class.pad_all_digits(rest)).strip.ljust(50, '~')
+        self.class.pad_all_digits(rest),
+        volume_info_with_serial_behavior
+      ].filter_map(&:presence).join(' ').strip
     end
   end
 end

--- a/lib/call_numbers/shelfkey_base.rb
+++ b/lib/call_numbers/shelfkey_base.rb
@@ -38,6 +38,15 @@ module CallNumbers
       self.class.reverse(to_shelfkey).ljust(50, '~')
     end
 
+    # Unit tests inidcate that serial deweys don't get reversed years justified with tildes
+    def volume_info_with_serial_behavior
+      return if call_number.volume_info.blank?
+      return unless call_number.scheme == 'lc' || call_number.scheme == 'dewey'
+      return self.class.pad_all_digits(call_number.volume_info) unless serial
+
+      self.class.reverse(self.class.pad_all_digits(call_number.volume_info)).strip.ljust(50, '~')
+    end
+
     delegate :pad, :pad_all_digits, :pad_cutter, to: :class
 
     class << self

--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -181,10 +181,11 @@ class FolioItem
 
   def build_call_number
     provided_call_number = @bound_with_holding&.dig('callNumber') ||
-                           ([@item.dig('callNumber', 'callNumber'), @item['volume'], @item['enumeration'], @item['chronology']].compact.join(' ') if @item) ||
+                           @item&.dig('callNumber', 'callNumber') ||
                            @holding&.dig('callNumber')
 
-    CallNumber.new(normalize_call_number(provided_call_number))
+    volume_info = normalize_call_number([@item['volume'], @item['enumeration'], @item['chronology']].compact.join(' ').presence) if @item
+    CallNumber.new(normalize_call_number(provided_call_number), volume_info:)
   end
 
   # Call number normalization ported from solrmarc code
@@ -202,19 +203,24 @@ class FolioItem
     VALID_DEWEY_REGEX = /^\d{1,3}(\.\d+)? *\.? *[A-Z]\d{1,3} *[A-Z]*+.*/
     VALID_LC_REGEX = /(^[A-Z&&[^IOWXY]]{1}[A-Z]{0,2} *\d+(\.\d*)?( +([\da-z]\w*)|([A-Z]\D+\w*))?) *\.?[A-Z]\d+.*/
 
-    attr_reader :call_number
+    attr_reader :base_call_number, :volume_info
 
     # NOTE: call_number may be nil (when used for an on-order item)
-    def initialize(call_number)
-      @call_number = call_number
+    def initialize(base_call_number, volume_info: nil)
+      @base_call_number = base_call_number
+      @volume_info = volume_info
     end
 
     def <=>(other)
       to_s <=> other.to_s
     end
 
+    def call_number
+      [base_call_number.to_s, volume_info].compact.join(' ')
+    end
+
     def to_s
-      call_number.to_s
+      call_number
     end
 
     def dewey?

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -160,16 +160,17 @@ def call_number_for_item(record, item, context)
 
     case calculated_call_number_type
     when 'LC'
-      CallNumbers::LC.new(item.call_number.to_s, serial:)
+      CallNumbers::LC.new(item.call_number.base_call_number.to_s, item.call_number.volume_info, serial:)
     when 'DEWEY'
-      CallNumbers::Dewey.new(item.call_number.to_s, serial:)
+      CallNumbers::Dewey.new(item.call_number.base_call_number.to_s, item.call_number.volume_info, serial:)
     else
       non_skipped_or_ignored_items = context.clipboard[:non_skipped_or_ignored_items_by_library_location_call_number_type]
 
       call_numbers_in_location = (non_skipped_or_ignored_items[[item.library, item.display_location&.dig('name'), item.call_number_type]] || []).map(&:call_number).map(&:to_s)
 
       CallNumbers::Other.new(
-        item.call_number.to_s,
+        item.call_number.base_call_number.to_s,
+        item.call_number.volume_info,
         longest_common_prefix: Utils.longest_common_prefix(*call_numbers_in_location),
         scheme: item.call_number_type == 'LC' ? 'OTHER' : item.call_number_type
       )

--- a/spec/factories/holdings.rb
+++ b/spec/factories/holdings.rb
@@ -16,11 +16,13 @@ FactoryBot.define do
           'notes' => notes
         }.tap do |json|
           json.merge!('callNumber' => { 'callNumber' => call_number }) if call_number
+          json.merge!('enumeration' => enumeration) if enumeration
         end
       end
       permanent_location_code { '' }
       permanent_location { { 'code' => permanent_location_code } }
       call_number { nil }
+      enumeration { nil }
     end
     library { 'GREEN' }
     type { '' }

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -712,8 +712,8 @@ RSpec.describe 'ItemInfo config' do
           end
         end
         let(:holdings) do
-          [build(:lc_holding, call_number: 'E184.S75 R47A V.1 1980'),
-           build(:lc_holding, call_number: 'E184.S75 R47A V.2 1980')]
+          [build(:lc_holding, call_number: 'E184.S75 R47A', enumeration: 'V.1 1980'),
+           build(:lc_holding, call_number: 'E184.S75 R47A', enumeration: 'V.2 1980')]
         end
         it {
           is_expected.to match_array([
@@ -734,8 +734,8 @@ RSpec.describe 'ItemInfo config' do
         end
 
         let(:holdings) do
-          [build(:dewey_holding, call_number: '553.2805 .P187 V.1-2 1916-1918'),
-           build(:dewey_holding, call_number: '553.2805 .P187 V.1-2 1919-1920')]
+          [build(:dewey_holding, call_number: '553.2805 .P187', enumeration: 'V.1-2 1916-1918'),
+           build(:dewey_holding, call_number: '553.2805 .P187', enumeration: 'V.1-2 1919-1920')]
         end
 
         it {

--- a/spec/lib/traject/config/preferred_barcode_spec.rb
+++ b/spec/lib/traject/config/preferred_barcode_spec.rb
@@ -252,10 +252,10 @@ RSpec.describe 'All_search config' do
     context 'with lc only' do
       let(:index_items) do
         [
-          build(:lc_holding, barcode: 'lc1', call_number: 'QE538.8 .N36 1975-1977'),
-          build(:lc_holding, barcode: 'lc2', call_number: 'QE538.8 .N36 1978-1980'),
-          build(:lc_holding, barcode: 'lc3', call_number: 'E184.S75 R47A V.1 1980'),
-          build(:lc_holding, barcode: 'lc4', call_number: 'E184.S75 R47A V.2 1980')
+          build(:lc_holding, barcode: 'lc1', call_number: 'QE538.8 .N36', enumeration: '1975-1977'),
+          build(:lc_holding, barcode: 'lc2', call_number: 'QE538.8 .N36', enumeration: '1978-1980'),
+          build(:lc_holding, barcode: 'lc3', call_number: 'E184.S75 R47A', enumeration: 'V.1 1980'),
+          build(:lc_holding, barcode: 'lc4', call_number: 'E184.S75 R47A', enumeration: 'V.2 1980')
         ]
       end
       specify do
@@ -267,10 +267,10 @@ RSpec.describe 'All_search config' do
     context 'with dewey only' do
       let(:index_items) do
         [
-          build(:dewey_holding, barcode: 'dewey1', call_number: '888.4 .J788 V.5'),
-          build(:dewey_holding, barcode: 'dewey2', call_number: '888.4 .J788 V.6'),
-          build(:dewey_holding, barcode: 'dewey3', call_number: '505 .N285B V.241-245 1973'),
-          build(:dewey_holding, barcode: 'dewey4', call_number: '505 .N285B V.241-245 1975')
+          build(:dewey_holding, barcode: 'dewey1', call_number: '888.4 .J788', enumeration: 'V.5'),
+          build(:dewey_holding, barcode: 'dewey2', call_number: '888.4 .J788', enumeration: 'V.6'),
+          build(:dewey_holding, barcode: 'dewey3', call_number: '505 .N285B', enumeration: 'V.241-245 1973'),
+          build(:dewey_holding, barcode: 'dewey4', call_number: '505 .N285B', enumeration: 'V.241-245 1975')
         ]
       end
       it { is_expected.to eq ['dewey4'] }
@@ -308,11 +308,11 @@ RSpec.describe 'All_search config' do
     context 'with lc only' do
       let(:index_items) do
         [
-          build(:lc_holding, barcode: 'lc1', call_number: 'QE538.8 .N36 1975-1977'),
-          build(:lc_holding, barcode: 'lc2', call_number: 'QE538.8 .N36 1978-1980'),
-          build(:lc_holding, barcode: 'lc3', call_number: 'E184.S75 R47A V.1 1980'),
-          build(:lc_holding, barcode: 'lc4', call_number: 'E184.S75 R47A V.2 1980'),
-          build(:lc_holding, barcode: 'lc5', call_number: 'E184.S75 R47A V.3')
+          build(:lc_holding, barcode: 'lc1', call_number: 'QE538.8 .N36', enumeration: '1975-1977'),
+          build(:lc_holding, barcode: 'lc2', call_number: 'QE538.8 .N36', enumeration: '1978-1980'),
+          build(:lc_holding, barcode: 'lc3', call_number: 'E184.S75 R47A', enumeration: 'V.1 1980'),
+          build(:lc_holding, barcode: 'lc4', call_number: 'E184.S75 R47A', enumeration: 'V.2 1980'),
+          build(:lc_holding, barcode: 'lc5', call_number: 'E184.S75 R47A', enumeration: 'V.3')
         ]
       end
       it { is_expected.to eq ['lc5'] }
@@ -321,11 +321,11 @@ RSpec.describe 'All_search config' do
     context 'with dewey only' do
       let(:index_items) do
         [
-          build(:dewey_holding, barcode: 'dewey1', call_number: '888.4 .J788 V.5'),
-          build(:dewey_holding, barcode: 'dewey2', call_number: '888.4 .J788 V.6'),
-          build(:dewey_holding, barcode: 'dewey3', call_number: '505 .N285B V.241-245 1973'),
-          build(:dewey_holding, barcode: 'dewey4', call_number: '505 .N285B V.241-245 1975'),
-          build(:dewey_holding, barcode: 'dewey5', call_number: '505 .N285B V.283-285')
+          build(:dewey_holding, barcode: 'dewey1', call_number: '888.4 .J788', enumeration: 'V.5'),
+          build(:dewey_holding, barcode: 'dewey2', call_number: '888.4 .J788', enumeration: 'V.6'),
+          build(:dewey_holding, barcode: 'dewey3', call_number: '505 .N285B', enumeration: 'V.241-245 1973'),
+          build(:dewey_holding, barcode: 'dewey4', call_number: '505 .N285B', enumeration: 'V.241-245 1975'),
+          build(:dewey_holding, barcode: 'dewey5', call_number: '505 .N285B', enumeration: 'V.283-285')
         ]
       end
       it { is_expected.to eq ['dewey5'] }


### PR DESCRIPTION
This refactor pushes the `volume_info` data even further down; this time the shelfkey implementations get to take volume information into account.

Includes #1371 and a hint of #1370. Merge those first.