### PR TITLE
Index the FOLIO library codes into holdings_library_code_ssim

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2039,6 +2039,10 @@ to_field 'preferred_barcode' do |record, accumulator, context|
   accumulator << preferred_item.barcode if preferred_item
 end
 
+to_field 'holdings_library_code_ssim' do |record, accumulator|
+  accumulator.concat(record.holdings.map { |holding| holding.dig('location', 'effectiveLocation', 'library', 'code') }.uniq)
+end
+
 to_field 'library_code_facet_ssim' do |record, accumulator, context|
   items(record, context).reject(&:skipped?).each do |item|
     next unless item.display_location&.dig('library')

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -241,6 +241,7 @@ RSpec.describe 'FOLIO indexing' do
     it { expect(result['access_facet']).to eq ['Online'] }
     it { expect(result['shelfkey']).to eq ['lc pr  3562.000000 l0.385000 002014'] }
     it { expect(result['building_facet']).to be_nil }
+    it { expect(result['holdings_library_code_ssim']).to eq ['SUL'] }
 
     context 'when the holding library is Law' do
       let(:items_and_holdings) do
@@ -260,6 +261,7 @@ RSpec.describe 'FOLIO indexing' do
       end
 
       it { expect(result['building_facet']).to eq ['Law (Crown)'] }
+      it { expect(result['holdings_library_code_ssim']).to eq ['LAW'] }
     end
 
     context 'when the holding does not include an electronic location' do


### PR DESCRIPTION
This will allow us to continue to support https://github.com/sul-dlss/SearchWorks/issues/3944 after we remove e-resources from the `item_display_struct`.
