### PR TITLE
Filter out bound-with parents that seem to be bound-with itself

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,8 @@ Style/MultilineIfModifier:
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*_spec.rb'
+    - 'spec/factories/**/*'
+
 Style/RedundantConstantBase:  # new in 1.40
   Enabled: true
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -94,7 +94,7 @@ Metrics/AbcSize:
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 94
+  Max: 60
 
 # Offense count: 9
 # Configuration parameters: CountBlocks.

--- a/lib/folio/marc_record_instance_mapper.rb
+++ b/lib/folio/marc_record_instance_mapper.rb
@@ -3,10 +3,12 @@
 module Folio
   # Creates a Marc Record for an Folio instance
   class MarcRecordInstanceMapper
-    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
-    def self.build(instance, holdings)
+    # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/BlockLength
+    def self.build(folio_record)
       MARC::Record.new.tap do |marc|
-        marc.append(MARC::ControlField.new('001', instance['hrid']))
+        marc.append(MARC::ControlField.new('001', folio_record.hrid))
+
+        instance = folio_record.instance
         # mode of issuance
         # identifiers
         instance['identifiers'].each do |identifier|
@@ -99,7 +101,7 @@ module Folio
           marc.append(MARC::DataField.new('856', '4', ind2, *subfields.to_a))
         end
 
-        holdings.flat_map { |h| h['electronicAccess'] }.each do |eresource|
+        folio_record.holdings.flat_map { |h| h['electronicAccess'] }.each do |eresource|
           ind2 = case eresource['name']
                  when 'Resource'
                    '0'
@@ -124,12 +126,12 @@ module Folio
         end
 
         # nature of content
-        marc.append(MARC::DataField.new('999', '', '', ['i', instance['id']]))
+        marc.append(MARC::DataField.new('999', '', '', ['i', folio_record.instance_id]))
         # date creaetd
         # date updated
       end.to_hash
     end
-    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength
+    # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/BlockLength
 
     # The FOLIO data can either be a plain string (pre-Poppy) or a hash (post-Poppy)
     def self.folio_value(folio_data)

--- a/lib/folio/marc_record_mapper.rb
+++ b/lib/folio/marc_record_mapper.rb
@@ -51,10 +51,10 @@ module Folio
       # if 590 with Bound-with related subfields are present, return the record as is
       unless record.fields('590').any? { |f| f['a'] && f['c'] }
         # if 590 or one of its Bound-with related subfields is missing, and FOLIO says this record is Bound-with, append the relevant data from FOLIO
-        holdings.select { |holding| holding['boundWith'].present? }.each do |holding|
+        folio_record.bound_with_holdings.each do |item|
           field590 = MARC::DataField.new('590', ' ', ' ')
-          field590.subfields << MARC::Subfield.new('a', "#{holding['callNumber']} bound with #{holding.dig('boundWith', 'instance', 'title')}")
-          field590.subfields << MARC::Subfield.new('c', "#{holding.dig('boundWith', 'instance', 'hrid')} (parent record)")
+          field590.subfields << MARC::Subfield.new('a', "#{item.holding['callNumber']} bound with #{item.holding.dig('boundWith', 'instance', 'title')}")
+          field590.subfields << MARC::Subfield.new('c', "#{item.holding.dig('boundWith', 'instance', 'hrid')} (parent record)")
           record.append(field590)
         end
       end

--- a/lib/folio/marc_record_mapper.rb
+++ b/lib/folio/marc_record_mapper.rb
@@ -2,8 +2,8 @@
 
 module Folio
   class MarcRecordMapper
-    def self.build(stripped_marc_json, holdings, instance)
-      record = MARC::Record.new_from_hash(stripped_marc_json || Folio::MarcRecordInstanceMapper.build(instance, holdings))
+    def self.build(stripped_marc_json, folio_record)
+      record = MARC::Record.new_from_hash(stripped_marc_json || Folio::MarcRecordInstanceMapper.build(folio_record))
 
       record.fields.each do |field|
         next unless field.respond_to? :subfields
@@ -17,7 +17,7 @@ module Folio
 
       # Copy FOLIO Holdings electronic access data to an 856 (used by Lane)
       # overwriting any existing 856 fields (to avoid having to reconcile/merge data)
-      eholdings = holdings.flat_map { |h| h['electronicAccess'] }.compact
+      eholdings = folio_record.holdings.flat_map { |h| h['electronicAccess'] }.compact
 
       if eholdings.any?
         record.fields.delete_if { |field| field.tag == '856' }

