### PR TITLE
Don't include the callnumber for the parent when making boundWith hol…

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -170,7 +170,7 @@ class FolioRecord
   # TODO: remove this when we stop using FolioItem
   def bound_with_holdings
     @bound_with_holdings ||= holdings.select { |holding| holding['boundWith'].present? || (holding.dig('holdingsType', 'name') || holding.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName')) == 'Bound-with' }.map do |holding|
-      parent_item = holding.dig('boundWith', 'item') || {}
+      parent_item = holding.dig('boundWith', 'item').excluding('callNumber') || {}
       parent_holding = holding.dig('boundWith', 'holding') || holding
 
       FolioItem.new(


### PR DESCRIPTION
…dings

On a Item the callNumber is supposed to point at an object, not a string