### PR TITLE
Set encoding to UTF-8 before trying to fix UTF-8 characters

### DIFF
--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -5,9 +5,11 @@ require_relative '../config/boot'
 
 module Utils
   def self.encoding_cleanup(value)
+    # Messages coming from Kafka are ASCII-8BIT, but since they are JSON, we know they must be UTF-8.
+    # This is also required for the UTF-8 regex
+    value.force_encoding('utf-8')
     # cleans up cyrlic encoding i︠a︡ to i͡a
-    # value.gsub(/\ufe20(.{1,2})\ufe21/, "\u0361\\1")
-    value
+    value.gsub(/\ufe20(.{1,2})\ufe21/, "\u0361\\1")
   end
 
   def self.balance_parentheses(string)

--- a/spec/lib/utils_spec.rb
+++ b/spec/lib/utils_spec.rb
@@ -3,17 +3,21 @@
 require 'spec_helper'
 
 RSpec.describe Utils do
-  xdescribe '.encoding_cleanup' do
-    it 'encodes cyrilic correctly' do
-      expect(described_class.encoding_cleanup('Strategii︠a︡ planirovanii︠a︡ izbiratelʹnoĭ kampanii')).to eq('Strategii͡a planirovanii͡a izbiratelʹnoĭ kampanii')
+  describe '.encoding_cleanup' do
+    subject(:encoded) { described_class.encoding_cleanup(input.force_encoding('ASCII-8BIT')) }
+    context 'cyrilic uncombined' do
+      let(:input) { +'Strategii︠a︡ planirovanii︠a︡ izbiratelʹnoĭ kampanii' }
+      it { is_expected.to eq('Strategii͡a planirovanii͡a izbiratelʹnoĭ kampanii') }
     end
 
-    it 'returns unencoded string without change' do
-      expect(described_class.encoding_cleanup('https://link.gale.com/apps/ECCO?u=stan90222')).to eq('https://link.gale.com/apps/ECCO?u=stan90222')
+    context 'cyrilic pre-combined' do
+      let(:input) { +'Strategiii︠a planirovaniia︡ izbiratelʹnoĭ kampanii' }
+      it { is_expected.to eq input }
     end
 
-    it 'returns encoded string without change' do
-      expect(described_class.encoding_cleanup('Strategiii︠a planirovaniia︡ izbiratelʹnoĭ kampanii')).to eq('Strategiii︠a planirovaniia︡ izbiratelʹnoĭ kampanii')
+    context 'unencoded string' do
+      let(:input) { +'https://link.gale.com/apps/ECCO?u=stan90222' }
+      it { is_expected.to eq input }
     end
   end
 


### PR DESCRIPTION
We know this is a safe operation, as JSON is required to be UTF-8 encoded and the whole payload is JSON

Fixes #1589
