### PR TITLE
Add UN document shelfkeys for browse nearby

### DIFF
--- a/lib/call_numbers/caldoc_shelfkey.rb
+++ b/lib/call_numbers/caldoc_shelfkey.rb
@@ -50,20 +50,9 @@ module CallNumbers
       return nil unless parsed[:year2]
 
       if parsed[:year2].length == 2
-        expand_two_digit_year(parsed[:year2], parsed[:year]).to_s
+        expand_two_digit_year(parsed[:year2], parsed[:year])
       else
         parsed[:year2]
-      end
-    end
-
-    def expand_two_digit_year(short_year_str, base_year_str)
-      short_year = short_year_str.to_i
-      base_year = base_year_str.to_i
-      century = (base_year / 100) * 100
-      if short_year < (base_year % 100)
-        century + 100 + short_year
-      else
-        century + short_year
       end
     end
 
@@ -72,15 +61,6 @@ module CallNumbers
         number_match[1]
       elsif (roman_match = parsed[:rest]&.match(/NO\.?\s*([MCDLXVI]+)/))
         roman_match[1].r_to_i.to_s
-      end
-    end
-
-    def replace_roman_numerals(text)
-      text.gsub(/(\s|^|\W)([MCDLXVI]+)(\s|$|\W)/i) do
-        prefix = ::Regexp.last_match(1)
-        roman = ::Regexp.last_match(2)
-        suffix = ::Regexp.last_match(3)
-        prefix + roman.r_to_i.to_s + suffix
       end
     end
   end

--- a/lib/call_numbers/shelfkey_base.rb
+++ b/lib/call_numbers/shelfkey_base.rb
@@ -46,7 +46,7 @@ module CallNumbers
       self.class.reverse(self.class.pad_all_digits(volume_info)).strip.ljust(50, '~')
     end
 
-    delegate :pad, :pad_all_digits, :pad_cutter, to: :class
+    delegate :pad, :pad_all_digits, :pad_cutter, :expand_two_digit_year, :replace_roman_numerals, to: :class
 
     class << self
       def reverse(value)
@@ -97,6 +97,26 @@ module CallNumbers
           value.ljust(by, character)
         when :left
           value.rjust(by, character)
+        end
+      end
+
+      def expand_two_digit_year(short_year_str, base_year_str)
+        short_year = short_year_str.to_i
+        base_year = base_year_str.to_i
+        century = (base_year / 100) * 100
+        if short_year < (base_year % 100)
+          (century + 100 + short_year).to_s
+        else
+          (century + short_year).to_s
+        end
+      end
+
+      def replace_roman_numerals(text)
+        text.gsub(/(\s|^|\W)([MCDLXVI]+)(\s|$|\W)/i) do
+          prefix = ::Regexp.last_match(1)
+          roman = ::Regexp.last_match(2)
+          suffix = ::Regexp.last_match(3)
+          prefix + roman.r_to_i.to_s + suffix
         end
       end
 

--- a/lib/call_numbers/undoc_shelfkey.rb
+++ b/lib/call_numbers/undoc_shelfkey.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module CallNumbers
+  class UndocShelfkey < ShelfkeyBase
+    def forward
+      parts = ['undoc'] + normalize_base_call_number + [volume_info_with_serial_behavior]
+      parts.filter_map(&:presence).join(' ').strip
+    end
+
+    private
+
+    def components
+      @components ||= begin
+        parts = base_call_number.split(%r{/(?![^(]*\))})
+
+        parts.map do |part|
+          part = normalize_periods(part)
+          UndocCallnumberComponent.new(part.strip)
+        end
+      end
+    end
+
+    def normalize_base_call_number
+      components.each_with_index.map do |component, index|
+        next_component = components[index + 1] if index + 1 < components.size
+        part = index > 1 || !component.symbol? ? replace_roman_numerals(component.value) : component.value
+        part = normalize_parens(part)
+        part = normalize_slashes(part)
+        part = expand_two_digit_year(part, '1945') if component.expandable_year? && next_component&.possible_sessional_info? && !four_digit_year?
+        pad_all_digits(part)
+      end
+    end
+
+    def normalize_periods(part)
+      part = part.gsub(/(\d+)\s*\.\s*(\d+)/, '\1 \2')
+      part = part.gsub(/([a-z]+)\s*\.\s*(\d+)/i, '\1\2')
+      part = part.gsub(/([a-z]+)\s*\.\s*([a-z]+)/i, '\1\2')
+      part = part.gsub(/(\d+)\s*\.\s*([a-z]+)/i, '\1\2')
+      part.tr('.', '')
+    end
+
+    def normalize_parens(part)
+      part.gsub(/\s*\(\s*/, ' ').gsub(/\s*\)\s*/, ' ')
+    end
+
+    def normalize_slashes(part)
+      part.split('/').map(&:strip).join(' ')
+    end
+
+    def four_digit_year?
+      components.any?(&:four_digit_year_or_range?)
+    end
+
+    class UndocCallnumberComponent
+      attr_reader :value
+
+      def initialize(value)
+        @value = value
+      end
+
+      def expandable_year?
+        value.match?(/^\d{2}$/)
+      end
+
+      def four_digit_year_or_range?
+        value.match?(/^\d{4}(?:-\d{2,4})?$/)
+      end
+
+      def possible_sessional_info?
+        value.match?(/^\d+$/)
+      end
+
+      def symbol?
+        value.match?(/^[A-Z]+$/)
+      end
+    end
+  end
+end

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -1990,6 +1990,8 @@ to_field 'preferred_barcode' do |record, accumulator, context|
   preferred_callnumber_scheme_items = chosen_items_by_callnumber_type['LC'] ||
                                       chosen_items_by_callnumber_type['DEWEY'] ||
                                       chosen_items_by_callnumber_type['SUDOC'] ||
