### PR TITLE
Geo Aardvark: Use hash variant to store downloadUrl in dct_references_s

### DIFF
--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -287,7 +287,15 @@ to_field('gbl_wxsIdentifier_s') { |record, accumulator| accumulator << "druid:#{
 # - if XML metadata files exist (not in data.zip), we link them
 # - data that is in geoJSON format (including index maps) gets a link to the spec
 to_field 'dct_references_s', purl_url, as_reference('http://schema.org/url')
-to_field 'dct_references_s', stacks_object_url, as_reference('http://schema.org/downloadUrl')
+# Create a hash verion of downloadUrl so that we always have a label for display without relying on dct_format_s
+# See https://github.com/geoblacklight/geoblacklight/blob/9ce0dccdc2336dad520dfc0578743b20d421b0f6/app/components/geoblacklight/download_links_component.html.erb#L12
+# Also see https://opengeometadata.org/configure-references-links/#multiple-downloads
+to_field 'dct_references_s', stacks_object_url, transform(lambda { |url|
+  [{
+    url:,
+    label: 'Zipped object'
+  }]
+}), as_reference('http://schema.org/downloadUrl')
 to_field 'dct_references_s', embed_url({ hide_title: true }), as_reference('https://oembed.com')
 to_field 'dct_references_s', iiif_manifest_url, as_reference('http://iiif.io/api/presentation#manifest')
 to_field 'dct_references_s', wms_url, as_reference('http://www.opengis.net/def/serviceType/ogc/wms')

--- a/spec/integration/geo_aardvark_config_spec.rb
+++ b/spec/integration/geo_aardvark_config_spec.rb
@@ -173,6 +173,10 @@ RSpec.describe 'EarthWorks Aardvark indexing' do
     it 'maps the searchworks URL when released to searchworks' do
       expect(references['https://schema.org/relatedLink']).to eq 'https://searchworks.stanford.edu/view/vv853br8653'
     end
+
+    it 'maps the downloadUrl as an array of objects with url and label' do
+      expect(references['http://schema.org/downloadUrl']).to eq [{ 'label' => 'Zipped object', 'url' => 'https://stacks.stanford.edu/object/vv853br8653' }]
+    end
   end
 
   context 'with contributor names that are structuredValues' do


### PR DESCRIPTION
Closes https://github.com/sul-dlss/earthworks/issues/1127

I tested this by modifying one of the geoblacklight fixtures to have this format, and checking the UI. 

<img width="348" alt="Screenshot 2024-08-12 at 16 36 18" src="https://github.com/user-attachments/assets/d86625aa-434e-4eac-9cba-26a7dd0a69d2">