--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -32,7 +32,7 @@ class FolioItem
   def initialize(item: nil, holding: nil, instance: nil,
                  course_reserves: [],
                  type: nil, status: nil,
-                 library: nil, record: nil)
+                 library: nil, record: nil, bound_with: false)
     @item = item
     @holding = holding
     @instance = instance
@@ -43,6 +43,7 @@ class FolioItem
     @barcode = @item&.dig('barcode')
     @course_reserves = course_reserves
     @record = record
+    @bound_with = bound_with
   end
   # rubocop:enable Metrics/ParameterLists
 
@@ -151,11 +152,13 @@ class FolioItem
   end
 
   def bound_with
+    return unless bound_with?
+
     holding&.dig('boundWith')
   end
 
   def bound_with?
-    bound_with.present?
+    @bound_with && holding&.dig('boundWith').present?
   end
 
   private

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -147,8 +147,6 @@ class FolioRecord
     holdings.select { |h| h.dig('holdingsType', 'name') == 'Electronic' || h.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName') == 'Electronic' }
   end
 
-  private
-
   def item_holdings
     @item_holdings ||= items.filter_map do |item|
       holding = holdings.find { |holding| holding['id'] == item['holdingsRecordId'] }
@@ -172,7 +170,7 @@ class FolioRecord
       parent_item = holding.dig('boundWith', 'item') || {}
 
       # bound-with "principals" appear as if they're bound-with themselves. See SW-4330.
-      next if parent_item['id'].in? item_holdings.map(&:id)
+      next if parent_item['id'].in? item_holdings.select { |item| item.holding['id'] == holding['id'] }.map(&:id)
 
       FolioItem.new(
         item: parent_item,
@@ -183,6 +181,8 @@ class FolioRecord
       )
     end
   end
+
+  private
 
   def on_order_holdings
     on_order_holdings = holdings.select do |holding|

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -178,7 +178,8 @@ class FolioRecord
         item: parent_item,
         holding:,
         instance:,
-        record: self
+        record: self,
+        bound_with: true
       )
     end
   end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -41,7 +41,7 @@ class FolioRecord
   # to create parity with the data contained in the Symphony record.
   # @return [MARC::Record]
   def marc_record
-    @marc_record ||= Folio::MarcRecordMapper.build(stripped_marc_json, holdings, instance)
+    @marc_record ||= Folio::MarcRecordMapper.build(stripped_marc_json, self)
   end
 
   def index_items
@@ -242,7 +242,7 @@ class FolioRecord
   end
 
   def instance_derived_marc_record
-    Folio::MarcRecordInstanceMapper.build(instance, holdings)
+    Folio::MarcRecordInstanceMapper.build(folio_record)
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/spec/factories/holdings.rb
+++ b/spec/factories/holdings.rb
@@ -27,6 +27,7 @@ FactoryBot.define do
     end
     library { 'GREEN' }
     type { '' }
+    bound_with { false }
 
     initialize_with { new(**attributes, holding:, item: default_item_attributes.merge(item).merge(additional_item_attributes.deep_stringify_keys)) }
 
@@ -56,6 +57,7 @@ FactoryBot.define do
     end
 
     trait :bound_with do
