### PR TITLE
Always pass the FOLIO record to the item

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -177,7 +177,8 @@ class FolioRecord
         item: parent_item,
         holding: parent_holding,
         instance: holding.dig('boundWith', 'instance'),
-        bound_with_holding: holding
+        bound_with_holding: holding,
+        record: self
       )
     end
   end
@@ -191,7 +192,8 @@ class FolioRecord
       FolioItem.new(
         holding:,
         instance:,
-        status: 'On order'
+        status: 'On order',
+        record: self
       )
     end
   end
@@ -207,7 +209,8 @@ class FolioRecord
       FolioItem.new(
         instance:,
         library: lib,
-        status: 'On order'
+        status: 'On order',
+        record: self
       )
     end
   end


### PR DESCRIPTION
This lets us appropriately lop e.g. bound-with alphanum call numbers