### PR TITLE
Re-enable cyrillic encoding cleanup

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -6,8 +6,7 @@ require_relative '../config/boot'
 module Utils
   def self.encoding_cleanup(value)
     # cleans up cyrlic encoding i︠a︡ to i͡a
-    # value.gsub(/\ufe20(.{1,2})\ufe21/, "\u0361\\1")
-    value
+    value.gsub(/\ufe20(.{1,2})\ufe21/, "\u0361\\1")
   end
 
   def self.balance_parentheses(string)

--- a/spec/lib/utils_spec.rb
+++ b/spec/lib/utils_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 
 RSpec.describe Utils do
-  xdescribe '.encoding_cleanup' do
+  describe '.encoding_cleanup' do
     it 'encodes cyrilic correctly' do
       expect(described_class.encoding_cleanup('Strategii︠a︡ planirovanii︠a︡ izbiratelʹnoĭ kampanii')).to eq('Strategii͡a planirovanii͡a izbiratelʹnoĭ kampanii')
     end


### PR DESCRIPTION
Attempts to fix https://github.com/sul-dlss/SearchWorks/issues/4010. I think we should merge this and run a full reindex in -test and take a look at the results to see if it breaks anything 🤷‍♂️ 

