### PR TITLE
Use browseable call numbers for Lane e-resources with other data in the holdings call number

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2192,7 +2192,7 @@ to_field 'browse_nearby_struct' do |record, accumulator, context|
     holding = record.electronic_holdings.first
     value = holding&.dig('callNumber')
     type = FolioItem.call_number_type_code(holding&.dig('callNumberType', 'name'))
-    FolioItem::CallNumber.new(value, type) if value.present?
+    FolioItem::CallNumber.new(value, type) if value.present? && %w[LC DEWEY ALPHANUM].include?(type&.upcase)
   end
 
   callnumber ||= Traject::MarcExtractor.cached('050ab:090ab', alternate_script: false).extract(record).filter_map do |item_050|

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -199,4 +199,55 @@ RSpec.describe 'Browse nearby' do
 
     it { is_expected.to include(hash_including('lopped_callnumber' => 'QA987 V.5:NO.5')) }
   end
+
+  context 'with a LANE e-resource' do
+    before do
+      allow(folio_record).to receive(:items_and_holdings).and_return(items_and_holdings)
+      allow(folio_record).to receive(:pieces).and_return([])
+    end
+
+    let(:record) do
+      MARC::Record.new.tap do |r|
+        r.leader = '15069nam a2200409 a 4500'
+        r.append(MARC::ControlField.new('008', '091123s2014    si a    sb    101 0 eng d'))
+        r.append(MARC::DataField.new('050', ' ', '0',
+                                     MARC::Subfield.new('a', 'F1356'),
+                                     MARC::Subfield.new('b', '.M464 2005')))
+        r.append(MARC::DataField.new('856', ' ', '0', MARC::Subfield.new('u', 'http://example.com')))
+      end
+    end
+
+    let(:items_and_holdings) do
+      { 'items' => [],
+        'holdings' =>
+         [
+           { 'id' => '4a3a0693-f2a5-4d79-8603-5659ed121ae2',
+             'notes' => [],
+             'location' =>
+             { 'effectiveLocation' =>
+               { 'code' => 'LANE-STACKS',
+                 'name' => 'Lane Stacks',
+                 'campusName' => 'Lane',
+                 'libraryName' => 'Lane',
+                 'institutionName' => 'Stanford University',
+                 'details' => {
+                   'holdingsTypeName' => 'Electronic'
+                 } },
+               'permanentLocation' => {},
+               'temporaryLocation' => {} },
+             'formerIds' => [],
+             'callNumber' => 'Karger',
+             'holdingsType' => {},
+             'electronicAccess' => [],
+             'receivingHistory' => { 'entries' => [] },
+             'statisticalCodes' => [],
+             'holdingsStatements' => [],
+             'suppressFromDiscovery' => false,
+             'holdingsStatementsForIndexes' => [],
+             'holdingsStatementsForSupplements' => [] }
+         ] }
+    end
+
+    it { is_expected.to include(hash_including('lopped_callnumber' => 'F1356 .M464 2005')) }
+  end
 end


### PR DESCRIPTION
E.g. the holdings record on https://searchworks.stanford.edu/view/L74649/  has the call number "Karger". We'd rather use the browseable LC  call number.