### PR TITLE
Modify Geo Aardvard mappings

### DIFF
--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -184,12 +184,18 @@ to_field 'dct_identifier_sm', cocina_descriptive('purl')
 # https://opengeometadata.org/ogm-aardvark/#resource-class
 # - if the item is a collection, set the resource class to "Collections" (only)
 # - if we didn't find anything, fall back to "Other" because the field is required
-to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('genre'), extract_values, translation_map('geo_resource_class')
-to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('genre'), extract_structured_values(flatten: true), translation_map('geo_resource_class')
-to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('form'), extract_values, translation_map('geo_resource_class')
-to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('form'), extract_structured_values(flatten: true), translation_map('geo_resource_class')
-to_field 'gbl_resourceClass_sm', cocina_descriptive('geographic', 'form'), select_type('type'), extract_values, translation_map('geo_resource_class')
-to_field 'gbl_resourceClass_sm', cocina_descriptive('subject', 'structuredValue'), select_type('genre'), extract_values, translation_map('geo_resource_class')
+# - we use a custom assign_resource_class_values macro to detect possible valid values (map/s and dataset/s) within phrases
+to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('genre'), extract_values, assign_resource_class_values, translation_map('geo_resource_class')
+
+to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('genre'), extract_structured_values(flatten: true), assign_resource_class_values, translation_map('geo_resource_class')
+
+to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('form'), extract_values, assign_resource_class_values, translation_map('geo_resource_class')
+to_field 'gbl_resourceClass_sm', cocina_descriptive('form'), select_type('form'), extract_structured_values(flatten: true), assign_resource_class_values, translation_map('geo_resource_class')
+
+to_field 'gbl_resourceClass_sm', cocina_descriptive('geographic', 'form'), select_type('type'), extract_values, assign_resource_class_values, translation_map('geo_resource_class')
+to_field 'gbl_resourceClass_sm', cocina_descriptive('subject', 'structuredValue'), select_type('genre'), extract_values, assign_resource_class_values, translation_map('geo_resource_class')
+
+# Fallbacks
 to_field('gbl_resourceClass_sm') { |_record, accumulator, context| accumulator << 'Other' if context.output_hash['gbl_resourceClass_sm'].blank? }
 to_field('gbl_resourceClass_sm') { |record, _accumulator, context| context.output_hash['gbl_resourceClass_sm'] = ['Collections'] if record.public_cocina.collection? }
 