+      bound_with { true }
       additional_item_attributes do
         {
           'id' => 'f947bd93-a1eb-5613-8745-1063f948c461',

--- a/spec/factories/holdings.rb
+++ b/spec/factories/holdings.rb
@@ -76,7 +76,7 @@ FactoryBot.define do
             },
             'holding' => {},
             'item' => {
-              'id' => 'f947bd93-a1eb-5613-8745-1063f948c461',
+              'id' => 'some-boundwith-parent-item-id',
               'volume' => nil,
               'callNumber' => { 'callNumber' => '630.654 .I39M' },
               'chronology' => nil,

--- a/spec/fixtures/files/folio_bw_principal.json
+++ b/spec/fixtures/files/folio_bw_principal.json
@@ -1,0 +1,402 @@
+{
+  "pieces": [
+    null
+  ],
+  "instance": {
+    "id": "0bd14032-6811-5361-a55b-14e0bafbbf0f",
+    "hrid": "a290907",
+    "tags": {
+      "tagList": [
+
+      ]
+    },
+    "notes": [
+      {
+        "note": "At head of title: Robert Schumann's compositionen für das pianoforte, kritisch rev., phrasirt und mit fingersatz versehen von Conrad Kühner",
+        "staffOnly": false,
+        "instanceNoteTypeId": "6a2533a7-4de2-4e64-8466-074c2fa9308c"
+      },
+      {
+        "note": "Stanford copy 1 (MUSC): Bound with: Album für die Jugend / Robert Schumann. Leipzig: C.F. Peters, [18--?]",
+        "staffOnly": false,
+        "instanceNoteTypeId": "265c4910-3997-4242-9269-6a4a2e91392b"
+      }
+    ],
+    "title": "Fantasiestücke, op 12.",
+    "series": [
+
+    ],
+    "source": "MARC",
+    "_version": 2,
+    "editions": [
+
+    ],
+    "metadata": {
+      "createdDate": "2023-08-20T16:22:12.308Z",
+      "updatedDate": "2024-05-20T17:14:56.187Z",
+      "createdByUserId": "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+      "updatedByUserId": "6f1cddbc-69fb-4ea9-8a06-13e809179239"
+    },
+    "statusId": "9634a5ab-9228-4703-baf2-4d12ebc77d56",
+    "subjects": [
+      "Piano music"
+    ],
+    "languages": [
+      "zxx"
+    ],
+    "indexTitle": "Fantasiestücke, op 12.",
+    "identifiers": [
+      {
+        "value": "(Sirsi) ABL9231",
+        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+      },
+      {
+        "value": "(CStRLIN)CSUG89-C2632",
+        "identifierTypeId": "7e591197-f335-4afb-bc6d-a6d76ca3bace"
+      },
+      {
+        "value": "(OCoLC-M)4396611",
+        "identifierTypeId": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef"
+      },
+      {
+        "value": "(OCoLC-I)272205514",
+        "identifierTypeId": "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef"
+      }
+    ],
+    "publication": [
+      {
+        "place": "Braunschweig",
+        "publisher": "H. Litolff",
+        "dateOfPublication": "[18--?]"
+      }
+    ],
+    "contributors": [
+      {
+        "name": "Schumann, Robert, 1810-1856",
+        "primary": true,
+        "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+      },
+      {
+        "name": "Kühner, Conrad, 1851-1909",
+        "primary": false,
+        "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+      }
+    ],
+    "catalogedDate": "1993-12-20",
+    "staffSuppress": false,
+    "instanceTypeId": "30fffe0e-e985-4144-b2e2-1e8179bdb41f",
+    "previouslyHeld": false,
+    "classifications": [
+
+    ],
+    "instanceFormats": [
+
+    ],
+    "electronicAccess": [
+
+    ],
+    "holdingsRecords2": [
+
+    ],
+    "modeOfIssuanceId": "9d18a02f-5897-4c31-9106-c9abb5c7ae8b",
+    "publicationRange": [
+
+    ],
+    "statisticalCodes": [
+
+    ],
+    "alternativeTitles": [
+      {
+        "alternativeTitle": "Fantasiestücke, piano, op. 12",
+        "alternativeTitleTypeId": "30512027-cdc9-4c79-af75-1565b3bd888d"
+      }
+    ],
+    "discoverySuppress": false,
+    "instanceFormatIds": [
+
+    ],
+    "statusUpdatedDate": "2023-08-20T16:22:12.302+0000",
+    "statisticalCodeIds": [
+
+    ],
+    "administrativeNotes": [
+
+    ],
+    "physicalDescriptions": [
+      "39, [1] p. 31 cm."
+    ],
+    "publicationFrequency": [
+
+    ],
+    "suppressFromDiscovery": false,
+    "natureOfContentTermIds": [
+
+    ]
+  },
+  "holdingSummaries": [
+    {
+      "poLineId": null,
+      "orderType": null,
+      "orderStatus": null,
+      "poLineNumber": null,
+      "orderSentDate": null,
+      "orderCloseReason": null,
+      "polReceiptStatus": null
+    }
+  ],
+  "holdings": [
+    {
+      "id": "61a02b20-39db-52a1-879a-34e3be8f0368",
+      "hrid": "ah290907_1",
+      "notes": [
+
+      ],
+      "_version": 2,
+      "metadata": {
+        "createdDate": "2023-08-20T16:25:07.169Z",
+        "updatedDate": "2024-05-20T17:25:22.982Z",
+        "createdByUserId": "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+        "updatedByUserId": "58d0aaf6-dcda-4d5e-92da-012e6b7dd766"
+      },
+      "sourceId": "f32d531e-df79-46b3-8932-cdd35f7a2264",
+      "boundWith": {
+        "item": {
+          "id": "2b9ba8c6-f25c-5ba2-a159-418a0c335703",
+          "hrid": "ai290907_1_1",
+          "status": "Available",
+          "volume": null,
+          "barcode": "36105042167762",
+          "callNumber": {
+            "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "callNumber": "M23 .S39 F2D"
+          },
+          "chronology": null,
+          "enumeration": null
+        },
+        "holding": {
+          "effectiveLocationId": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+          "location": {
+            "effectiveLocation": {
+              "id": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+              "code": "MUS-SCORES",
+              "name": "Scores",
+              "campus": {
+                "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+                "code": "SUL",
+                "name": "Stanford Libraries"
+              },
+              "details": {
+              },
+              "library": {
+                "id": "45d4bfcc-439b-4ae3-8c62-a8f975be1d5b",
+                "code": "MUSIC",
+                "name": "Music Library"
+              },
+              "isActive": true,
+              "institution": {
+                "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                "code": "SU",
+                "name": "Stanford University"
+              }
+            }
+          }
+        },
+        "instance": {
+          "id": "0bd14032-6811-5361-a55b-14e0bafbbf0f",
+          "hrid": "a290907",
+          "title": "Fantasiestücke, op 12."
+        }
+      },
+      "formerIds": [
+
+      ],
+      "illPolicy": null,
+      "callNumber": "M23 .S39 F2D",
+      "instanceId": "0bd14032-6811-5361-a55b-14e0bafbbf0f",
+      "holdingsType": {
+        "id": "dacfaaab-ee77-425a-b34a-7c0140860b6d",
+        "name": "Score",
+        "source": "local"
+      },
+      "holdingsItems": [
+
+      ],
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "holdingsTypeId": "dacfaaab-ee77-425a-b34a-7c0140860b6d",
+      "callNumberTypeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+      "electronicAccess": [
+
+      ],
+      "bareHoldingsItems": [
+
+      ],
+      "holdingsStatements": [
+
+      ],
+      "statisticalCodeIds": [
+
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+      "permanentLocationId": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+      "suppressFromDiscovery": false,
+      "holdingsStatementsForIndexes": [
+
+      ],
+      "holdingsStatementsForSupplements": [
+
+      ],
+      "location": {
+        "effectiveLocation": {
+          "id": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+          "code": "MUS-SCORES",
+          "name": "Scores",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "45d4bfcc-439b-4ae3-8c62-a8f975be1d5b",
+            "code": "MUSIC",
+            "name": "Music Library"
+          },
+          "isActive": true,
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        },
+        "permanentLocation": {
+          "id": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+          "code": "MUS-SCORES",
+          "name": "Scores",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "45d4bfcc-439b-4ae3-8c62-a8f975be1d5b",
+            "code": "MUSIC",
+            "name": "Music Library"
+          },
+          "isActive": true,
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        }
+      }
+    }
+  ],
+  "items": [
+    {
+      "id": "2b9ba8c6-f25c-5ba2-a159-418a0c335703",
+      "hrid": "ai290907_1_1",
+      "notes": [
+
+      ],
+      "status": "Available",
+      "barcode": "36105042167762",
+      "request": null,
+      "_version": 6,
+      "metadata": {
+        "createdDate": "2023-08-20T16:27:39.792Z",
+        "updatedDate": "2024-05-20T17:38:32.403Z",
+        "createdByUserId": "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+        "updatedByUserId": "6f1cddbc-69fb-4ea9-8a06-13e809179239"
+      },
+      "formerIds": [
+
+      ],
+      "callNumber": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "typeName": "Library of Congress classification",
+        "callNumber": "M23 .S39 F2D"
+      },
+      "copyNumber": "1",
+      "lastCheckIn": {
+        "dateTime": "2024-05-20T17:38:32.119+00:00",
+        "staffMemberId": "6f1cddbc-69fb-4ea9-8a06-13e809179239",
+        "servicePointId": "4d77d74b-271e-421a-91c6-992afa9afb3c"
+      },
+      "yearCaption": [
+
+      ],
+      "materialType": "score",
+      "callNumberType": {
+        "id": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "name": "Library of Congress classification",
+        "source": "folio"
+      },
+      "materialTypeId": "8cea2cd7-6a61-494e-a602-17045da7e3cb",
+      "numberOfPieces": "1",
+      "circulationNotes": [
+
+      ],
+      "electronicAccess": [
+
+      ],
+      "holdingsRecordId": "61a02b20-39db-52a1-879a-34e3be8f0368",
+      "discoverySuppress": false,
+      "itemDamagedStatus": null,
+      "permanentLoanType": "Can circulate",
+      "temporaryLoanType": null,
+      "statisticalCodeIds": [
+        "e6f1059b-4ab2-4bb2-adcb-af66acb6f4fa"
+      ],
+      "administrativeNotes": [
+
+      ],
+      "effectiveLocationId": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+      "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+      "suppressFromDiscovery": false,
+      "effectiveShelvingOrder": "M 223 S39 F2 D 11",
+      "effectiveCallNumberComponents": {
+        "typeId": "95467209-6d7b-468b-94df-0f5d7ad2747d",
+        "callNumber": "M23 .S39 F2D"
+      },
+      "location": {
+        "effectiveLocation": {
+          "id": "ec0d3f2e-c266-459e-8aaa-a44dea58255d",
+          "code": "MUS-SCORES",
+          "name": "Scores",
+          "campus": {
+            "id": "c365047a-51f2-45ce-8601-e421ca3615c5",
+            "code": "SUL",
+            "name": "Stanford Libraries"
+          },
+          "details": {
+          },
+          "library": {
+            "id": "45d4bfcc-439b-4ae3-8c62-a8f975be1d5b",
+            "code": "MUSIC",
+            "name": "Music Library"
+          },
+          "isActive": true,
+          "institution": {
+            "id": "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+            "code": "SU",
+            "name": "Stanford University"
+          }
+        }
+      },
+      "courses": [
+
+      ]
+    }
+  ]
+}

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -188,6 +188,7 @@ RSpec.describe FolioRecord do
               }
             }
           }],
