### PR TITLE
Generate Sudoc shelfkeys

### DIFF
--- a/lib/call_numbers/other_shelfkey.rb
+++ b/lib/call_numbers/other_shelfkey.rb
@@ -15,8 +15,6 @@ module CallNumbers
 
     # this transfomation only applies when generating shelfkeys
     def shelfkey_scheme
-      return 'sudoc' if scheme == 'SUDOC'
-
       'other'
     end
   end

--- a/lib/call_numbers/sudoc_shelfkey.rb
+++ b/lib/call_numbers/sudoc_shelfkey.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+module CallNumbers
+  class SudocShelfkey < ShelfkeyBase
+    DELIMITER_PRECEDENCE = {
+      ':' => 'a',
+      '.' => 'b',
+      ';' => 'c',
+      '/' => 'd',
+      '+' => 'e'
+    }.freeze
+
+    TYPE_PRECEDENCE = {
+      alphabetic: 'q',
+      year: 'r',
+      numeric: 's'
+    }.freeze
+
+    def forward
+      [
+        'sudoc',
+        pad(parsed[:agency]&.downcase, by: 3),
+        pad_all_digits(parsed[:class_num]),
+        normalize_remainder(parsed[:remainder])
+      ].filter_map(&:presence).join(' ').strip
+    end
+
+    private
+
+    def parsed
+      @parsed ||= /
+        ^\s*(?:\[[^\]]+\]\s*)?
+        (?<agency>[A-Z]+)\s*
+        (?<class_num>\d+)
+        (?<remainder>.*)
+      /ix.match(base_call_number)
+
+      @parsed ||= {}
+    end
+
+    def normalize_remainder(remainder)
+      return nil unless remainder.present?
+
+      tokens = tokenize_remainder(remainder.downcase)
+      previous_token = nil
+
+      result = tokens.filter_map do |token|
+        normalized_token = normalize_token(token, previous_token)
+        previous_token = token
+        normalized_token
+      end.join(' ')
+
+      terminate_remainder(result)
+    end
+
+    def tokenize_remainder(remainder)
+      remainder.scan(%r{[:.;/+\s]|[^:.;/+\s]+})
+    end
+
+    # This assists reverse dealing with arbitrary length strings
+    def terminate_remainder(remainder)
+      "#{remainder} !"
+    end
+
+    def with_type_prefix(type, value)
+      "#{TYPE_PRECEDENCE[type]}#{value}"
+    end
+
+    def normalize_token(token, previous_token = nil)
+      return nil if /^\s*$/.match?(token)
+
+      case token
+      when ->(t) { DELIMITER_PRECEDENCE.key?(t) }
+        DELIMITER_PRECEDENCE[token]
+      when /^\d+-\d+$/
+        normalize_number_range(token, previous_token)
+      when /^\d+-[a-z]+$/, /^[a-z]+-\d+$/
+        normalize_mixed_range(token, previous_token)
+      when /^\d{3,4}$/
+        normalize_potential_year(token, previous_token)
+      when /^\d+$/
+        with_type_prefix(:numeric, pad_all_digits(token))
+      else
+        with_type_prefix(:alphabetic, pad_all_digits(token))
+      end
+    end
+
+    def normalize_potential_year(token, previous_token)
+      if possible_year?(token, previous_token)
+        with_type_prefix(:year, four_digit_year_string(token))
+      else
+        with_type_prefix(:numeric, pad_all_digits(token))
+      end
+    end
+
+    def normalize_mixed_range(token, previous_token)
+      range_start, range_end = token.split('-')
+      [normalize_token(range_start, previous_token), normalize_token(range_end, '-')].join
+    end
+
+    def normalize_number_range(token, previous_token)
+      range_start, range_end = token.split('-')
+      if year_range?(range_start, range_end)
+        with_type_prefix(:year, "#{four_digit_year_string(range_start)}*#{four_digit_year_string(range_end, range_start)}")
+      elsif possible_year?(range_start, previous_token)
+        [with_type_prefix(:year, four_digit_year_string(range_start)), with_type_prefix(:numeric, pad_all_digits(range_end))].join
+      else
+        [with_type_prefix(:numeric, pad_all_digits(range_start)), with_type_prefix(:numeric, pad_all_digits(range_end))].join
+      end
+    end
+
+    def possible_year?(token, previous_token = nil)
+      return false unless previous_token && ([':', '/'].include?(previous_token))
+
+      val = token.to_i
+
+      # Oldest SUDOC year may be 1841?
+      # Prior to 2000, years were sometimes written as three digits.
+      return true if val.between?(841, 999)
+
+      return true if val.between?(1841, Time.now.year)
+
+      false
+    end
+
+    def four_digit_year_string(year_string, basis = '1000')
+      return year_string if year_string.length == 4
+      return nil unless year_string.length.between?(1, 3)
+
+      basis[0..-(year_string.length + 1)] + year_string
+    end
+
+    def year_range?(start, finish)
+      return false unless possible_year?(start)
+
+      end_year_string = four_digit_year_string(finish, start)
+      return false unless end_year_string
+
+      return true if start.to_i < end_year_string.to_i
+
+      false
+    end
+  end
+end