--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -137,6 +137,7 @@ to_field 'dct_language_sm', cocina_descriptive('language'), transform(->(lang) {
 
 # https://opengeometadata.org/ogm-aardvark/#creator
 to_field 'dct_creator_sm', cocina_descriptive('contributor'), select_role('creator'), extract_names
+to_field 'dct_creator_sm', cocina_descriptive('contributor', 'name'), extract_names_from_structured_values
 
 # https://opengeometadata.org/ogm-aardvark/#publisher
 to_field 'dct_publisher_sm', cocina_descriptive('event', 'contributor'), select_role('publisher'), extract_names

--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -231,6 +231,11 @@ to_field 'gbl_georeferenced_b', cocina_descriptive('access', 'url'),
 to_field 'gbl_georeferenced_b', cocina_descriptive('relatedResource', 'url'), select_type('has other format'),
          transform(->(res) { true if res['displayLabel'] == 'Georeferenced Map' })
 
+# https://opengeometadata.org/ogm-aardvark/#relation
+# - we are choosing to use this field to hold the georefereced link if it exists
+to_field 'dct_relation_sm', cocina_descriptive('access', 'url'),
+         transform(->(res) { res['value'] if res['displayLabel'] == 'Georeferenced map in EarthWorks' })
+
 # https://opengeometadata.org/ogm-aardvark/#member-of
 # - links items to collections and collections to their items via a box on the show page
 # - a separate 'relations' solr query using this field is performed in the app to render the box

--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -232,7 +232,7 @@ to_field 'gbl_georeferenced_b', cocina_descriptive('relatedResource', 'url'), se
          transform(->(res) { true if res['displayLabel'] == 'Georeferenced Map' })
 
 # https://opengeometadata.org/ogm-aardvark/#relation
-# - we are choosing to use this field to hold the georefereced link if it exists
+# - we are choosing to use this field to hold the georeferenced link if it exists
 to_field 'dct_relation_sm', cocina_descriptive('access', 'url'),
          transform(->(res) { res['value'] if res['displayLabel'] == 'Georeferenced map in EarthWorks' })
 

--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -180,6 +180,7 @@ to_field 'schema_provider_s', literal('Stanford')
 # https://opengeometadata.org/ogm-aardvark/#identifier
 # - we could add other links here if desired
 to_field 'dct_identifier_sm', cocina_descriptive('purl')
+to_field 'dct_identifier_sm', cocina_descriptive('identifier'), extract_values, doi
 
 # https://opengeometadata.org/ogm-aardvark/#resource-class
 # - if the item is a collection, set the resource class to "Collections" (only)

--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -226,7 +226,10 @@ to_field('dcat_bbox') { |_record, accumulator, context| accumulator << context.o
 
 # https://opengeometadata.org/ogm-aardvark/#georeferenced
 # - currently unused in the UI
-to_field('gbl_georeferenced_b') { |_record, accumulator, context| accumulator << true if context.output_hash['dct_title_s'].first.match?(/\(Raster Image\)/) }
+to_field 'gbl_georeferenced_b', cocina_descriptive('access', 'url'),
+         transform(->(res) { true if res['displayLabel'] == 'Georeferenced map in EarthWorks' })
+to_field 'gbl_georeferenced_b', cocina_descriptive('relatedResource', 'url'), select_type('has other format'),
+         transform(->(res) { true if res['displayLabel'] == 'Georeferenced Map' })
 
 # https://opengeometadata.org/ogm-aardvark/#member-of
 # - links items to collections and collections to their items via a box on the show page

--- a/lib/traject/macros/cocina.rb
+++ b/lib/traject/macros/cocina.rb
@@ -32,6 +32,18 @@ module Traject
         end
       end
 
+      def doi
+        lambda do |_record, accumulator, _context|
+          accumulator.each do |node|
+            doi = node['type'] == 'DOI' ||
+                  node['displayLabel'] == 'DOI' ||
+                  (node['source'] && node['source']['code'] == 'doi')
+
+            accumulator << node['value'] if doi
+          end
+        end
+      end
+
       # Generate an embed url for the object, with optional parameters
       def embed_url(params = {})
         lambda do |record, accumulator, context|

--- a/lib/traject/macros/geo.rb
+++ b/lib/traject/macros/geo.rb
@@ -66,6 +66,32 @@ module Traject
         end
       end
 
+      # Assigns "map" or "dataset" to the accumulator based on the presence of those substrings
+      # For example, "Digital Map" "Digital Maps" and "Maps and Atlases" will be assigned "map"
+      # "Dataset#Raster" will be assigned "dataset"
+      # We do not want to remove the original values, so we append our value
+      # (Original values, in addition to these appended values, are used by the translation_map for resource class)
+      def assign_resource_class_values
+        lambda do |_record, accumulator, _context|
+          resource_classes = %w[dataset map]
+
+          accumulator.map! do |value|
+            # Find a matching substring, or return nil if none found
+            matching_substring = resource_classes.find { |substr| value.downcase.include?(substr) }
+
+            if matching_substring
+              [matching_substring, value]
+            else
+              value
+            end
+          end if accumulator.any?
+
+          # Remove neseting, duplicates
+          accumulator.flatten! if accumulator.any?
+          accumulator.uniq! if accumulator.any?
+        end
+      end
+
       private
 
       # Get the right geoserver url for an item given its access rights

--- a/lib/traject/macros/geo.rb
+++ b/lib/traject/macros/geo.rb
@@ -86,7 +86,7 @@ module Traject
             end
           end if accumulator.any?
 
-          # Remove neseting, duplicates
+          # Remove nesting, duplicates
           accumulator.flatten! if accumulator.any?
           accumulator.uniq! if accumulator.any?
         end

--- a/lib/translation_maps/geo_resource_class.yaml
+++ b/lib/translation_maps/geo_resource_class.yaml
@@ -4,10 +4,10 @@
 ## description -> form (type=genre)
 ## subject -> structuredValue (type=genre)
 
+# Note: we detect and manipulate resource class values in Traject::Macros::Geo#assign_resource_class_values
+# Transform our assigned, singular values to plural categories
 map: Maps
-Maps: Maps
-Datasets: Datasets
-Dataset: Datasets
+dataset: Datasets
 
 ## description -> form (type=form)
 
@@ -15,14 +15,6 @@ Dataset: Datasets
 GeoTIFF:
   - Datasets
   - Maps
-
-# Anything with 'dataset' is a dataset
-Dataset#Polygon: Datasets
-Dataset#Point: Datasets
-Dataset#Line: Datasets
-Dataset#Mixed: Datasets
-Dataset#LineString: Datasets
-"Dataset#": Datasets
 
 # Rasters are both datasets and maps
 Raster:

--- a/spec/fixtures/files/df451fk6628.json
+++ b/spec/fixtures/files/df451fk6628.json
@@ -1,0 +1,232 @@
+{
+    "cocinaVersion": "0.75.0",
+    "type": "https://cocina.sul.stanford.edu/models/image",
+    "externalIdentifier": "druid:df451fk6628",
+    "label": "McLaughlin_df451fk6628",
+    "version": 9,
+    "access": {
+        "view": "world",
+        "download": "world",
+        "controlledDigitalLending": false,
+        "copyright": "This work has been identified as being free of known restrictions under copyright law, including all related and neighboring rights. You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.",
+        "useAndReproductionStatement": "Image from the Glen McLaughlin Map Collection of California as an Island courtesy Stanford University Libraries. This item is in the public domain. There are no restrictions on use. If you have questions, please contact the David Rumsey Map Center at rumseymapcenter@stanford.edu.",
+        "license": "https://creativecommons.org/publicdomain/mark/1.0/"
+    },
+    "administrative": {
+        "hasAdminPolicy": "druid:nk327xn8125"
+    },
+    "description": {
+        "title": [
+            {
+                "value": "A Map of Mexico or New Spain Florida now called Louisiana and Part of California & c.",
+                "status": "primary"
+            }
+        ],
+        "contributor": [
+            {
+                "name": [
+                    {
+                        "value": "Moll, Herman, d. 1732.",
+                        "source": {
+                            "code": "local"
+                        }
+                    }
+                ],
+                "type": "person"
+            }
+        ],
+        "event": [
+            {
+                "date": [
+                    {
+                        "value": "1717",
+                        "type": "creation",
+                        "status": "primary",
+                        "encoding": {
+                            "code": "w3cdtf"
+                        },
+                        "qualifier": "questionable"
+                    }
+                ]
+            }
+        ],
+        "form": [
+            {
+                "value": "Early Maps",
+                "type": "genre"
+            },
+            {
+                "value": "Digital Maps",
+                "type": "genre"
+            },
+            {
+                "value": "cartographic",
+                "type": "resource type",
+                "source": {
+                    "value": "MODS resource types"
+                }
+            },
+            {
+                "value": "image/tiff",
+                "type": "media type",
+                "source": {
+                    "value": "IANA media types"
+                }
+            },
+            {
+                "value": "digitized other analog",
+                "type": "digital origin",
+                "source": {
+                    "value": "MODS digital origin terms"
+                }
+            }
+        ],
+        "note": [
+            {
+                "value": "in book: Atlas Geographus: or, a compleat System of Geography, (Ancient and Modern) for America. 1717"
+            },
+            {
+                "value": "Includes bibliographical references (p. xv-xvi) and indexes."
+            },
+            {
+                "value": "Glen McLaughlin with Nancy H. Mayo.",
+                "type": "statement of responsibility",
+                "displayLabel": "Statement of responsibility"
+            }
+        ],
+        "identifier": [
+            {
+                "value": "108-02",
+                "type": "local",
+                "source": {
+                    "code": "local"
+                },
+                "displayLabel": "Original McLaughlin book number (1995 edition) with latest state information"
+            }
+        ],
+        "subject": [
+            {
+                "value": "W 173°00ʹ --W 10°00ʹ/N 84°00ʹ --N 7°10ʹ",
+                "type": "map coordinates"
+            }
+        ],
+        "adminMetadata": {
+            "contributor": [
+                {
+                    "name": [
+                        {
+                            "value": "Lyberteam Metadata ToolKit"
+                        }
+                    ]
+                }
+            ]
+        },
+        "purl": "https://purl.stanford.edu/df451fk6628"
+    },
+    "identification": {
+        "catalogLinks": [
+            {
+                "catalog": "folio",
+                "refresh": true,
+                "catalogRecordId": "a10624817"
+            },
+            {
+                "catalog": "symphony",
+                "refresh": true,
+                "catalogRecordId": "10624817"
+            }
+        ],
+        "sourceId": "sul:10624817-2001"
+    },
+    "structural": {
+        "contains": [
+            {
+                "type": "https://cocina.sul.stanford.edu/models/resources/image",
+                "externalIdentifier": "https://cocina.sul.stanford.edu/fileSet/df451fk6628-df451fk6628_1",
+                "label": "mclaughlin_df451fk6628",
+                "version": 8,
+                "structural": {
+                    "contains": [
+                        {
+                            "type": "https://cocina.sul.stanford.edu/models/file",
+                            "externalIdentifier": "https://cocina.sul.stanford.edu/file/df451fk6628-df451fk6628_1/df451fk6628_05_0001.jp2",
+                            "label": "df451fk6628_05_0001.jp2",
+                            "filename": "df451fk6628_05_0001.jp2",
+                            "size": 3635735,
+                            "version": 8,
+                            "hasMimeType": "image/jp2",
+                            "sdrGeneratedText": false,
+                            "correctedForAccessibility": false,
+                            "hasMessageDigests": [
+                                {
+                                    "type": "sha1",
+                                    "digest": "d7d788405747d09677bf1f695aa65900db383e20"
+                                },
+                                {
+                                    "type": "md5",
+                                    "digest": "2de088bbe7758d74fc8f5c0432c66df8"
+                                }
+                            ],
+                            "access": {
+                                "view": "world",
+                                "download": "world",
+                                "controlledDigitalLending": false
+                            },
+                            "administrative": {
+                                "publish": true,
+                                "sdrPreserve": true,
+                                "shelve": true
+                            },
+                            "presentation": {
+                                "height": 3792,
+                                "width": 5089
+                            }
+                        },
+                        {
+                            "type": "https://cocina.sul.stanford.edu/models/file",
+                            "externalIdentifier": "https://cocina.sul.stanford.edu/file/df451fk6628-df451fk6628_1/df451fk6628_00_0001.tif",
+                            "label": "df451fk6628_00_0001.tif",
+                            "filename": "df451fk6628_00_0001.tif",
+                            "size": 57917516,
+                            "version": 8,
+                            "hasMimeType": "image/tiff",
+                            "sdrGeneratedText": false,
+                            "correctedForAccessibility": false,
+                            "hasMessageDigests": [
+                                {
+                                    "type": "sha1",
+                                    "digest": "195ade5801ff748dad9656979aaebe21f89013a8"
+                                },
+                                {
+                                    "type": "md5",
+                                    "digest": "eec641398fde40ac1625032df3a9a3c7"
+                                }
+                            ],
+                            "access": {
+                                "view": "world",
+                                "download": "world",
+                                "controlledDigitalLending": false
+                            },
+                            "administrative": {
+                                "publish": false,
+                                "sdrPreserve": true,
+                                "shelve": false
+                            },
+                            "presentation": {
+                                "height": 3792,
+                                "width": 5089
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "hasMemberOrders": [],
+        "isMemberOf": [
+            "druid:zb871zd0767"
+        ]
+    },
+    "created": "2022-07-26T23:19:06.000+00:00",
+    "modified": "2024-06-13T06:27:07.000+00:00",
+    "lock": "W/\"druid:df451fk6628=0=1-gzip\""
+}

--- a/spec/fixtures/files/df451fk6628.meta_json
+++ b/spec/fixtures/files/df451fk6628.meta_json
@@ -1,0 +1,5 @@
+{
+    "sitemap": false,
+    "searchworks": false,
+    "earthworks": true
+}

--- a/spec/fixtures/files/gm036df2527.json
+++ b/spec/fixtures/files/gm036df2527.json
@@ -1,0 +1,613 @@
+{
+    "cocinaVersion": "0.75.0",
+    "type": "https://cocina.sul.stanford.edu/models/image",
+    "externalIdentifier": "druid:gm036df2527",
+    "label": "Map of Africa Showing its most Recent Discoveries",
+    "version": 21,
+    "access": {
+        "view": "world",
+        "download": "world",
+        "controlledDigitalLending": false,
+        "copyright": "This work has been identified as being free of known restrictions under copyright law, including all related and neighboring rights. You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.",
+        "useAndReproductionStatement": "Image from the Dr. Oscar I. Norwich collection of maps of Africa and its islands, 1486 - ca. 1865 courtesy Stanford University Libraries. This item is in the public domain. There are no restrictions on use. If you have questions, please contact the David Rumsey Map Center at rumseymapcenter@stanford.edu.",
+        "license": "https://creativecommons.org/publicdomain/mark/1.0/"
+    },
+    "administrative": {
+        "hasAdminPolicy": "druid:ww057vk7675",
+        "releaseTags": [
+            {
+                "who": "lkrueger",
+                "what": "self",
+                "date": "2022-08-17T00:14:52.000+00:00",
+                "to": "Searchworks",
+                "release": true
+            },
+            {
+                "who": "bergeraj",
+                "what": "self",
+                "date": "2023-04-14T00:56:07.000+00:00",
+                "to": "Earthworks",
+                "release": true
+            }
+        ]
+    },
+    "description": {
+        "title": [
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Map of Africa Showing its most Recent Discoveries",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            }
+        ],
+        "contributor": [
+            {
+                "name": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "Mitchell, S. Augustus (Samuel Augustus), 1792-1868",
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "type": "person",
+                "status": "primary",
+                "role": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "creator",
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "identifier": [],
+                "note": [],
+                "parallelContributor": []
+            },
+            {
+                "name": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "Williams, W. (Wellington)",
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "type": "person",
+                "role": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "engraver",
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "identifier": [],
+                "note": [],
+                "parallelContributor": []
+            }
+        ],
+        "event": [
+            {
+                "structuredValue": [],
+                "date": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "1881",
+                        "type": "publication",
+                        "encoding": {
+                            "code": "marc",
+                            "note": []
+                        },
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "contributor": [],
+                "location": [],
+                "identifier": [],
+                "note": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "monographic",
+                        "type": "issuance",
+                        "identifier": [],
+                        "source": {
+                            "value": "MODS issuance terms",
+                            "note": []
+                        },
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "parallelEvent": []
+            }
+        ],
+        "form": [
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "map",
+                "type": "genre",
+                "identifier": [],
+                "source": {
+                    "code": "marcgt",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "cartographic image",
+                "type": "genre",
+                "identifier": [],
+                "source": {
+                    "code": "rdacontent",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Maps",
+                "type": "genre",
+                "identifier": [],
+                "source": {
+                    "code": "lcgft",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "cartographic",
+                "type": "resource type",
+                "identifier": [],
+                "source": {
+                    "value": "MODS resource types",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "map",
+                "type": "form",
+                "identifier": [],
+                "source": {
+                    "code": "marccategory",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "map",
+                "type": "form",
+                "identifier": [],
+                "source": {
+                    "code": "marcsmd",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "unmediated",
+                "type": "media",
+                "identifier": [],
+                "source": {
+                    "code": "rdamedia",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "sheet",
+                "type": "carrier",
+                "identifier": [],
+                "source": {
+                    "code": "rdacarrier",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1 map ; 27 x 34 cm",
+                "type": "extent",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Scale in miles",
+                "type": "map scale",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            }
+        ],
+        "geographic": [],
+        "language": [],
+        "note": [
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "\"First appeared in Mitchell's New General Atlas in 1867\". Map shows expedition routes of\n        Stanley and Livingstone. Inset: Island of St. Helena (place where Napoleon was buried). Top\n        right: 120; Prime meridian through Washington.",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Colored",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Dr. Oscar I. Norwich",
+                "type": "acquisition",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "David Rumsey Map Center copy 1: Norwich no. NOR\n        0146.",
+                "type": "local",
+                "identifier": [],
+                "displayLabel": "Local note",
+                "note": [],
+                "appliesTo": []
+            }
+        ],
+        "identifier": [],
+        "subject": [
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Africa--Maps",
+                "type": "place",
+                "identifier": [],
+                "source": {
+                    "code": "lcsh",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "G8200 1881 .M5",
+                "type": "classification",
+                "identifier": [],
+                "source": {
+                    "code": "lcc",
+                    "note": []
+                },
+                "note": [],
+                "appliesTo": []
+            },
+            {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "W 18°--E 51°/N 37°--S 35°",
+                "type": "map coordinates",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+            }
+        ],
+        "access": {
+            "url": [
+                {
+                    "structuredValue": [],
+                    "parallelValue": [],
+                    "groupedValue": [],
+                    "value": "https://searchworks.stanford.edu/view/px984sn6906",
+                    "identifier": [],
+                    "displayLabel": "Georeferenced map in SearchWorks",
+                    "note": [],
+                    "appliesTo": []
+                },
+                {
+                    "structuredValue": [],
+                    "parallelValue": [],
+                    "groupedValue": [],
+                    "value": "https://earthworks.stanford.edu/catalog/stanford-px984sn6906",
+                    "identifier": [],
+                    "displayLabel": "Georeferenced map in EarthWorks",
+                    "note": [],
+                    "appliesTo": []
+                }
+            ],
+            "physicalLocation": [],
+            "digitalLocation": [],
+            "accessContact": [],
+            "digitalRepository": [],
+            "note": []
+        },
+        "relatedResource": [
+            {
+                "type": "referenced by",
+                "title": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "Norwich, I., Pam Kolbe, and Jeffrey C Stone. Norwich's Maps of Africa: An\n            Illustrated and Annotated Carto-Bibliography. 2nd ed. / rev. and edited by Jeffrey C.\n            Stone. Norwich, Vt.: Terra Nova Press, 1997, map 0146, p. 165",
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "contributor": [],
+                "event": [],
+                "form": [],
+                "language": [],
+                "note": [],
+                "identifier": [],
+                "subject": [],
+                "relatedResource": []
+            },
+            {
+                "type": "has other format",
+                "displayLabel": "Georeferenced Map",
+                "title": [
+                    {
+                        "structuredValue": [],
+                        "parallelValue": [],
+                        "groupedValue": [],
+                        "value": "Map of Africa Showing its most Recent Discoveries (Raster Image)",
+                        "identifier": [],
+                        "note": [],
+                        "appliesTo": []
+                    }
+                ],
+                "contributor": [],
+                "event": [],
+                "form": [],
+                "language": [],
+                "note": [],
+                "identifier": [],
+                "subject": [],
+                "relatedResource": []
+            }
+        ],
+        "marcEncodedData": [],
+        "adminMetadata": {
+            "contributor": [
+                {
+                    "name": [
+                        {
+                            "structuredValue": [],
+                            "parallelValue": [],
+                            "groupedValue": [],
+                            "code": "CSt",
+                            "identifier": [],
+                            "source": {
+                                "code": "marcorg",
+                                "note": []
+                            },
+                            "note": [],
+                            "appliesTo": []
+                        }
+                    ],
+                    "type": "organization",
+                    "role": [
+                        {
+                            "structuredValue": [],
+                            "parallelValue": [],
+                            "groupedValue": [],
+                            "value": "original cataloging agency",
+                            "identifier": [],
+                            "note": [],
+                            "appliesTo": []
+                        }
+                    ],
+                    "identifier": [],
+                    "note": [],
+                    "parallelContributor": []
+                }
+            ],
+            "event": [
+                {
+                    "structuredValue": [],
+                    "type": "modification",
+                    "date": [
+                        {
+                            "structuredValue": [],
+                            "parallelValue": [],
+                            "groupedValue": [],
+                            "value": "20170805011746.0",
+                            "encoding": {
+                                "code": "iso8601",
+                                "note": []
+                            },
+                            "identifier": [],
+                            "note": [],
+                            "appliesTo": []
+                        }
+                    ],
+                    "contributor": [],
+                    "location": [],
+                    "identifier": [],
+                    "note": [],
+                    "parallelEvent": []
+                }
+            ],
+            "language": [
+                {
+                    "appliesTo": [],
+                    "code": "eng",
+                    "groupedValue": [],
+                    "note": [],
+                    "parallelValue": [],
+                    "source": {
+                        "code": "iso639-2b",
+                        "note": []
+                    },
+                    "structuredValue": []
+                }
+            ],
+            "note": [
+                {
+                    "structuredValue": [],
+                    "parallelValue": [],
+                    "groupedValue": [],
+                    "value": "Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl\n          (Version 1.2.5 2013/08/11)",
+                    "type": "record origin",
+                    "identifier": [],
+                    "note": [],
+                    "appliesTo": []
+                }
+            ],
+            "metadataStandard": [],
+            "identifier": [
+                {
+                    "structuredValue": [],
+                    "parallelValue": [],
+                    "groupedValue": [],
+                    "value": "a12113468",
+                    "type": "SIRSI",
+                    "identifier": [],
+                    "note": [],
+                    "appliesTo": []
+                }
+            ]
+        },
+        "purl": "https://purl.stanford.edu/gm036df2527"
+    },
+    "identification": {
+        "catalogLinks": [
+            {
+                "catalog": "folio",
+                "refresh": true,
+                "catalogRecordId": "a12113468"
+            },
+            {
+                "catalog": "symphony",
+                "refresh": true,
+                "catalogRecordId": "12113468"
+            }
+        ],
+        "sourceId": "sul:MOA0175"
+    },
+    "structural": {
+        "contains": [
+            {
+                "type": "https://cocina.sul.stanford.edu/models/resources/image",
+                "externalIdentifier": "https://cocina.sul.stanford.edu/fileSet/gm036df2527-http://cocina.sul.stanford.edu/fileSet/202c6b5e-4cf5-4ef6-9910-58ba15e19c4f",
+                "label": "Image 1",
+                "version": 20,
+                "structural": {
+                    "contains": [
+                        {
+                            "type": "https://cocina.sul.stanford.edu/models/file",
+                            "externalIdentifier": "https://cocina.sul.stanford.edu/file/gm036df2527-202c6b5e-4cf5-4ef6-9910-58ba15e19c4f/AM_0100.jp2",
+                            "label": "AM_0100.jp2",
+                            "filename": "AM_0100.jp2",
+                            "size": 12359006,
+                            "version": 20,
+                            "hasMimeType": "image/jp2",
+                            "hasMessageDigests": [
+                                {
+                                    "type": "sha1",
+                                    "digest": "0f7d4f121a706faf849d312d86158af8419474fc"
+                                },
+                                {
+                                    "type": "md5",
+                                    "digest": "cc4e737b7c056b1c19991bc44bbbbb77"
+                                }
+                            ],
+                            "access": {
+                                "view": "world",
+                                "download": "world",
+                                "controlledDigitalLending": false
+                            },
+                            "administrative": {
+                                "publish": true,
+                                "sdrPreserve": false,
+                                "shelve": true
+                            },
+                            "presentation": {
+                                "height": 7557,
+                                "width": 8686
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "hasMemberOrders": [],
+        "isMemberOf": [
+            "druid:qb438pg7646"
+        ]
+    },
+    "created": "2022-07-26T23:22:32.000+00:00",
+    "modified": "2022-07-26T23:22:32.000+00:00",
+    "lock": "druid:gm036df2527=0"
+}

--- a/spec/fixtures/files/gm036df2527.meta_json
+++ b/spec/fixtures/files/gm036df2527.meta_json
@@ -1,0 +1,5 @@
+{
+    "sitemap": false,
+    "searchworks": true,
+    "earthworks": true
+}

--- a/spec/fixtures/files/rk962wd2562.json
+++ b/spec/fixtures/files/rk962wd2562.json
@@ -1,0 +1,512 @@
+{
+    "cocinaVersion": "0.75.0",
+    "type": "https://cocina.sul.stanford.edu/models/image",
+    "externalIdentifier": "druid:rk962wd2562",
+    "label": "TABVLA  PRI   MA ASIE",
+    "version": 15,
+    "access": {
+        "view": "world",
+        "download": "world",
+        "controlledDigitalLending": false,
+        "copyright": "This work has been identified as being free of known restrictions under copyright law, including all related and neighboring rights. You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.",
+        "useAndReproductionStatement": "Images from the The Renaissance Exploration Collection courtesy Stanford University Libraries. This item is in the public domain. There are no restrictions on use. If you have questions, please contact the David Rumsey Map Center at rumseymapcenter@stanford.edu.",
+        "license": "https://creativecommons.org/publicdomain/mark/1.0/"
+    },
+    "administrative": {
+        "hasAdminPolicy": "druid:gv774qv8440"
+    },
+    "description": {
+        "title": [
+            {
+                "value": "Tabula prima Asie"
+            },
+            {
+                "value": "Tabvla prima Asie",
+                "type": "alternative"
+            }
+        ],
+        "contributor": [
+            {
+                "name": [
+                    {
+                        "structuredValue": [
+                            {
+                                "value": "Ptolemy",
+                                "type": "name"
+                            },
+                            {
+                                "value": "active 2nd century",
+                                "type": "activity dates"
+                            }
+                        ]
+                    }
+                ],
+                "type": "person",
+                "status": "primary"
+            },
+            {
+                "name": [
+                    {
+                        "structuredValue": [
+                            {
+                                "value": "Waldseemüller, Martin",
+                                "type": "name"
+                            },
+                            {
+                                "value": "1470-1519",
+                                "type": "life dates"
+                            }
+                        ]
+                    }
+                ],
+                "type": "person",
+                "role": [
+                    {
+                        "value": "editor."
+                    }
+                ]
+            },
+            {
+                "name": [
+                    {
+                        "structuredValue": [
+                            {
+                                "value": "Schott, Johann",
+                                "type": "name"
+                            },
+                            {
+                                "value": "1477-1548",
+                                "type": "life dates"
+                            }
+                        ]
+                    }
+                ],
+                "type": "person",
+                "role": [
+                    {
+                        "value": "publisher."
+                    }
+                ]
+            },
+            {
+                "name": [
+                    {
+                        "value": "Essler, Jacob."
+                    }
+                ],
+                "type": "person"
+            },
+            {
+                "name": [
+                    {
+                        "structuredValue": [
+                            {
+                                "value": "Übelin, Georg",
+                                "type": "name"
+                            },
+                            {
+                                "value": "active 15th century-16th century",
+                                "type": "activity dates"
+                            }
+                        ]
+                    }
+                ],
+                "type": "person"
+            }
+        ],
+        "event": [
+            {
+                "date": [
+                    {
+                        "value": "1513]",
+                        "type": "publication"
+                    },
+                    {
+                        "value": "1513",
+                        "type": "publication",
+                        "encoding": {
+                            "code": "marc"
+                        }
+                    }
+                ],
+                "contributor": [
+                    {
+                        "name": [
+                            {
+                                "value": "Johannes Schott"
+                            }
+                        ],
+                        "type": "organization",
+                        "role": [
+                            {
+                                "value": "publisher",
+                                "code": "pbl",
+                                "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+                                "source": {
+                                    "code": "marcrelator",
+                                    "uri": "http://id.loc.gov/vocabulary/relators/"
+                                }
+                            }
+                        ]
+                    }
+                ],
+                "location": [
+                    {
+                        "value": "[Strasbourg"
+                    },
+                    {
+                        "code": "fr",
+                        "source": {
+                            "code": "marccountry"
+                        }
+                    }
+                ],
+                "note": [
+                    {
+                        "value": "monographic",
+                        "type": "issuance",
+                        "source": {
+                            "value": "MODS issuance terms"
+                        }
+                    }
+                ]
+            }
+        ],
+        "form": [
+            {
+                "value": "map",
+                "type": "genre",
+                "source": {
+                    "code": "marcgt"
+                }
+            },
+            {
+                "value": "cartographic",
+                "type": "resource type",
+                "source": {
+                    "value": "MODS resource types"
+                }
+            },
+            {
+                "value": "electronic",
+                "type": "form",
+                "source": {
+                    "code": "marcform"
+                }
+            },
+            {
+                "value": "1 map : woodcut ; 38 x 52 cm",
+                "type": "extent"
+            },
+            {
+                "value": "Scale not given",
+                "type": "map scale"
+            }
+        ],
+        "language": [
+            {
+                "code": "lat",
+                "source": {
+                    "code": "iso639-2b"
+                }
+            }
+        ],
+        "note": [
+            {
+                "value": "Relief shown pictorially."
+            },
+            {
+                "value": "Trapezoidal."
+            },
+            {
+                "value": "Geographical numbers, climate demarcations, and linear parallels indicated along margins."
+            },
+            {
+                "value": "Title at top."
+            },
+            {
+                "value": "Shows topography, waterways, ports."
+            },
+            {
+                "value": "Appears in Waldseemüller's edition of Ptolemy's Geographia, Strasbourg: Johannes Schott, 1513."
+            },
+            {
+                "value": "This copy has pencil inscription in lower left: 218.",
+                "type": "local",
+                "displayLabel": "Local note"
+            },
+            {
+                "value": "Watermark.",
+                "type": "local",
+                "displayLabel": "Local note"
+            }
+        ],
+        "subject": [
+            {
+                "structuredValue": [
+                    {
+                        "value": "Europe",
+                        "type": "place"
+                    },
+                    {
+                        "value": "Maps",
+                        "type": "genre"
+                    },
+                    {
+                        "value": "Early works to 1800",
+                        "type": "genre"
+                    }
+                ],
+                "source": {
+                    "code": "lcsh"
+                }
+            },
+            {
+                "structuredValue": [
+                    {
+                        "value": "Anatolia (Turkey)",
+                        "type": "place"
+                    },
+                    {
+                        "value": "Maps",
+                        "type": "genre"
+                    },
+                    {
+                        "value": "Early works to 1800",
+                        "type": "genre"
+                    }
+                ],
+                "source": {
+                    "code": "lcsh"
+                }
+            },
+            {
+                "value": "E 25°19'00\"--E 39°33'00\"/N 43°03'00\"--N 35°19'00\").",
+                "type": "map coordinates"
+            }
+        ],
+        "access": {
+            "note": [
+                {
+                    "value": "electronic resource",
+                    "type": "display label",
+                    "appliesTo": [
+                        {
+                            "value": "purl"
+                        }
+                    ]
+                }
+            ]
+        },
+        "relatedResource": [
+            {
+                "type": "referenced by",
+                "title": [
+                    {
+                        "value": "Tooley"
+                    }
+                ],
+                "note": [
+                    {
+                        "value": "A-D: 11; Q-Z: 130, 299, 344"
+                    }
+                ]
+            },
+            {
+                "type": "part of",
+                "title": [
+                    {
+                        "value": "Geographia"
+                    }
+                ],
+                "event": [
+                    {
+                        "contributor": [
+                            {
+                                "name": [
+                                    {
+                                        "value": "Strasbourg: Johannes Schott, 1513"
+                                    }
+                                ],
+                                "type": "organization",
+                                "role": [
+                                    {
+                                        "value": "publisher",
+                                        "code": "pbl",
+                                        "uri": "http://id.loc.gov/vocabulary/relators/pbl",
+                                        "source": {
+                                            "code": "marcrelator",
+                                            "uri": "http://id.loc.gov/vocabulary/relators/"
+                                        }
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "form": [
+                    {
+                        "value": "atlas",
+                        "type": "extent"
+                    }
+                ]
+            }
+        ],
+        "adminMetadata": {
+            "contributor": [
+                {
+                    "name": [
+                        {
+                            "code": "CSt-ES",
+                            "source": {
+                                "code": "marcorg"
+                            }
+                        }
+                    ],
+                    "type": "organization",
+                    "role": [
+                        {
+                            "value": "original cataloging agency"
+                        }
+                    ]
+                }
+            ],
+            "event": [
+                {
+                    "type": "creation",
+                    "date": [
+                        {
+                            "value": "140805",
+                            "encoding": {
+                                "code": "marc"
+                            }
+                        }
+                    ]
+                }
+            ],
+            "note": [
+                {
+                    "value": "Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)",
+                    "type": "record origin"
+                }
+            ],
+            "metadataStandard": [
+                {
+                    "code": "aacr"
+                }
+            ],
+            "identifier": [
+                {
+                    "value": "a10366695"
+                }
+            ]
+        },
+        "purl": "https://purl.stanford.edu/rk962wd2562"
+    },
+    "identification": {
+        "catalogLinks": [
+            {
+                "catalog": "folio",
+                "refresh": true,
+                "catalogRecordId": "a10366695"
+            },
+            {
+                "catalog": "symphony",
+                "refresh": true,
+                "catalogRecordId": "10366695"
+            }
+        ],
+        "sourceId": "renaissance:218"
+    },
+    "structural": {
+        "contains": [
+            {
+                "type": "https://cocina.sul.stanford.edu/models/resources/image",
+                "externalIdentifier": "https://cocina.sul.stanford.edu/fileSet/rk962wd2562-http://cocina.sul.stanford.edu/fileSet/37a52fd3-91fc-4048-9b79-b875dd942ac9",
+                "label": "Image 1",
+                "version": 15,
+                "structural": {
+                    "contains": [
+                        {
+                            "type": "https://cocina.sul.stanford.edu/models/file",
+                            "externalIdentifier": "https://cocina.sul.stanford.edu/file/rk962wd2562-37a52fd3-91fc-4048-9b79-b875dd942ac9/rk962wd2562_00_0001.tif",
+                            "label": "rk962wd2562_00_0001.tif",
+                            "filename": "rk962wd2562_00_0001.tif",
+                            "size": 221246844,
+                            "version": 15,
+                            "hasMimeType": "image/tiff",
+                            "sdrGeneratedText": false,
+                            "correctedForAccessibility": false,
+                            "hasMessageDigests": [
+                                {
+                                    "type": "sha1",
+                                    "digest": "4e671ab1b70b64dbf79b140a3990f5384c258474"
+                                },
+                                {
+                                    "type": "md5",
+                                    "digest": "5cb83e6f68e15a236a9483480aaa1c87"
+                                }
+                            ],
+                            "access": {
+                                "view": "world",
+                                "download": "world",
+                                "controlledDigitalLending": false
+                            },
+                            "administrative": {
+                                "publish": false,
+                                "sdrPreserve": true,
+                                "shelve": false
+                            },
+                            "presentation": {
+                                "height": 7293,
+                                "width": 10111
+                            }
+                        },
+                        {
+                            "type": "https://cocina.sul.stanford.edu/models/file",
+                            "externalIdentifier": "https://cocina.sul.stanford.edu/file/rk962wd2562-37a52fd3-91fc-4048-9b79-b875dd942ac9/rk962wd2562_00_0001.jp2",
+                            "label": "rk962wd2562_00_0001.jp2",
+                            "filename": "rk962wd2562_00_0001.jp2",
+                            "size": 13899770,
+                            "version": 15,
+                            "hasMimeType": "image/jp2",
+                            "sdrGeneratedText": false,
+                            "correctedForAccessibility": false,
+                            "hasMessageDigests": [
+                                {
+                                    "type": "sha1",
+                                    "digest": "e67ba330d976b767cd77032fe10ff819f5973af5"
+                                },
+                                {
+                                    "type": "md5",
+                                    "digest": "c54010c9d7d25459fa309c9a2434779e"
+                                }
+                            ],
+                            "access": {
+                                "view": "world",
+                                "download": "world",
+                                "controlledDigitalLending": false
+                            },
+                            "administrative": {
+                                "publish": true,
+                                "sdrPreserve": false,
+                                "shelve": true
+                            },
+                            "presentation": {
+                                "height": 7293,
+                                "width": 10111
+                            }
+                        }
+                    ]
+                }
+            }
+        ],
+        "hasMemberOrders": [],
+        "isMemberOf": [
+            "druid:sr605np6062"
+        ]
+    },
+    "created": "2022-04-30T09:18:53.000+00:00",
+    "modified": "2024-06-13T04:52:13.000+00:00",
+    "lock": "W/\"druid:rk962wd2562=0=1-gzip\""
+}

--- a/spec/fixtures/files/rk962wd2562.meta_json
+++ b/spec/fixtures/files/rk962wd2562.meta_json
@@ -1,0 +1,5 @@
+{
+    "sitemap": false,
+    "searchworks": true,
+    "earthworks": true
+}

--- a/spec/integration/geo_aardvark_config_spec.rb
+++ b/spec/integration/geo_aardvark_config_spec.rb
@@ -175,6 +175,13 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     end
   end
 
+  context 'with contributor names that are structuredValues' do
+    let(:druid) { 'rk962wd2562' }
+    it 'maps the creators' do
+      expect(result['dct_creator_sm']).to eq ['Ptolemy, active 2nd century', 'Waldseemüller, Martin, 1470-1519', 'Schott, Johann, 1477-1548', 'Übelin, Georg, active 15th century-16th century']
+    end
+  end
+
   context 'with a shapefile with unzipped metadata (not released to searchworks)' do
     let(:druid) { 'bc559yb0972' }
 

--- a/spec/integration/geo_aardvark_config_spec.rb
+++ b/spec/integration/geo_aardvark_config_spec.rb
@@ -286,6 +286,10 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     it 'maps the source map' do
       expect(result['dct_source_sm']).to eq ['stanford-df334jk2963']
     end
+
+    it 'does not populate dct_relation_sm' do
+      expect(result['dct_relation_sm']).to be_nil
+    end
   end
 
   context 'with a scanned map that has a georeferenced map' do
@@ -293,6 +297,10 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
 
     it 'maps the georeferenced status' do
       expect(result['gbl_georeferenced_b']).to eq true
+    end
+
+    it 'populates the link to the georeferenced map in dct_relation_sm' do
+      expect(result['dct_relation_sm']).to eq ['https://earthworks.stanford.edu/catalog/stanford-px984sn6906']
     end
   end
 

--- a/spec/integration/geo_aardvark_config_spec.rb
+++ b/spec/integration/geo_aardvark_config_spec.rb
@@ -264,6 +264,7 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     let(:druid) { 'kd514jp1398' }
 
     it 'maps the resource class' do
+      # Dataset#Raster has "Maps" added in the translation_map step
       expect(result['gbl_resourceClass_sm']).to eq %w[Datasets Maps]
     end
 
@@ -277,6 +278,14 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
 
     it 'maps the source map' do
       expect(result['dct_source_sm']).to eq ['stanford-df334jk2963']
+    end
+  end
+
+  context 'with metadata that has "Digital Map" as its form>genre metadata' do
+    let(:druid) { 'df451fk6628' }
+
+    it 'maps the resource class to Map' do
+      expect(result['gbl_resourceClass_sm']).to eq ['Maps']
     end
   end
 

--- a/spec/integration/geo_aardvark_config_spec.rb
+++ b/spec/integration/geo_aardvark_config_spec.rb
@@ -215,6 +215,13 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     end
   end
 
+  context 'with a DOI and a Purl' do
+    let(:druid) { 'fk339wc1276' }
+    it 'finds the DOI and appends it to dct_identifier_sm with the purl' do
+      expect(result['dct_identifier_sm']).to eq ["https://purl.stanford.edu/#{druid}", "https://doi.org/10.25740/#{druid}"]
+    end
+  end
+
   context 'with a scanned map' do
     let(:druid) { 'dc482zx1528' }
 

--- a/spec/integration/geo_aardvark_config_spec.rb
+++ b/spec/integration/geo_aardvark_config_spec.rb
@@ -267,7 +267,7 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     end
   end
 
-  context 'with a scanned map that was georeferenced' do
+  context 'with the georeferenced map version of a scanned map' do
     let(:druid) { 'kd514jp1398' }
 
     it 'maps the resource class' do
@@ -280,11 +280,19 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     end
 
     it 'maps the georeferenced status' do
-      expect(result['gbl_georeferenced_b']).to eq true
+      expect(result['gbl_georeferenced_b']).to be_nil
     end
 
     it 'maps the source map' do
       expect(result['dct_source_sm']).to eq ['stanford-df334jk2963']
+    end
+  end
+
+  context 'with a scanned map that has a georeferenced map' do
+    let(:druid) { 'gm036df2527' }
+
+    it 'maps the georeferenced status' do
+      expect(result['gbl_georeferenced_b']).to eq true
     end
   end
 


### PR DESCRIPTION
Closes https://github.com/sul-dlss/earthworks/issues/1114

Addresses items 1 and 2.

Partially addresses item 3 (add the DOI to the data but doesn't display it), it is now stored in the index.

Addresses 4 (the boolean `gbl_georeferenced_b` field).
Also adds `dct_realtion_sm` to hold the link as requested.