### PR TITLE
Stop indexing unneeded stanford_rights_metadata_s field

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -390,9 +390,6 @@ to_field 'hashed_id_ssi' do |_record, accumulator, context|
 end
 
 to_field 'dct_provenance_s', literal('Stanford')
-to_field 'stanford_rights_metadata_s' do |record, accumulator|
-  accumulator << record.rights_xml
-end
 
 to_field 'stanford_license_s' do |record, accumulator|
   field = record.mods_display.accessCondition.find { |x| x.label == 'License:' }

--- a/spec/integration/geo_config_spec.rb
+++ b/spec/integration/geo_config_spec.rb
@@ -45,10 +45,6 @@ RSpec.describe 'EarthWorks indexing' do
       expect(result['solr_geom']).to eq 'ENVELOPE(138.523426, 138.630362, 036.656354, 036.597519)'
     end
 
-    it 'contains rights metadata' do
-      expect(result['stanford_rights_metadata_s']).to include(/<rightsMetadata>/)
-    end
-
     it 'contains creator metadata' do
       expect(result['dc_creator_sm']).to include('Kikyōya Genkichi', '桔梗屋源吉')
     end
@@ -163,10 +159,6 @@ RSpec.describe 'EarthWorks indexing' do
 
     it 'contains dct_issued_s' do
       expect(result).to include 'dct_issued_s' => ['2009']
-    end
-
-    it 'contains rights metadata' do
-      expect(result['stanford_rights_metadata_s']).to include(/<rightsMetadata>/)
     end
 
     it 'contains dc_language_s' do


### PR DESCRIPTION
It is no longer needed since https://github.com/sul-dlss/earthworks/commit/8c9226a53ba5fcee1907162d9cd0f6d89006b300