### PR TITLE
Map FOLIO data to the MARC leader

### DIFF
--- a/lib/constants.rb
+++ b/lib/constants.rb
@@ -226,4 +226,34 @@ module Constants
     852 853 863 866 867 868
     901 910 918 923 924 930 935 940 948 949 950 955 960 962 980 981 983 990 993 998
   ]
+
+  INSTANCE_TYPE_LEADER_CODE = {
+    'cartographic dataset' => 'e',
+    'cartographic image' => 'e',
+    'cartographic moving image' => 'e',
+    'cartographic tactile image' => 'e',
+    'cartographic tactile three-dimensional form' => 'e',
+    'cartographic three-dimensional form' => 'e',
+    'computer dataset' => 'm',
+    'computer program' => 'm',
+    'notated music' => 'c',
+    'performed music' => 'j',
+    'sounds' => 'i',
+    'spoken word' => 'i',
+    'still image' => 'k',
+    'tactile image' => 'k',
+    'tactile notated music' => 'c',
+    'tactile three-dimensional form' => 'r',
+    'text' => 'a',
+    'three-dimensional form' => 'r',
+    'three-dimensional moving image' => 'r',
+    'two-dimensional moving image' => 'g'
+  }
+
+  MODE_OF_ISSUANCE_LEADER_CODE = {
+    'integrating resource' => 'i',
+    'multipart monograph' => 'a',
+    'serial' => 's',
+    'single unit' => 'm'
+  }
 end

--- a/lib/folio/marc_record_instance_mapper.rb
+++ b/lib/folio/marc_record_instance_mapper.rb
@@ -3,9 +3,13 @@
 module Folio
   # Creates a Marc Record for an Folio instance
   class MarcRecordInstanceMapper
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+    # rubocop:disable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength
     def self.build(instance, holdings)
       MARC::Record.new.tap do |marc|
+        # Add what we can to the leader from FOLIO data
+        marc.leader[6] = Constants::INSTANCE_TYPE_LEADER_CODE[instance.dig('instanceType', 'name')] || ' '
+        marc.leader[7] = Constants::MODE_OF_ISSUANCE_LEADER_CODE[instance.dig('modeOfIssuance', 'name')] || ' '
+
         marc.append(MARC::ControlField.new('001', instance['hrid']))
         # mode of issuance
         # identifiers
@@ -129,7 +133,7 @@ module Folio
         # date updated
       end.to_hash
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/BlockLength, Metrics/CyclomaticComplexity, Metrics/MethodLength
 
     # The FOLIO data can either be a plain string (pre-Poppy) or a hash (post-Poppy)
     def self.folio_value(folio_data)

--- a/spec/lib/folio/marc_record_instance_mapper_spec.rb
+++ b/spec/lib/folio/marc_record_instance_mapper_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Folio::MarcRecordInstanceMapper do
+  describe '.build' do
+    let(:instance) do
+      {
+        'id' => '8d3623d4-60ab-4aa6-8637-1c0bf6cfb297',
+        'hrid' => 'in00000003052',
+        'notes' => [],
+        'title' => "Akira Kurosawa's dreams",
+        'series' => [],
+        'source' => 'FOLIO',
+        'editions' => [],
+        'subjects' => [],
+        'languages' => [],
+        'identifiers' => [],
+        'publication' => [],
+        'contributors' => [],
+        'electronicAccess' => [],
+        'publicationRange' => [],
+        'physicalDescriptions' => [],
+        'publicationFrequency' => []
+      }
+    end
+
+    let(:holdings) { [{ 'electronicAccess' => [] }] }
+
+    context 'when instance type is not available' do
+      it 'leaves leader byte 6 unset' do
+        marc = described_class.build(instance, holdings)
+        expect(marc['leader'][6]).to eq(' ')
+      end
+    end
+
+    context 'when instance type is available' do
+      let(:instance_with_instance_type) do
+        instance.merge(
+          'instanceType' => {
+            'name' => 'two-dimensional moving image'
+          }
+        )
+      end
+      it 'sets leader byte 6' do
+        marc = described_class.build(instance_with_instance_type, holdings)
+        expect(marc['leader'][6]).to eq('g')
+      end
+    end
+
+    context 'when mode of issuance is not available' do
+      it 'leaves leader byte 7 unset' do
+        marc = described_class.build(instance, holdings)
+        expect(marc['leader'][7]).to eq(' ')
+      end
+    end
+
+    context 'when mode of issuance is available' do
+      let(:instance_with_mode_of_issuance) do
+        instance.merge(
+          'modeOfIssuance' => {
+            'name' => 'single unit'
+          }
+        )
+      end
+      it 'sets leader byte 7' do
+        marc = described_class.build(instance_with_mode_of_issuance, holdings)
+        expect(marc['leader'][7]).to eq('m')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses #1343.

Draft until Jeanette can review the mapping as requested.

Calling out we *could* drop the query modifications here and do the comparisons via instance type/mode of issuance UUID directly (the UUIDs for both are in the existing instance data) if we wanted to prioritize query simplicity.