### PR TITLE
remove trailing space from reverse_shelfkey

### DIFF
--- a/lib/call_numbers/shelfkey_base.rb
+++ b/lib/call_numbers/shelfkey_base.rb
@@ -35,7 +35,7 @@ module CallNumbers
     end
 
     def reverse
-      self.class.reverse(forward).ljust(50, '~')
+      self.class.reverse(forward).strip.ljust(50, '~')
     end
 
     # Unit tests inidcate that serial deweys don't get reversed years justified with tildes


### PR DESCRIPTION
closes https://github.com/sul-dlss/SearchWorks/issues/4797

The reason this wasn't working was the parent record had the reverse_shelf key: `en~0~~~zwtu}szzzzz~ez}uwzzzz~r 000001 nr 000001 001933 maj ` with a space at the end. The problem is the search was escaping the space to `en~0~~~zwtu}szzzzz~ez}uwzzzz~r 000001 nr 000001 001933 maj\` so when we were doing a matching https://github.com/sul-dlss/SearchWorks/blob/2bbe292af1bc73ed3ebe21420d79cb3bb161b0d7/app/models/nearby_on_shelf.rb#L44 the search reverse_shelfkey wasn't matching due to the space. Removing trailing spaces from indexing will clean up this up.