+                                      chosen_items_by_callnumber_type['CALDOC'] ||
+                                      chosen_items_by_callnumber_type['UNDOC'] ||
                                       chosen_items_by_callnumber_type['ALPHANUM'] ||
                                       chosen_items_by_callnumber_type.values.first
 
@@ -2119,7 +2121,7 @@ to_field 'item_display_struct' do |record, accumulator, context|
   end
 end
 
-CALL_TYPE = %w[LC DEWEY ALPHANUM SUDOC CALDOC].freeze
+CALL_TYPE = %w[LC DEWEY ALPHANUM SUDOC CALDOC UNDOC].freeze
 ERESOURCE_CALL_TYPE = %w[LC DEWEY ALPHANUM].freeze
 # Each (browseable) base call number is represented by a single browse nearby entry; we choose
 # the representative item by the following rules:

--- a/spec/factories/holdings.rb
+++ b/spec/factories/holdings.rb
@@ -51,6 +51,11 @@ FactoryBot.define do
       scheme { 'Superintendent of Documents classification' }
     end
 
+    factory :undoc_holding do
+      call_number { 'ECE/EAD/PAU/2003/1' }
+      scheme { 'Shelving control number' }
+    end
+
     factory :alphanum_holding do
       call_number { 'ISHII SPRING 2009' }
       scheme { 'Shelving control number' }

--- a/spec/lib/call_numbers/undoc_shelfkey_spec.rb
+++ b/spec/lib/call_numbers/undoc_shelfkey_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe CallNumbers::UndocShelfkey do
+  describe 'sorting by generated key' do
+    it 'sorts UN document call numbers' do
+      call_numbers = [
+        'A/HRC/7/3/ADD.2',
+        'A/HRC/7/28/ADD.1',
+        'E/1ST YR./JOUR.1-30',
+        'E/1ST YR. 1ST SESS.',
+        'E/1ST YR. 2ND SESS.',
+        'E/CN.12/CCE/14 3RD IN VOL',
+        'E/CN.12/CCE/157',
+        # Shelfkeys are built assuming that each slash delimited part is significant for that position.
+        # This does mean we're depending on call number convention for things like 2006-2007 here.
+        'E/ESCWA /ED/SER.Z/2/2005/2006-2007/2008',
+        'E/ESCWA/ED/SER.Z/2/2009/2010',
+        'E/ESCWA/EDID/2017/2',
+        'E/ESCWA/EDID/2018/4',
+        # There are two digit years. It is not always clear what is a two digit year and what is a sessional number.
+        'HR/PUB/96/3',
+        'HR/PUB/1998/1',
+        'HR/PUB/98/2',
+        'HR/PUB/1998/3',
+        'HR/PUB/22/6',
+        # ICAO commonly has its leading prefixes omitted, to the point where they don't look like UN doc call numbers.
+        'ICAO DOC 8071 V.2',
+        'ICAO DOC 9161',
+        'LC/G.2367(SES.32/3)',
+        'LC/G.2368 (SES.32/4)',
+        'OEA/SER.L/V/2',
+        'OEA/SER.L/V/III',
+        'OEA/SER.L/V/ IV',
+        'OEA/SER.L/V/5',
+        'ST/ESCAP/ASIAN POP./47',
+        'ST/ESCAP/ASIAN POP./131-A',
+        'ST/ESCAP/ASIAN POP./131-E',
+        'ST/ODA/SER.Z/1/39',
+        'ST/SG/AC.10/30/REV.9',
+        'ST/SG/AC.10/30/REV.10',
+        'ST/SG/SER.B 1971-1973',
+        'ST/SG/SER.F/BULL ./35-37/5',
+        'ST/SG/SER .F/BULL./35-37/6',
+        'ST/SG/SER.F/SPEC.BULL ./2001-2010',
+        'ST/SG/SER.Y/10/V.1',
+        'ST/SG/SER.Y/10/V.2',
+        'ST/SG/SER.Y/10/V.11',
+        'ST/SOA/45-51',
+        'ST/SOA /47-48, ETC.',
+        # Technically UNCTAD should be under TD (https://digitallibrary.un.org/record/955333?ln=en).
+        # There are many possible similar situations (e.g., HR/PUB could be ST/HR/PUB prior to 1996).
+        # We have been advised that in general UN documents are shelved with the call number "as written"
+        'UNCTAD/ALDC/AFRICA/2023',
+        'UNCTAD/DTL/TIKD/2022/1',
+        # The 23 here isn't a two digit year.
+        'UNEP/SER.Y/23/2015',
+        'UNEP/SER.Y/44/2015',
+        # The 99 is made up, using it to verify we aren't confusing it with a year (1999 < 2023)
+        'UNEP/SER.Y/99/2015'
+      ]
+
+      unsorted_call_numbers = call_numbers.shuffle
+      sorted_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                 .sort_by(&:forward)
+                                                 .map(&:base_call_number)
+      expect(sorted_call_numbers).to eq(call_numbers)
+
+      reversed_call_numbers = unsorted_call_numbers.map { |x| described_class.new(x) }
+                                                   .sort_by(&:reverse)
+                                                   .map(&:base_call_number)
+      expect(reversed_call_numbers).to eq(call_numbers.reverse)
+    end
+
+    it 'expands two digit years only if there is a possible sessional component and no other identifiable year' do
+      expect(described_class.new('HR/PUB/98/2').forward).to eq 'undoc hr pub 001998 000002'
+      expect(described_class.new('ST/SG/SER.Y/10/V.1').forward).to eq 'undoc st sg sery 000010 v000001'
+      expect(described_class.new('ST/SG/SER.Y/10/V.1').forward).to eq 'undoc st sg sery 000010 v000001'
+    end
+
+    it 'converts roman numerals' do
+      expect(described_class.new('OEA/SER.L/V/ III').forward).to eq 'undoc oea serl 000005 000003'
+      expect(described_class.new('TD/B(S-XIX)/7').forward).to eq 'undoc td b s-000019 000007'
+    end
+
+    it 'does not covert UN document symbols that look like roman numerals' do
+      expect(described_class.new('LC/G.2367(SES.32/3)').forward).to eq 'undoc lc g002367 ses000032 000003'
+    end
+
+    it 'respects scoping of slashes within parens' do
+      expect(described_class.new('LC/G.2367(SES.32/3)').forward).to eq 'undoc lc g002367 ses000032 000003'
+    end
+  end
+end

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -157,6 +157,26 @@ RSpec.describe 'Browse nearby' do
     }
   end
 
