### PR TITLE
Index records with any marc links data, not just a full text url

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2223,8 +2223,8 @@ end
 ##
 # Skip records for missing `item_display` field
 each_record do |_record, context|
-  if context.output_hash['item_display_struct'].blank? && context.output_hash['url_fulltext'].blank? && settings['skip_empty_item_display'] > -1
-    context.skip!('No item_display_struct or url_fulltext field')
+  if context.output_hash['item_display_struct'].blank? && context.output_hash['marc_links_struct'].blank? && settings['skip_empty_item_display'] > -1
+    context.skip!('No item_display_struct or marc_links_struct field')
   end
 end
 

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'FOLIO indexing' do
   subject(:result) { indexer.map_record(folio_record) }
 
   let(:indexer) do
-    Traject::Indexer.new('okapi.url' => 'https://example.com').tap do |i|
+    Traject::Indexer.new('okapi.url' => 'https://example.com', 'skip_empty_item_display' => '0').tap do |i|
       i.load_config_file('./lib/traject/config/folio_config.rb')
     end
   end


### PR DESCRIPTION
This should be closer to parity with the stub e-resource items we used to create prior to #1381; otherwise we end up excluding records with e.g. SFX urls (e.g. `a12195945`)