### PR TITLE
Add dor-services-client in order as a prerequisite for accessing cocina

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,4 +42,5 @@ gem 'activesupport', '~> 7.0'
 gem 'slop'
 
 gem 'dor-event-client'
+gem 'dor-services-client', '~> 14.0'
 gem 'factory_bot', '~> 6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,6 +33,7 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     amq-protocol (2.3.2)
     ast (2.4.2)
+    attr_extras (7.1.0)
     base64 (0.2.0)
     bigdecimal (3.1.6)
     builder (3.2.4)
@@ -60,6 +61,23 @@ GEM
       sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
+    cocina-models (0.95.0)
+      activesupport
+      deprecation
+      dry-struct (~> 1.0)
+      dry-types (~> 1.1)
+      edtf
+      equivalent-xml
+      i18n
+      jsonpath
+      nokogiri
+      openapi3_parser
+      openapi_parser (~> 1.0)
+      rss
+      super_diff
+      thor
+      zeitwerk (~> 2.1)
+    commonmarker (0.23.10)
     concurrent-ruby (1.2.3)
     config (5.3.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -73,6 +91,8 @@ GEM
       irb (~> 1.10)
       reline (>= 0.3.8)
     deep_merge (1.2.2)
+    deprecation (1.1.0)
+      activesupport
     diff-lcs (1.5.1)
     digest-crc (0.6.5)
       rake (>= 12.0.0, < 14.0.0)
@@ -89,14 +109,49 @@ GEM
       zeitwerk (~> 2.1)
     dor-rights-auth (1.8.0)
       nokogiri
+    dor-services-client (14.2.0)
+      activesupport (>= 4.2, < 8)
+      cocina-models (~> 0.95.0)
+      deprecation
+      faraday (~> 2.0)
+      faraday-retry
+      zeitwerk (~> 2.1)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
     drb (2.2.1)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (1.0.0)
+    dry-logic (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-struct (1.6.0)
+      dry-core (~> 1.0, < 2)
+      dry-types (>= 1.7, < 2)
+      ice_nine (~> 0.11)
+      zeitwerk (~> 2.6)
+    dry-types (1.7.2)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     edtf (3.1.1)
       activesupport (>= 3.0, < 8.0)
+    equivalent-xml (0.6.0)
+      nokogiri (>= 1.4.3)
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
+    faraday (2.9.0)
+      faraday-net_http (>= 2.0, < 3.2)
+    faraday-net_http (3.1.0)
+      net-http
+    faraday-retry (2.2.0)
+      faraday (~> 2.0)
     ffi (1.16.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -116,12 +171,15 @@ GEM
     httpclient (2.8.3)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     io-console (0.7.2)
     irb (1.11.2)
       rdoc
       reline (>= 0.4.2)
     iso-639 (0.3.6)
     json (2.7.1)
+    jsonpath (1.1.5)
+      multi_json
     language_server-protocol (3.17.0.3)
     llhttp-ffi (0.5.0)
       ffi-compiler (~> 1.0)
@@ -147,7 +205,10 @@ GEM
       rails_autolink
       stanford-mods (~> 3.3, >= 3.3.9)
       view_component
+    multi_json (1.15.0)
     mutex_m (0.2.0)
+    net-http (0.4.1)
+      uri
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
     net-sftp (4.0.0)
@@ -160,10 +221,16 @@ GEM
     nom-xml (1.2.0)
       i18n
       nokogiri
+    openapi3_parser (0.9.2)
+      commonmarker (~> 0.17)
+    openapi_parser (1.0.0)
+    optimist (3.1.0)
     parallel (1.24.0)
     parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
+    patience_diff (1.2.0)
+      optimist (~> 3.0)
     pg (1.5.6)
     psych (5.1.2)
       stringio
@@ -219,6 +286,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
+    rss (0.3.0)
+      rexml
     rubocop (1.61.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -257,6 +326,10 @@ GEM
       mods (~> 3.0, >= 3.0.4)
     statsd-ruby (1.5.0)
     stringio (3.1.0)
+    super_diff (0.11.0)
+      attr_extras (>= 6.2.4)
+      diff-lcs
+      patience_diff
     thor (1.3.1)
     traject (3.8.2)
       concurrent-ruby (>= 0.8.0)
@@ -275,6 +348,7 @@ GEM
       unf_ext
     unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
+    uri (0.13.0)
     view_component (3.11.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -307,6 +381,7 @@ DEPENDENCIES
   dlss-capistrano
   dor-event-client
   dor-rights-auth
+  dor-services-client (~> 14.0)
   factory_bot (~> 6.2)
   honeybadger
   http


### PR DESCRIPTION
This is a prerequisite for #1380 in order to find cocina objects for metadata indexing.