### PR TITLE
Reporting via Traject writer for all SDR content

### DIFF
--- a/lib/sdr_events.rb
+++ b/lib/sdr_events.rb
@@ -40,6 +40,34 @@ class SdrEvents
       create_event(druid:, target:, type: 'indexing_errored', data: { message:, context: }.compact)
     end
 
+    # Take a SolrBetterJsonWriter::Batch and report successful adds/deletes
+    def report_indexing_batch_success(batch, target:)
+      batch.actions.each do |action, druid, _data|
+        next unless druid
+
+        case action
+        when :delete
+          report_indexing_deleted(druid, target:)
+        when :add
+          report_indexing_success(druid, target:)
+        end
+      end
+    end
+
+    # Take a SolrBetterJsonWriter::Batch and report failed adds/deletes
+    def report_indexing_batch_errored(batch, target:, exception:)
+      batch.actions.each do |action, druid, _data|
+        next unless druid
+
+        case action
+        when :delete
+          report_indexing_errored(druid, target:, message: 'delete failed', context: exception)
+        when :add
+          report_indexing_errored(druid, target:, message: 'add failed', context: exception)
+        end
+      end
+    end
+
     private
 
     # Generic event creation; prefer more specific methods

--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -180,7 +180,6 @@ each_record do |record, context|
   # delete records form the index
   context.output_hash['id'] = ["stanford-#{druid}"]
 
-  SdrEvents.report_indexing_deleted(druid, target: settings['purl_fetcher.target'])
   context.skip!("Delete: #{druid}")
 end
 
@@ -475,12 +474,11 @@ each_record do |record, context|
   end
 end
 
-each_record do |record, context|
+each_record do |_record, context|
   t0 = context.clipboard[:benchmark_start_time]
   t1 = Time.now
 
   logger.debug('geo_config.rb') { "Processed #{context.output_hash['id']} (#{t1 - t0}s)" }
-  SdrEvents.report_indexing_success(record.druid, target: settings['purl_fetcher.target'])
 end
 
 # rubocop:disable Metrics/MethodLength

--- a/lib/traject/writers/solr_better_json_writer.rb
+++ b/lib/traject/writers/solr_better_json_writer.rb
@@ -133,11 +133,14 @@ class Traject::SolrBetterJsonWriter < Traject::SolrJsonWriter
     # non-SDR content.
     def actions
       @actions ||= @contexts.map do |context|
+        record = context.source_record
+        druid = record&.druid if record.respond_to?(:druid)
+
         if context.skip?
           id = Array(context.output_hash['id']).first
-          [:delete, context.source_record&.druid, id] if id
+          [:delete, druid, id] if id
         else
-          [:add, context.source_record&.druid, context.output_hash]
+          [:add, druid, context.output_hash]
         end
       end.compact
     end

--- a/spec/integration/geo_config_spec.rb
+++ b/spec/integration/geo_config_spec.rb
@@ -312,22 +312,6 @@ describe 'EarthWorks indexing' do
       )
     end
 
-    context 'when indexing is successful' do
-      it 'creates an indexing success event' do
-        expect(result).to be_a Hash
-        expect(SdrEvents).to have_received(:report_indexing_success).with(druid, target: 'Earthworks')
-      end
-    end
-
-    context 'when the item was deleted' do
-      let(:record) { { id: "druid:#{druid}", delete: true } }
-
-      it 'creates an indexing delete event' do
-        expect(result).to be_nil
-        expect(SdrEvents).to have_received(:report_indexing_deleted).with(druid, target: 'Earthworks')
-      end
-    end
-
     context 'when the item has no public XML' do
       before { allow(record).to receive(:public_xml).and_return(nil) }
 

--- a/spec/lib/traject/writers/solr_better_json_writer_spec.rb
+++ b/spec/lib/traject/writers/solr_better_json_writer_spec.rb
@@ -3,7 +3,16 @@
 require 'spec_helper'
 
 describe Traject::SolrBetterJsonWriter do
-  subject(:writer) { described_class.new('solr_json_writer.http_client' => http_client, 'solr.update_url' => 'http://localhost/solr', 'solr_better_json_writer.debounce_timeout' => 1) }
+  subject(:writer) do
+    described_class.new(
+      'solr_json_writer.http_client' => http_client,
+      'solr.update_url' => 'http://localhost/solr',
+      'solr_better_json_writer.debounce_timeout' => 1,
+      'purl_fetcher.target' => 'Searchworks',
+      'solr_writer.max_skipped' => 100
+    )
+  end
+
   let(:http_client) { double(post: double(status: 200)) }
   let(:doc) { Traject::Indexer::Context.new.tap { |doc| doc.output_hash['id'] = [1] } }
   let(:skipped_doc) do
@@ -39,26 +48,108 @@ describe Traject::SolrBetterJsonWriter do
   describe '#send_batch' do
     it 'adds documents to solr' do
       writer.send_batch([doc])
-      expect(http_client).to have_received(:post).with('http://localhost/solr', '{add: {"doc":{"id":[1]}}}',
-                                                       'Content-type' => 'application/json')
+      expect(http_client).to have_received(:post).with(
+        'http://localhost/solr',
+        '{"add":{"doc":{"id":[1]}}}',
+        'Content-type' => 'application/json'
+      )
     end
 
     it 'deletes documents from solr' do
       writer.send_batch([skipped_doc])
