### PR TITLE
add 'is_bound_with_principal' to the item display to identify whether…

### DIFF
--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -117,7 +117,8 @@ class FolioItem
       effective_location_id: temporary_location&.dig('id') || permanent_location&.dig('id'),
       material_type_id: item&.dig('materialTypeId'),
       loan_type_id: item&.dig('temporaryLoanTypeId') || item&.dig('permanentLoanTypeId'),
-      bound_with: bound_with_data
+      bound_with: bound_with_data,
+      is_bound_with_principal: bound_with_principal?
     }.merge(course_reserves_data)
   end
 
@@ -133,6 +134,12 @@ class FolioItem
       enumeration: item['enumeration'],
       chronology: item['chronology']
     }
+  end
+
+  def bound_with_principal?
+    return false if bound_with? || holding.blank?
+
+    holding['boundWith'].present?
   end
 
   def course_reserves_data

--- a/spec/integration/folio_config_spec.rb
+++ b/spec/integration/folio_config_spec.rb
@@ -342,6 +342,24 @@ RSpec.describe 'FOLIO indexing' do
     end
   end
 
+  context 'with a bound-with principal' do
+    let(:folio_record) do
+      FolioRecord.new(source_record_json, client)
+    end
+
+    let(:source_record_json) do
+      JSON.parse(File.read(file_fixture('folio_bw_principal.json')))
+    end
+
+    let(:item_display_structs) do
+      Array(result['item_display_struct']).map { |x| JSON.parse(x) }
+    end
+
+    it 'identifies the bound-with principals' do
+      expect(item_display_structs).to contain_exactly(include('barcode' => '36105042167762', 'is_bound_with_principal' => true))
+    end
+  end
+
   describe 'item_display_struct' do
     context 'item status is checked out' do
       let(:items) do


### PR DESCRIPTION
… the item has bound-with children.

This will allow e.g. https://github.com/sul-dlss/SearchWorks/pull/4107/files to be smarter about when it tries to look up bound-with child information.