--- a/lib/call_numbers/sudoc_shelfkey.rb
+++ b/lib/call_numbers/sudoc_shelfkey.rb
@@ -59,7 +59,9 @@ module CallNumbers
     end
 
     def normalize_remainder_periods(remainder)
-      remainder = remainder.gsub(/(\d+)\.(\d+)/, '\1 \2')
+      remainder = remainder.gsub(/(\d+)\s*\.\s*(\d+)/, '\1 \2')
+      remainder = remainder.gsub(/([a-z]+)\s*\.\s*(\d+)/i, '\1 \2')
+      remainder = remainder.gsub(/(\d+)\s*\.\s*([a-z]+)/i, '\1 \2')
       remainder.tr('.', '')
     end
 

--- a/lib/call_numbers/sudoc_shelfkey.rb
+++ b/lib/call_numbers/sudoc_shelfkey.rb
@@ -11,8 +11,8 @@ module CallNumbers
     }.freeze
 
     TYPE_PRECEDENCE = {
-      alphabetic: 'q',
-      year: 'r',
+      year: 'q',
+      alphabetic: 'r',
       numeric: 's'
     }.freeze
 

--- a/spec/lib/call_numbers/other_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/other_shelfkey_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe CallNumbers::OtherShelfkey do
   end
 
   describe '#shelfkey_scheme' do
-    it 'is "sudoc" when "SUDOC" is passed' do
-      expect(described_class.new('ZDVD 1234', scheme: 'SUDOC').forward).to start_with 'sudoc'
-    end
-
     it 'is "other" for any other value or nil' do
       expect(described_class.new('ZDVD 1234', scheme: 'LITERALLY ANYTHING ELSE').forward).to start_with 'other'
       expect(described_class.new('ZDVD 1234').forward).to start_with 'other'

--- a/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe CallNumbers::SudocShelfkey do
       expect(sorted_call_numbers).to eq(call_numbers)
     end
 
-    it 'considers periods in the suffix a significant delimiter only between numbers' do
+    it 'considers periods in the suffix a significant delimiter only when involving numbers' do
       call_numbers = [
         'SSA 1.2:AG 8/SWEDEN',
         'SSA 1.2:AG 8/SWITZ.',
@@ -67,7 +67,11 @@ RSpec.describe CallNumbers::SudocShelfkey do
         'SSA 1.2:AG 8/USA',
         'SSA 1.2:AG 8/USA/VERISON 1.2',
         'SSA 1.2:AG 8/USA/VERISON 1.3',
-        'SSA 1.2:AG 8/USA/VERISON 12'
+        'SSA 1.2:AG 8/USA/VERISON 12',
+        'SSA 1.2:AG 8/USA/VERISON 12 No. 1',
+        'SSA 1.2:AG 8/USA/VERISON 12 No.2',
+        'SSA 1.2:AG 8/USA/VERISON 12 No 2.1',
+        'SSA 1.2:AG 8/USA/VERISON 12 No. 3'
       ]
       unsorted_call_numbers = call_numbers.shuffle
       sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }

--- a/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
@@ -55,60 +55,20 @@ RSpec.describe CallNumbers::SudocShelfkey do
       expect(sorted_call_numbers).to eq(call_numbers)
     end
 