+  context 'with UN document call numbers' do
+    before do
+      allow(folio_record).to receive(:index_items).and_return(index_items)
+    end
+
+    let(:index_items) do
+      [
+        build(:undoc_holding, barcode: 'Undoc1', call_number: 'ECE/EAD/PAU/2003/1'),
+        build(:undoc_holding, barcode: 'Undoc1', call_number: 'ICAO DOC 9941 AN/478'),
+        build(:undoc_holding, barcode: 'Undoc1', call_number: 'ST/ESA/PAD/SER.E/75')
+      ]
+    end
+
+    it {
+      is_expected.to include(hash_including('lopped_callnumber' => 'ECE/EAD/PAU/2003/1'),
+                             hash_including('lopped_callnumber' => 'ICAO DOC 9941 AN/478'),
+                             hash_including('lopped_callnumber' => 'ST/ESA/PAD/SER.E/75'))
+    }
+  end
+
   context 'with a mix of items' do
     before do
       allow(folio_record).to receive(:index_items).and_return(index_items)
@@ -168,7 +188,9 @@ RSpec.describe 'Browse nearby' do
         build(:dewey_holding, barcode: 'Dewey1', call_number: '888.4 .J788', enumeration: 'V.5'),
         build(:dewey_holding, barcode: 'Dewey2', call_number: '888.4 .J788', enumeration: 'V.6'),
         build(:sudoc_holding, barcode: 'Sudoc1', call_number: 'Y 4.G 74/7-11:110"'),
-        build(:sudoc_holding, barcode: 'Sudoc2', call_number: 'Y 4.G 74/7-11:1101')
+        build(:sudoc_holding, barcode: 'Sudoc2', call_number: 'Y 4.G 74/7-11:1101'),
+        build(:undoc_holding, barcode: 'Undoc1', call_number: 'ECE/EAD/PAU/2003/3'),
+        build(:undoc_holding, barcode: 'Undoc2', call_number: 'ICAO DOC 9941 AN/478')
       ]
     end
 


### PR DESCRIPTION
Part of #1562

UN Documents span three call number schemes in Folio (LC, ALPHANUM, OTHER)...

Danielle Gensch has advised us that as a general rule, UN Docs are shelved by the call number "as written". There's nothing too tricky going on here.

The most important quote from the [official documentation](https://research.un.org/en/docs/undocumentsymbols/intro):

> UN document symbols can be complex and have changed over time.
> 
> Each UN body has its own pattern of documentation that reflects the body's rules of procedure, working methods, and budgeted resources. Research into UN documentation can be challenging at times. Expect the unexpected!