### PR TITLE
Stop indexing unused fields for geo objects

### DIFF
--- a/lib/traject/config/geo_config.rb
+++ b/lib/traject/config/geo_config.rb
@@ -394,41 +394,6 @@ to_field 'stanford_rights_metadata_s' do |record, accumulator|
   accumulator << record.rights_xml
 end
 
-to_field 'stanford_license_s' do |record, accumulator|
-  field = record.mods_display.accessCondition.find { |x| x.label == 'License:' }
-
-  if field
-    accumulator << field.values.first.to_s
-  else
-    statement = record.public_xml_doc.xpath(
-      '//rightsMetadata/use/human[@type="creativeCommons" or @type="openDataCommons"]'
-    ).first
-    accumulator << statement.content if statement
-  end
-end
-
-to_field 'stanford_use_and_reproduction_s' do |record, accumulator|
-  field = record.mods_display.accessCondition.find { |x| x.label == 'Use and reproduction:' }
-
-  if field
-    accumulator << field.values.first.to_s
-  else
-    statement = record.public_xml_doc.xpath('//rightsMetadata/use/human[@type="useAndReproduction"]').first
-    accumulator << statement.content if statement
-  end
-end
-
-to_field 'stanford_copyright_s' do |record, accumulator|
-  field = record.mods_display.accessCondition.find { |x| x.label == 'Copyright:' }
-
-  if field
-    accumulator << field.values.first.to_s
-  else
-    statement = record.public_xml_doc.xpath('//rightsMetadata/copyright').first
-    accumulator << statement.content if statement
-  end
-end
-
 to_field 'solr_year_i' do |record, accumulator|
   subject_dates = record.stanford_mods.subject.temporal.map { |t| Mods::Date.from_element(t) }
   subject_year = subject_dates.map { |x| x&.as_range&.first&.year }.compact.min

--- a/spec/integration/geo_config_spec.rb
+++ b/spec/integration/geo_config_spec.rb
@@ -89,18 +89,6 @@ RSpec.describe 'EarthWorks indexing' do
     end
   end
 
-  context 'with rights information in the MODS' do
-    let(:druid) { 'ny179kk3075' }
-
-    it 'parses out the rights information into fields' do
-      expect(result).to include(
-        'stanford_license_s' => include(/This work is in the public domain/),
-        'stanford_use_and_reproduction_s' => include(/Image from the Map Collections courtesy Stanford University/),
-        'stanford_copyright_s' => include(/This work has been identified as being/)
-      )
-    end
-  end
-
   context 'with geo content' do
     let(:druid) { 'vv853br8653' }
 


### PR DESCRIPTION
Removes stanford_license_s, stanford_use_and_reproduction_s, and stanford_copyright_s