-      expect(http_client).to have_received(:post).with('http://localhost/solr', '{delete: 2}',
-                                                       'Content-type' => 'application/json')
+      expect(http_client).to have_received(:post).with(
+        'http://localhost/solr',
+        '{"delete":2}',
+        'Content-type' => 'application/json'
+      )
     end
 
     it 'skips writing documents that have no id' do
       writer.send_batch([bad_doc])
-      expect(http_client).to have_received(:post).with('http://localhost/solr', '{}',
-                                                       'Content-type' => 'application/json')
+      expect(http_client).to have_received(:post).with(
+        'http://localhost/solr',
+        '{}',
+        'Content-type' => 'application/json'
+      )
     end
 
     it 'sends the request as a batch' do
       writer.send_batch([doc, skipped_doc])
-      expect(http_client).to have_received(:post).with('http://localhost/solr',
-                                                       "{add: {\"doc\":{\"id\":[1]}},\ndelete: 2}", 'Content-type' => 'application/json')
+      expect(http_client).to have_received(:post).with(
+        'http://localhost/solr',
+        "{\"add\":{\"doc\":{\"id\":[1]}},\n\"delete\":2}",
+        'Content-type' => 'application/json'
+      )
+    end
+  end
+
+  describe 'event reporting' do
+    let(:sdr_docs) do
+      [
+        Traject::Indexer::Context.new.tap do |doc|
+          doc.output_hash['id'] = [1]
+          doc.source_record = PublicXmlRecord.new('bb112zx3193')
+        end,
+        Traject::Indexer::Context.new.tap do |doc|
+          doc.output_hash['id'] = [2]
+          doc.source_record = PublicXmlRecord.new('py305sy7961')
+        end
+      ]
+    end
+
+    before do
+      allow(Settings.sdr_events).to receive(:enabled).and_return(true)
+      allow(SdrEvents).to receive_messages(
+        report_indexing_deleted: true,
+        report_indexing_success: true,
+        report_indexing_errored: true
+      )
+    end
+
+    context 'when SDR events are disabled' do
+      before do
+        allow(Settings.sdr_events).to receive(:enabled).and_return(false)
+        allow(Dor::Event::Client).to receive(:create)
+      end
+
+      it 'does not report any events' do
+        writer.send_batch(sdr_docs)
+        expect(Dor::Event::Client).not_to have_received(:create)
+      end
+    end
+
+    context 'when all docs index successfully' do
+      it 'reports docs that are successfully added' do
+        writer.send_batch(sdr_docs)
+        expect(SdrEvents).to have_received(:report_indexing_success).with('bb112zx3193', target: 'Searchworks')
+        expect(SdrEvents).to have_received(:report_indexing_success).with('py305sy7961', target: 'Searchworks')
+      end
+
+      it 'reports docs that are successfully deleted' do
+        skipped_doc.source_record = PublicXmlRecord.new('bj057dg6517')
+        writer.send_batch([skipped_doc])
+        expect(SdrEvents).to have_received(:report_indexing_deleted).with('bj057dg6517', target: 'Searchworks')
+      end
+    end
+
+    context 'when some docs fail to index' do
+      let(:http_client) { double(post: double(status: 400, body: 'Malformed data')) }
+
+      it 'reports docs that fail to index' do
+        writer.send_batch(sdr_docs)
+        expect(SdrEvents).to have_received(:report_indexing_errored).with(
+          'bb112zx3193',
+          target: 'Searchworks',
+          message: 'add failed',
+          context: 'Solr error response: 400: Malformed data'
+        )
+        expect(SdrEvents).to have_received(:report_indexing_errored).with(
+          'py305sy7961',
+          target: 'Searchworks',
+          message: 'add failed',
+          context: 'Solr error response: 400: Malformed data'
+        )
+      end
     end
   end
 end

--- a/spec/lib/traject/writers/solr_better_json_writer_spec.rb
+++ b/spec/lib/traject/writers/solr_better_json_writer_spec.rb
@@ -96,6 +96,15 @@ describe Traject::SolrBetterJsonWriter do
         end
       ]
     end
+    let(:folio_doc) do
+      Traject::Indexer::Context.new.tap do |doc|
+        doc.output_hash['id'] = [3]
+        doc.source_record = FolioRecord.new_from_source_record(
+          JSON.parse(File.read(file_fixture('a14185492.json'))),
+          nil
+        )
+      end
+    end
 
     before do
       allow(Settings.sdr_events).to receive(:enabled).and_return(true)
@@ -114,6 +123,17 @@ describe Traject::SolrBetterJsonWriter do
 
       it 'does not report any events' do
         writer.send_batch(sdr_docs)
+        expect(Dor::Event::Client).not_to have_received(:create)
+      end
+    end
+
+    context 'with a FolioRecord' do
+      before do
+        allow(Dor::Event::Client).to receive(:create)
+      end
+
+      it 'does not report any events' do
+        writer.send_batch([folio_doc])
         expect(Dor::Event::Client).not_to have_received(:create)
       end
     end


### PR DESCRIPTION
- Reapply "Shift some indexing reporting to the SolrBetterJsonWriter"
- Ensure SolrBetterJsonWriter doesn't report on FolioRecords
- Enable SDR event reporting for all SDR content
