### PR TITLE
Stop using MARC 596 for on-order information

### DIFF
--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -48,10 +48,7 @@ class FolioRecord
     @index_items ||= begin
       items = item_holdings.concat(bound_with_holdings)
 
-      unless all_items.any? || eresource?
-        items = on_order_holdings if items.empty?
-        items = on_order_stub_holdings if items.empty?
-      end
+      items = on_order_holdings if !(all_items.any? || eresource?) && items.empty?
 
       items
     end
@@ -193,23 +190,6 @@ class FolioRecord
       FolioItem.new(
         holding:,
         instance:,
-        status: 'On order',
-        record: self
-      )
-    end
-  end
-
-  def on_order_stub_holdings
-    order_libs = Traject::MarcExtractor.cached('596a', alternate_script: false).extract(marc_record)
-    translation_map = Traject::TranslationMap.new('library_on_order_map')
-
-    lib_codes = order_libs.flat_map(&:split).map { |order_lib| translation_map[order_lib] }.uniq
-    # exclude generic SUL if there's a more specific library
-    lib_codes -= ['SUL'] if lib_codes.length > 1
-    lib_codes.map do |lib|
-      FolioItem.new(
-        instance:,
-        library: lib,
         status: 'On order',
         record: self
       )

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2206,8 +2206,6 @@ each_record do |_record, context|
   end
 end
 
-to_field 'on_order_library_ssim', extract_marc('596a', translation_map: 'library_on_order_map')
-
 to_field 'mhld_display' do |record, accumulator, _context|
   record.mhld.each { |holding| accumulator << holding }
 end

--- a/spec/integration/compare_against_solrmarc_docs_spec.rb
+++ b/spec/integration/compare_against_solrmarc_docs_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'comparing against a well-known location full of documents genera
        title_variant_display summary_display pub_display]
   end
   let(:ignored_fields) do
-    %w[all_search created last_updated format _version_ author_sort author_title_search callnum_facet_hsim marcbib_xml marcxml mhld_display fund_facet building_facet collection item_display barcode_search] + copy_fields
+    %w[all_search created last_updated format _version_ author_sort author_title_search callnum_facet_hsim marcbib_xml marcxml mhld_display fund_facet building_facet collection item_display barcode_search on_order_library_ssim] + copy_fields
   end
   let(:pending_fields) { %w[reverse_shelfkey shelfkey preferred_barcode date_cataloged access_facet] }
   subject(:result) { indexer.map_record(folio_record).transform_values { |v| v.sort } }

--- a/spec/lib/traject/config/access_spec.rb
+++ b/spec/lib/traject/config/access_spec.rb
@@ -158,19 +158,6 @@ RSpec.describe 'Access config' do
     specify { expect(field).to contain_exactly 'At the Library' }
   end
 
-  context 'without items or holdings but with a 596a in the bib record' do
-    let(:marc_record) do
-      MARC::Record.new.tap do |r|
-        r.leader = '00988nas a2200193z  4500'
-        r.append(MARC::ControlField.new('008', '071214uuuuuuuuuxx uu |ss    u|    |||| d'))
-        r.append(MARC::DataField.new('596', ' ', ' ',
-                                     MARC::Subfield.new('a', '31')))
-      end
-    end
-
-    specify { expect(field).to contain_exactly 'On order' }
-  end
-
   context 'for a suppressed item' do
     let(:holdings) do
       [{

--- a/spec/lib/traject/config/holdings_spec.rb
+++ b/spec/lib/traject/config/holdings_spec.rb
@@ -9,16 +9,6 @@ RSpec.describe 'Holdings config' do
 
   subject(:result) { indexer.map_record(marc_to_folio(record)) }
 
-  describe 'on_order_library_ssim' do
-    let(:field) { 'on_order_library_ssim' }
-    let(:fixture_name) { '44794.json' }
-    let(:records) { MARC::JSONLReader.new(file_fixture(fixture_name).to_s).to_a }
-    let(:record) { records.first }
-
-    subject(:value) { result[field] }
-    it { is_expected.to eq ['SAL3'] }
-  end
-
   describe 'bookplates_display' do
     let(:field) { 'bookplates_display' }
     describe 'population of bookplates_display' do

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -184,22 +184,6 @@ RSpec.describe 'ItemInfo config' do
     let(:field) { 'item_display_struct' }
     subject(:value) { result[field].map { |x| JSON.parse(x) } }
 
-    context 'when an item is on-order' do
-      # NOTE: This test exercises on_order_stub_holdings
-      let(:record) do
-        MARC::Record.new.tap do |r|
-          r.append(
-            MARC::DataField.new(
-              '596', ' ', ' ',
-              MARC::Subfield.new('a', '1 2 22')
-            )
-          )
-        end
-      end
-
-      it { is_expected.to match_array([hash_including('library' => 'GREEN'), hash_including('library' => 'ART')]) }
-    end
-
     context 'when an item is bound-with' do
       let(:record) do
         MARC::Record.new.tap do |r|


### PR DESCRIPTION
Kevin determined there's only ~150 items with a 596 without any holdings record, and gryphon-search was ok dropping the 596 logic and remediating the data at some future point.