+          'items' => [],
           'source_record' => [{
             'fields' => [
               { '001' => 'a14154194' },
@@ -229,6 +230,7 @@ RSpec.describe FolioRecord do
               }
             }
           }],
+          'items' => [],
           'source_record' => [{
             'fields' => [
               { '001' => 'a14154194' }

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -346,6 +346,14 @@ RSpec.describe FolioRecord do
         end
       end
 
+      context 'for a bound-with principal' do
+        let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('folio_bw_principal.json'))), client) }
+
+        it 'includes the bound-with principal only once' do
+          expect(index_items).to contain_exactly(have_attributes(id: '2b9ba8c6-f25c-5ba2-a159-418a0c335703'))
+        end
+      end
+
       context 'with Symphony migrated data without the right linkages between the bound-with holding and item' do
         let(:record) do
           {

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe 'Browse nearby' do
 
     let(:index_items) do
       [
-        build(:dewey_holding, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.5')),
-        build(:dewey_holding, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.6'))
+        build(:dewey_holding, bound_with: true, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.5')),
+        build(:dewey_holding, bound_with: true, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.6'))
       ]
     end
 
@@ -193,7 +193,7 @@ RSpec.describe 'Browse nearby' do
 
     let(:index_items) do
       [
-        build(:dewey_holding, call_number: 'AB1234', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => 'QA987 V.5:NO.5'))
+        build(:dewey_holding, bound_with: true, call_number: 'AB1234', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => 'QA987 V.5:NO.5'))
       ]
     end
 

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -221,6 +221,12 @@ RSpec.describe 'ItemInfo config' do
 
       context 'with holdings' do
         let(:holdings) { [build(:lc_holding, :bound_with)] }
+
+        before do
+          allow(folio_record).to receive(:item_holdings).and_return([])
+          allow(folio_record).to receive(:bound_with_holdings).and_return(holdings)
+        end
+
         it 'contains a bound_with parent' do
           expect(value).to match_array([
                                          hash_including('bound_with' => {


### PR DESCRIPTION
The bound-with principal ("parent") holdings record will (now) always have a bound-with item attached to it (its own item)  to ~obscure~ make the bound-with parent and bound-with children have the same data structure. Without doing anything, we'll end up duplicating the bound-with parent data (showing the actual item and the supposedly-bound-with holding item) e.g. https://searchworks.stanford.edu/view/290907...

So we need to do something to suppress that extra data. Unfortunately, not all our bound-with holdings have the bound-with holdings type, so we get to try our best to de-duplicate 🤷‍♂️  