### PR TITLE
Update stanford-geo gem to 0.2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,4 @@ gem 'slop'
 gem 'cocina-models'
 gem 'dor-event-client'
 gem 'factory_bot', '~> 6.2'
-git 'https://github.com/sul-dlss/stanford-geo.git' do
-  gem 'stanford-geo'
-end
+gem 'stanford-geo', '0.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/sul-dlss/stanford-geo.git
-  revision: 8fb8f30d0cf36b92565fc45a74a953978ca44b15
-  branch: bbox-parsing
-  specs:
-    stanford-geo (0.1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -287,8 +280,6 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rss (0.3.0)
-      rexml
     rubocop (1.64.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
@@ -323,6 +314,7 @@ GEM
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
+    stanford-geo (0.2.0)
     stanford-mods (3.3.9)
       activesupport
       mods (~> 3.0, >= 3.0.4)
@@ -400,7 +392,7 @@ DEPENDENCIES
   ruby-kafka
   simplecov
   slop
-  stanford-geo!
+  stanford-geo (= 0.2.0)
   stanford-mods (~> 3.0)
   statsd-ruby
   traject (~> 3.0)


### PR DESCRIPTION
Don't use a github branch -- use the newly released gem.