-    it 'handles the Northwestern nothing before something example' do
-      call_numbers = [
-        'GS1.2:So2',
-        'GS1.2:So2/4',
-        'L2.3;16:',
-        'L2.3/16-2:',
-        'Y4.F76/1:C42/4',
-        'Y4.F76/1:C42/4/985',
-        'Y4.F76/1:C76/13/982',
-        'Y4.F76/1:C76/13/982-2',
-        'Y4.F76/2:Af8/12',
-        'Y4.F76/2:Af8/12/rev.',
-        'Y4.F76/2:S.prt.101-105',
-        'Y4.F76/2:Sa2/7/982',
-        'Y4.G74/7:N21/5',
-        'Y4.G74/7:N21a'
-      ]
-      unsorted_call_numbers = call_numbers.shuffle
-      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
-                                                 .sort_by(&:forward)
-                                                 .map(&:base_call_number)
-
-      expect(sorted_call_numbers).to eq(call_numbers)
-    end
-
-    it 'handles the Northwestern sample sudoc sequence' do
-      call_numbers = [
-        'T22.19:M54',
-        'T22.19:M54/990',
-        'T22.19/2:P94',
-        'T22.19/2:P94/2',
-        'T22.19/2:V88/retest',
-        'T22.19/2:V88/retest/989',
-        'T22.19/2:V88/test/989',
-        'T22.19/2:V88/test-2/988',
-        'T22.19/2:V88/test-2/989',
-        'T22.19/2:V88/989/student/militia',
-        'T22.19/2:V88/989/student/spanish',
-        'T22.19/2:V88/989/student/text',
-        'T22.19/2:V88/990/student/spanish',
-        'T22.19/2:V88/2',
-        'T22.19/2:V88/2/989'
-      ]
-
-      unsorted_call_numbers = call_numbers.shuffle
-      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
-                                                 .sort_by(&:forward)
-                                                 .map(&:base_call_number)
-
-      expect(sorted_call_numbers).to eq(call_numbers)
-    end
-
     it 'sorts this list of sudoc call numbers' do
       call_numbers = [
+        'A 13.2:T 73/4',
+        'A 93.2:N 95/3',
+        'A 93.73:76',
+        'A 93.73:89',
+        'A 93.73/2:62',
+        'C 13.58:7564',
+        'C 13.58:7611',
+        'EP 1.23:600/998-103',
+        'EP 1.23:600/R-98-23',
+        'HE 20.4002:AD 9/2',
+        'HE 20.4002:AD9/5',
+        'HE 20.4002:F 94',
         'I 29.2:W 58/12/2022/FALL',
         'I 29.2:W 58/12/2022/SPRING',
         'I 53.11/4:36121-E 1-TM-100/2022',
@@ -127,6 +87,8 @@ RSpec.describe CallNumbers::SudocShelfkey do
         'ITC 1.12:731-TA-1054-1055/PRELIM.',
         'J 32.2:C 43/CHILD',
         'J 32.2:C 43/EARLY',
+        'J 32.21:999',
+        'J 32.21:M',
         'NAS 1.83:NP-2019-06-2726-HQ',
         'NAS 1.83:NP-2019-07-2735-HQ',
         'NAS 1.83:NP-2019-07-2739-HQ',

--- a/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
@@ -55,6 +55,27 @@ RSpec.describe CallNumbers::SudocShelfkey do
       expect(sorted_call_numbers).to eq(call_numbers)
     end
 
+    it 'considers periods in the suffix a significant delimiter only between numbers' do
+      call_numbers = [
+        'SSA 1.2:AG 8/SWEDEN',
+        'SSA 1.2:AG 8/SWITZ.',
+        'SSA 1.2:AG 8/SWITZ/996',
+        'SSA 1.2:AG 8/SWITZ./997',
+        'SSA 1.2:AG 8/U.K./996',
+        'SSA 1.2:AG 8/UK/997',
+        'SSA 1.2:AG 8/U.K./998',
+        'SSA 1.2:AG 8/USA',
+        'SSA 1.2:AG 8/USA/VERISON 1.2',
+        'SSA 1.2:AG 8/USA/VERISON 1.3',
+        'SSA 1.2:AG 8/USA/VERISON 12'
+      ]
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+      expect(sorted_call_numbers).to eq(call_numbers)
+    end
+
     it 'sorts this list of sudoc call numbers' do
       call_numbers = [
         'A 13.2:T 73/4',

--- a/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/sudoc_shelfkey_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CallNumbers::SudocShelfkey do
+  describe 'sorting by generated key' do
+    it 'handles whitespace variations properly' do
+      call_numbers = [
+        'Y4.ED 8/1:117-48',
+        'Y 4.ED 8/1:117-49',
+        'Y 4.ED8/1:117-50',
+        'Y4.ED8/1:117-53'
+      ]
+
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+
+      expect(sorted_call_numbers).to eq(call_numbers)
+    end
+
+    it 'is case insensitive' do
+      call_numbers = [
+        'Y4.ED 8/1:117-48',
+        'y4.ED 8/1:117-49',
+        'Y 4.ed8/1:117-50'
+      ]
+
+      unsorted_call_numbers = call_numbers.reverse
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+
+      expect(sorted_call_numbers).to eq(call_numbers)
+    end
+
+    it 'handles three digit years' do
+      call_numbers = [
+        'I 29.21:M 75/2/1996',
+        'I 29.21:M 75/2/998',
+        'I 29.21:M 75/2/2019',
+        'I 29.21:M 75/2/2021',
+        'I 29.21:M 75/2/10',
+        'Y 4.F 76/2:S.HRG.115-747',
+        'Y 4.F 76/2:S.HRG.115-830',
+        'Y 4.F 76/2:S.HRG.115-831',
+        'Y 4.F 76/2:S.HRG.116-105'
+      ]
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+
+      expect(sorted_call_numbers).to eq(call_numbers)
+    end
+
+    it 'handles the Northwestern nothing before something example' do
+      call_numbers = [
+        'GS1.2:So2',
+        'GS1.2:So2/4',
+        'L2.3;16:',
+        'L2.3/16-2:',
+        'Y4.F76/1:C42/4',
+        'Y4.F76/1:C42/4/985',
+        'Y4.F76/1:C76/13/982',
+        'Y4.F76/1:C76/13/982-2',
+        'Y4.F76/2:Af8/12',
+        'Y4.F76/2:Af8/12/rev.',
+        'Y4.F76/2:S.prt.101-105',
+        'Y4.F76/2:Sa2/7/982',
+        'Y4.G74/7:N21/5',
+        'Y4.G74/7:N21a'
+      ]
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+
+      expect(sorted_call_numbers).to eq(call_numbers)
+    end
+
+    it 'handles the Northwestern sample sudoc sequence' do
+      call_numbers = [
+        'T22.19:M54',
+        'T22.19:M54/990',
+        'T22.19/2:P94',
+        'T22.19/2:P94/2',
+        'T22.19/2:V88/retest',
+        'T22.19/2:V88/retest/989',
+        'T22.19/2:V88/test/989',
+        'T22.19/2:V88/test-2/988',
+        'T22.19/2:V88/test-2/989',
+        'T22.19/2:V88/989/student/militia',
+        'T22.19/2:V88/989/student/spanish',
+        'T22.19/2:V88/989/student/text',
+        'T22.19/2:V88/990/student/spanish',
+        'T22.19/2:V88/2',
+        'T22.19/2:V88/2/989'
+      ]
+
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+
+      expect(sorted_call_numbers).to eq(call_numbers)
+    end
+
+    it 'sorts this list of sudoc call numbers' do
+      call_numbers = [
+        'I 29.2:W 58/12/2022/FALL',
+        'I 29.2:W 58/12/2022/SPRING',
+        'I 53.11/4:36121-E 1-TM-100/2022',
+        'I 53.11/4:38102-E 1-TM-100/2022',
+        'I 53.11/4:39102-A 1-TM-100/2022',
+        'I 53.11/4:39108-A 1-TM-100/2020',
+        'I 53.11/4:39108-A 1-TM-100/2021',
+        'I 53.11/4:39121-A 1-TM-100/2021',
+        'I 53.11/4:42112-A 1-TM-100/2022',
+        'I 53.59:P 87/2/FINAL/V.1',
+        'I 53.59:P 87/2/FINAL/V.1 3-4',
+        'I 53.59:P 87/2/FINAL/V.1 5-7',
+        'I 53.59:P 87/2/FINAL/V.2',
+        'I 53.59:P 87/2/FINAL/V.10',
+        'ITC 1.12:731-TA-1054-1055/FINAL',
+        'ITC 1.12:731-TA-1054-1055/PRELIM.',
+        'J 32.2:C 43/CHILD',
+        'J 32.2:C 43/EARLY',
+        'NAS 1.83:NP-2019-06-2726-HQ',
+        'NAS 1.83:NP-2019-07-2735-HQ',
+        'NAS 1.83:NP-2019-07-2739-HQ',
+        'PM 1.10:RI 83-3/989',
+        'PM 1.10:RI 83-4/989-2',
+        'PM 1.10:RI 83-4/989-12',
+        'PM 1.10:RI 83-4/995',
+        'PM 1.10:RI 83-5/989-2',
+        'PREX 3.10/4-5:POLIT.',
+        'PREX 3.10/4-5:RELIEF',
+        'PREX 3.10/4-8:',
+        'PREX 28.2:H 34',
+        'Y 1.1/7:110-27',
+        'Y 1.1/8:110-934',
+        'Y 3.L 71:2 C 43/BIRTH',
+        'Y 3.L 71:2 C 43/BIRTH/2003',
+        'Y 3.L 71:2 C 43/KINDER.',
+        'Y 3.L 71:2 C 43/KINDER./2003',
+        'Y 3.N 88:10/0586/SUPP.1/VOL .1/FINAL',
+        'Y 3.N 88:10/0586/SUPP.1/VOL .2/FINAL',
+        'Y 4.AG 8:S.HRG.110-403',
+        'Y 4.AG 8:S.HRG.110-404',
+        'Y 4.AP 6/1:AP 6/10/2018/BK .1',
+        'Y 4.AP 6/1:AP 6/10/2018/BK .2',
+        'Y 4.C 73/8:115-11',
+        'Y 4.C 73/8:115-110',
+        'Y 4.C 73/8:115-116+ERRATA',
+        'Y 4.C 73/8:115-117',
+        'Y 4.J 89/2:S.HRG.108-257',
+        'Y 4.J 89/2:S.HRG.108-257/ERRATA',
+        'Y 4.W 36:WMCP 108-2',
+        'Y 4.W 36:WMCP 108-12',
+        'Y 4.W 36:115-TR 01',
+        'Y 4.W 36:115-TR 02'
+      ]
+
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+      expect(sorted_call_numbers).to eq(call_numbers)
+
+      reversed_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                   .sort_by(&:reverse)
+                                                   .map(&:base_call_number)
+      expect(reversed_call_numbers).to eq(call_numbers.reverse)
+    end
+  end
+end

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -52,13 +52,13 @@ RSpec.describe 'Browse nearby' do
     end
   end
 
-  context 'when the item does not have a sortable call number (e.g. SUDOC type)' do
+  context 'when the item does not have a sortable call number (e.g. OTHER type)' do
     before do
       allow(folio_record).to receive(:index_items).and_return(index_items)
     end
 
     let(:index_items) do
-      [build(:sudoc_holding, call_number: 'I 19.76:98-600-B')]
+      [build(:other_holding)]
     end
 
     it { is_expected.to be_blank }
@@ -113,6 +113,33 @@ RSpec.describe 'Browse nearby' do
     end
 
     it { is_expected.to include(hash_including('lopped_callnumber' => 'QE538.8 .N36', 'callnumber' => 'QE538.8 .N36 1978-1980')) }
+  end
+
+  context 'with a mix of Sudocs' do
+    before do
+      allow(folio_record).to receive(:index_items).and_return(index_items)
+    end
+
+    let(:index_items) do
+      [
+        build(:sudoc_holding, barcode: 'Sudoc1', call_number: 'Y 4.SCI 2:107-46/V.1'),
+        build(:sudoc_holding, barcode: 'Sudoc2', call_number: 'Y 1.1/8:118-400/PT.1 PT.1'),
+        build(:sudoc_holding, barcode: 'Sudoc3', call_number: 'Y 1.1/8:118-400/PT.2 PT.2'),
+        build(:sudoc_holding, barcode: 'Sudoc4', call_number: 'Y 4.W 36:WMCP 108-11'),
+        build(:sudoc_holding, barcode: 'Sudoc5', call_number: 'A 13.92:B 63/5/LAND/V.1-2/2003'),
+        build(:sudoc_holding, barcode: 'Sudoc6', call_number: 'I 53.11/4-2:42117-E 1-TM-100/2005'),
+        build(:sudoc_holding, barcode: 'Sudoc7', call_number: 'I 49.44/2:N 81 P')
+      ]
+    end
+
+    it {
+      is_expected.to include(hash_including('lopped_callnumber' => 'Y 4.SCI 2:107-46'),
+                             hash_including('lopped_callnumber' => 'Y 1.1/8:118-400'),
+                             hash_including('lopped_callnumber' => 'Y 4.W 36:WMCP 108-11'),
+                             hash_including('lopped_callnumber' => 'A 13.92:B 63'),
+                             hash_including('lopped_callnumber' => 'I 53.11/4-2:42117-E 1-TM-100'),
+                             hash_including('lopped_callnumber' => 'I 49.44/2:N 81'))
+    }
   end
 
   context 'with a mix of items' do


### PR DESCRIPTION
Part of #1562 

Adds support for SuDoc shelfkeys for browse nearby.

For the shelfkey I'm ordering the entire call number and there is quite the diverse set. Ultimately it isn't doing anything that fancy beyond trying to determine what is likely a year versus just a number. "Words" sort alphabetically. That seems to be the norm and they tend to be very late in the call number, in which case you rarely see them because they are consolidated behind the lopped call number. I think user feedback would be extremely valuable. I suspect there could be a range of practices that users would discover. It's a challenge to sample 2+ million call numbers.

As opposed to shelfkeys, here lopped call numbers are depending on the (mostly) consistent stem + book number part of the suffix. This seemed correct, in practice, but we might need to depend on user feedback for this as well.
