### PR TITLE
Add CalDoc specific shelfkeys

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'parallel'
 gem 'pg', platform: :mri
 gem 'rake'
 gem 'retriable'
+gem 'roman_numerals', '~> 1.0'
 gem 'ruby-kafka'
 gem 'stanford-mods', '~> 3.0'
 gem 'statsd-ruby'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,7 @@ GEM
     erubi (1.13.1)
     factory_bot (6.5.1)
       activesupport (>= 6.1.0)
+    ffi (1.17.1)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -199,6 +200,7 @@ GEM
       marc (~> 1.0)
     match_map (3.0.0)
     method_source (1.1.0)
+    mini_portile2 (2.8.8)
     minitest (5.25.5)
     mods (3.0.5)
       csv (~> 3.3)
@@ -218,6 +220,9 @@ GEM
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.0)
+    nokogiri (1.18.7)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
     nokogiri (1.18.7-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.7-x86_64-darwin)
@@ -283,6 +288,7 @@ GEM
       io-console (~> 0.5)
     retriable (3.1.2)
     rexml (3.4.1)
+    roman_numerals (1.0.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -413,6 +419,7 @@ DEPENDENCIES
   pg
   rake
   retriable
+  roman_numerals (~> 1.0)
   rspec
   rubocop
   rubocop-performance

--- a/lib/call_numbers/caldoc_shelfkey.rb
+++ b/lib/call_numbers/caldoc_shelfkey.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module CallNumbers
+  class CaldocShelfkey < ShelfkeyBase
+    def forward
+      [
+        'caldoc',
+        parsed[:caldoc_letter]&.downcase,
+        pad(parsed[:caldoc_number], by: 4, direction: :left),
+        pad_all_digits(parsed[:sub_agency]),
+        pad_all_digits(parsed[:book1]),
+        pad_all_digits(parsed[:book2]),
+        pad(parsed[:year], by: 4, direction: :left),
+        pad(year_range_end, by: 4, direction: :left),
+        pad(accession_number, by: 4, direction: :left),
+        pad_all_digits(parsed[:rest]),
+        volume_info_normalized
+      ].filter_map(&:presence).join(' ').strip
+    end
+
+    def volume_info_normalized
+      return unless volume_info.present?
+
+      replace_roman_numerals(volume_info).downcase
+    end
+
+    private
+
+    def parsed
+      @parsed ||= %r{
+        ^.*CALIF\s+
+        (?<caldoc_letter>[A-Z])\s*
+        (?<caldoc_number>\d{3,4})\s*
+        (?<sub_agency>[A-Z]\d{1,2})?\s*
+        \.*\s*
+        (?<book1>[A-Z]\d{1,4}[A-Z]*)\s*
+        (?<book2>[A-Z]\d{1,4})?\s*
+        (?<year>\d{4}?)(?:[-/](?<year2>\d{4}|(?:\d{2})))?\s*
+        (?<rest>.*)
+     }xi.match(base_call_number)
+
+      @parsed ||= {}
+    end
+
+    def year_range_end
+      @year_range_end ||= calculate_year_end
+    end
+
+    def calculate_year_end
+      return nil unless parsed[:year2]
+
+      if parsed[:year2].length == 2
+        expand_two_digit_year(parsed[:year2], parsed[:year]).to_s
+      else
+        parsed[:year2]
+      end
+    end
+
+    def expand_two_digit_year(short_year_str, base_year_str)
+      short_year = short_year_str.to_i
+      base_year = base_year_str.to_i
+      century = (base_year / 100) * 100
+      if short_year < (base_year % 100)
+        century + 100 + short_year
+      else
+        century + short_year
+      end
+    end
+
+    def accession_number
+      if (number_match = parsed[:rest]&.match(/NO\.?\s*(\d+)/))
+        number_match[1]
+      elsif (roman_match = parsed[:rest]&.match(/NO\.?\s*([MCDLXVI]+)/))
+        roman_match[1].r_to_i.to_s
+      end
+    end
+
+    def replace_roman_numerals(text)
+      text.gsub(/(\s|^|\W)([MCDLXVI]+)(\s|$|\W)/i) do
+        prefix = ::Regexp.last_match(1)
+        roman = ::Regexp.last_match(2)
+        suffix = ::Regexp.last_match(3)
+        prefix + roman.r_to_i.to_s + suffix
+      end
+    end
+  end
+end

--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -259,6 +259,7 @@ class FolioItem
   end
 
   class CallNumber
+    VALID_CALDOC_REGEX = /^.*CALIF\s+[A-Z]\s*\d{3,4}/
     VALID_DEWEY_REGEX = /^\d{1,3}(\.\d+)? *\.? *[A-Z]\d{1,3} *[A-Z]*+.*/
     VALID_LC_REGEX = /(^[A-Z&&[^IOWXY]]{1}[A-Z]{0,2} *\d+(\.\d*)?( +([\da-z]\w*)|([A-Z]\D+\w*))?) *\.?[A-Z]\d+.*/
     TEMP_CALLNUM_PREFIX = 'XX('
@@ -283,6 +284,8 @@ class FolioItem
                   else
                     'OTHER'
                   end
+                elsif purported_type == 'ALPHANUM'
+                  valid_caldoc? ? 'CALDOC' : purported_type.upcase
                 else
                   purported_type.upcase
                 end
@@ -313,6 +316,8 @@ class FolioItem
         CallNumbers::DeweyShelfkey.new(base_call_number.to_s, volume_info, serial:)
       when 'SUDOC'
         CallNumbers::SudocShelfkey.new(base_call_number.to_s, volume_info, serial:)
+      when 'CALDOC'
+        CallNumbers::CaldocShelfkey.new(base_call_number.to_s, volume_info, serial:)
       else
         CallNumbers::OtherShelfkey.new(
           base_call_number.to_s,
@@ -350,6 +355,10 @@ class FolioItem
     end
 
     private
+
+    def valid_caldoc?
+      call_number&.match?(VALID_CALDOC_REGEX)
+    end
 
     def valid_dewey?
       call_number&.match?(VALID_DEWEY_REGEX)

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -2119,7 +2119,7 @@ to_field 'item_display_struct' do |record, accumulator, context|
   end
 end
 
-CALL_TYPE = %w[LC DEWEY ALPHANUM SUDOC].freeze
+CALL_TYPE = %w[LC DEWEY ALPHANUM SUDOC CALDOC].freeze
 ERESOURCE_CALL_TYPE = %w[LC DEWEY ALPHANUM].freeze
 # Each (browseable) base call number is represented by a single browse nearby entry; we choose
 # the representative item by the following rules:

--- a/spec/factories/holdings.rb
+++ b/spec/factories/holdings.rb
@@ -31,6 +31,11 @@ FactoryBot.define do
 
     initialize_with { new(**attributes, holding:, item: default_item_attributes.merge(item).merge(additional_item_attributes.deep_stringify_keys)) }
 
+    factory :caldoc_holding do
+      call_number { 'CALIF C728 .F6 1973' }
+      scheme { 'Shelving control number' }
+    end
+
     factory :lc_holding do
       call_number { 'QE538.8 .N36 1975-1977' }
       scheme { 'LC' }

--- a/spec/lib/call_numbers/caldoc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/caldoc_shelfkey_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CallNumbers::CaldocShelfkey do
+  describe 'sorting by generated key' do
+    it 'sorts CalDoc call numbers with volume info' do
+      call_numbers_data = [
+        { base: 'CALIF E200 .E9', volume_info: 'Region 2' },
+        { base: 'CALIF E200 .E9', volume_info: 'Region III' },
+        { base: 'CALIF E200 .E9', volume_info: 'Region iv' },
+        { base: 'CALIF E200 .E9', volume_info: 'Region 7' },
+        { base: 'CALIF G105 .B9', volume_info: '' },
+        { base: 'CALIF G105 .B9', volume_info: '1965' },
+        { base: 'CALIF G105 .B9', volume_info: '1966-1967' },
+        { base: 'CALIF G105 .B9', volume_info: '1968-1973' }
+      ]
+
+      unsorted_data = call_numbers_data.shuffle
+
+      sorted_call_numbers = unsorted_data
+                            .map { |data| described_class.new(data[:base], data[:volume_info], serial: data[:serial]) }
+                            .sort_by(&:forward)
+                            .map { |obj| { base: obj.base_call_number, volume_info: obj.volume_info } }
+      expect(sorted_call_numbers).to eq(call_numbers_data)
+
+      reversed_call_numbers = unsorted_data
+                              .map { |data| described_class.new(data[:base], data[:volume_info], serial: data[:serial]) }
+                              .sort_by(&:reverse)
+                              .map { |obj| { base: obj.base_call_number, volume_info: obj.volume_info } }
+      expect(reversed_call_numbers).to eq(call_numbers_data.reverse)
+    end
+
+    it 'sorts CalDoc base call numbers' do
+      call_numbers = [
+        # These fixtures are from real Folio data (maybe with a tweak).
+        'CALIF H990 .W68 1985/86',
+        # Sometimes the year is included in the base call number, sometimes it's in the volume info
+        # Sometimes there is a range ending in a two digit year
+        'CALIF H997 .C62 1983-84',
+        # Sometimes a four digit year
+        'CALIF H997 .C62 1983-1986',
+        'CALIF H997 .C62 1983-90',
+        'CALIF I250 .R4m',
+        'CALIF I250 .R4s',
+        'CALIF I625   .R4L',
+        'CALIF I625 .R4Lc',
+        # Might not exist in real data but Librarians warned us about leading garbage
+        '[folio] CALIF I625 .R4v',
+        'CALIF I625 .R42',
+        'CALIF I625 .R63 2000',
+        'CALIF I625 .R63 2002',
+        'CALIF I625.R63 2004',
+        # Sometimes there's a number in the base call number. Most of the time it's in the volume info
+        'CALIF L500.P685 1990 NO.1',
+        'CALIF L500 .P685 1990 NO.2',
+        'CALIF L500.P685 1990 NO.12',
+        'CALIF P2200 .M5DC',
+        'CALIF P2200 .M59',
+        # These "DRAFT" types properties seem to normally be in the volume info
+        'CALIF R960 .C42 DRAFT',
+        'CALIF R960 .C42 FINAL',
+        'CALIF R960 .E76',
+        # Note that we have "work letters" that are more than one character
+        'CALIF R960 .M36DR CD',
+        'CALIF R960 .P6S',
+        'CALIF S930 .L4A NO.01',
+        'CALIF S930 .L4A NO. 02',
+        'CALIF S930 .L4A NO.48',
+        'CALIF S930 .L4A NO.48 AMEND.'
+      ]
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+
+      expect(sorted_call_numbers).to eq(call_numbers)
+
+      reversed_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                   .sort_by(&:reverse)
+                                                   .map(&:base_call_number)
+      expect(reversed_call_numbers).to eq(call_numbers.reverse)
+    end
+  end
+end

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -115,6 +115,21 @@ RSpec.describe 'Browse nearby' do
     it { is_expected.to include(hash_including('lopped_callnumber' => 'QE538.8 .N36', 'callnumber' => 'QE538.8 .N36 1978-1980')) }
   end
 
+  context 'with some CalDoc call numbers of a series' do
+    before do
+      allow(folio_record).to receive(:index_items).and_return(index_items)
+    end
+
+    let(:index_items) do
+      [
+        build(:caldoc_holding, barcode: 'CalDoc1', call_number: 'CALIF C728 .F6 1973', enumeration: 'V.1'),
+        build(:caldoc_holding, barcode: 'CalDoc1', call_number: 'CALIF C728 .F6 1973', enumeration: 'V.2')
+      ]
+    end
+
+    it { is_expected.to include(hash_including('lopped_callnumber' => 'CALIF C728 .F6 1973', 'callnumber' => 'CALIF C728 .F6 1973 V.1')) }
+  end
+
   context 'with a mix of Sudocs' do
     before do
       allow(folio_record).to receive(:index_items).and_return(index_items)

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -624,8 +624,8 @@ RSpec.describe 'ItemInfo config' do
       end
 
       it 'has the same shelfkey in the field as it does in the item_display' do
-        expect(browse_shelfkey).to eq 'other calif a000125 .a000034 002002'
-        expect(shelfkey).to eq ['other calif a000125 .a000034 002002']
+        expect(browse_shelfkey).to eq 'caldoc a 0125 a000034 0000 0000 0000 2002'
+        expect(shelfkey).to eq ['caldoc a 0125 a000034 0000 0000 0000 2002']
       end
     end
 


### PR DESCRIPTION
Part of #1562.

Previously CalDocs where going through the "OTHER" call number shelfkey path. This adds specific handling for CalDocs.

There seems to be a mix of practices/conventions in the data in what is included in the base call number versus the volume info. This work is prioritizing the data in the base call number (not trying to infer intent of volume info) as that is what is most visible to the user in the browse nearby spines.