### PR TITLE
Add hierarchical field format_hsim to Folio indexing

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -6,6 +6,7 @@ require 'csv'
 require 'i18n'
 require 'digest/md5'
 require 'active_support/core_ext/time'
+require_relative 'folio_format_config'
 
 I18n.available_locales = [:en]
 
@@ -13,6 +14,7 @@ extend Traject::Macros::Marc21
 extend Traject::Macros::Marc21Semantics
 extend Traject::SolrBetterJsonWriter::IndexerPatch
 extend Traject::MarcUtils
+extend FolioFormatConfig
 
 Utils.logger = logger
 
@@ -113,6 +115,9 @@ end
 def items(record, context)
   context.clipboard[:item] ||= record.index_items
 end
+
+# This handles the format_hsim fields in folio_format_config.rb
+add_folio_format_fields
 
 to_field 'id', extract_marc('001') do |_record, accumulator|
   accumulator.map! do |v|

--- a/lib/traject/config/folio_format_config.rb
+++ b/lib/traject/config/folio_format_config.rb
@@ -1,0 +1,139 @@
+# frozen_string_literal: true
+
+require_relative '../macros/folio_format'
+require_relative '../macros/extras'
+
+module FolioFormatConfig
+  include Traject::Macros::FolioFormat
+  include Traject::Macros::Extras
+
+  # rubocop:disable Metrics/AbcSize
+  # rubocop:disable Metrics/MethodLength
+  def add_folio_format_fields
+    to_field 'format_hsim',
+             condition(
+               leader?(byte: 6, values: %w[p t d f]),
+               literal('Archive/Manuscript')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 6, values: %w[a]),
+               leader?(byte: 7, values: %w[c]),
+               literal('Archive/Manuscript')
+             )
+
+    to_field 'format_hsim',
+             condition(
+               marc_subfield?('245', subfield: 'h', values: [%r{manuscript|manuscript/digital}]),
+               literal('Archive/Manuscript')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 6, values: %w[a t]),
+               leader?(byte: 7, values: %w[a m]),
+               literal('Book')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 7, values: %w[s]),
+               control_field_byte?('008', byte: 21, values: ['m']),
+               literal('Book')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               control_field_byte?('006', byte: 0, values: ['s']),
+               control_field_byte?('006', byte: 4, values: ['m']),
+               literal('Book')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 7, values: %w[s]),
+               control_field_byte?('008', byte: 21, values: ['d']),
+               literal('Database')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               control_field_byte?('006', byte: 0, values: ['s']),
+               control_field_byte?('006', byte: 4, values: ['d']),
+               literal('Database')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 6, values: %w[m]),
+               control_field_byte?('008', byte: 26, values: ['j']),
+               literal('Database')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 6, values: %w[m]),
+               control_field_byte?('008', byte: 26, values: ['a']),
+               literal('Dataset')
+             )
+
+    to_field 'format_hsim' do |record, acc, _ctx|
+      acc << 'Equipment' if record.respond_to?(:holdings) && record.holdings.any? { |h| h.dig('holdingsType', 'name') == 'Equipment' }
+    end
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 6, values: %w[k]),
+               control_field_byte?('008', byte: 33, values: [/[aciklnopst 0-9|]/]),
+               literal('Image')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               leader?(byte: 6, values: %w[g]),
+               control_field_byte?('008', byte: 33, values: [/[ aciklnopst]/]),
+               literal('Image')
+             )
+
+    image_terms = [
+      'art original', 'digital graphic', 'slide', 'slides', 'chart', 'art reproduction', 'graphic', 'technical drawing', 'flash card', 'transparency', 'activity card', 'picture', 'graphic/digital graphic', 'diapositives'
+    ]
+
+    to_field 'format_hsim',
+             condition(
+               marc_subfield?('245', subfield: 'h', values: image_terms),
+               literal('Image')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               control_field_byte?('007', byte: 0, values: %w[k r]),
+               marc_subfield?('245', subfield: 'h', values: %w[kit]),
+               literal('Image')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               control_field_byte?('007', byte: 0, values: %w[k]),
+               control_field_byte?('007', byte: 1, values: %w[g h r v]),
+               literal_multiple('Image', 'Image|Photo')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               control_field_byte?('007', byte: 0, values: %w[k]),
+               control_field_byte?('007', byte: 1, values: %w[k]),
+               literal_multiple('Image', 'Image|Poster')
+             )
+
+    to_field 'format_hsim',
+             all_conditions(
+               control_field_byte?('007', byte: 0, values: %w[g]),
+               control_field_byte?('007', byte: 1, values: %w[s]),
+               literal_multiple('Image', 'Image|Slide')
+             )
+  end
+end
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/MethodLength

--- a/lib/traject/macros/extras.rb
+++ b/lib/traject/macros/extras.rb
@@ -72,6 +72,17 @@ module Traject
           accumulator.replace(centuries.to_a + decades.to_a + hierarchicalized_years)
         end
       end
+
+      # Similar to Traject's built-in `literal` macro,
+      # but allows for multiple values to be added to the accumulator.
+      #
+      # Usage:
+      #   to_field 'sample', literal_multiple('Image', 'Image|Slide')
+      def literal_multiple(*values)
+        lambda do |_record, accumulator, _context|
+          values.each { |value| accumulator << value }
+        end
+      end
     end
   end
 end

--- a/lib/traject/macros/folio_format.rb
+++ b/lib/traject/macros/folio_format.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+module Traject
+  module Macros
+    module FolioFormat
+      # Combine conditions with an action lambda
+      # Returns a method that calls the action only if all conditions pass
+      #
+      # Usage:
+      #   to_field 'sample', all_conditions(cond1, cond2, action_lambda)
+      #
+      # where cond = ->(rec, ctx) { true/false }
+      # and action_lambda = ->(rec, acc, ctx) { acc << 'value' }
+      def all_conditions(*args)
+        *conditions, action = args
+
+        lambda do |record, accumulator, context|
+          action.call(record, accumulator, context) if conditions.all? { |condition| condition.call(record, context) }
+        end
+      end
+
+      # Condition + action for a single condition only
+      #
+      # Usage:
+      #   to_field 'sample', conditional(condition, action_lambda)
+      #
+      # where cond = ->(rec, ctx) { true/false }
+      # and action_lambda = ->(rec, acc, ctx) { acc << 'value' }
+      def condition(condition, action)
+        lambda do |record, accumulator, context|
+          action.call(record, accumulator, context) if condition.call(record, context)
+        end
+      end
+
+      # Check if the MARC leader byte matches any of the specified values
+      #
+      # Usage:
+      #   leader?(byte: 6, values: ['p', 't', 'd', 'f'])
+      def leader?(byte:, values:)
+        lambda do |record, _context|
+          leader = record.leader
+          return false unless leader && leader.length > byte
+
+          values.include?(leader[byte])
+        end
+      end
+
+      # Check a MARC subfield (like '245$h') for matching values
+      #
+      # Usage:
+      #   marc_subfield('245', subfield: 'h', values: ['manuscript', 'manuscript/digital'])
+      def marc_subfield?(tag, subfield:, values:)
+        values = Array(values)
+
+        lambda do |record, _context|
+          record.fields(tag).any? do |field|
+            field.subfields.any? do |sf|
+              next unless sf.code == subfield
+
+              field_value = sf.value
+              values.any? do |v|
+                v.is_a?(Regexp) ? field_value.match?(v) : field_value == v
+              end
+            end
+          end
+        end
+      end
+
+      # Check a control field (like '008') at a specific byte for matching values
+      #
+      # Usage:
+      #   control_field_byte('008', byte: 26, values: ['a'])
+      def control_field_byte?(tag, byte:, values:)
+        values = Array(values)
+
+        lambda do |record, _context|
+          record.fields(tag).any? do |field|
+            field_value = field.value
+            next false unless field_value && field_value.length > byte
+
+            character = field_value[byte]
+            values.any? do |v|
+              v.is_a?(Regexp) ? character.match?(v) : character == v
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/traject/config/folio_format_config_spec.rb
+++ b/spec/lib/traject/config/folio_format_config_spec.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+RSpec.describe 'format_hsim config' do
+  let(:indexer) do
+    Traject::Indexer.new.tap do |i|
+      i.load_config_file('./lib/traject/config/folio_config.rb')
+    end
+  end
+
+  let(:instance) { {} }
+  subject(:result) { indexer.map_record(folio_record) }
+  let(:folio_record) { marc_to_folio(record, instance:) }
+  let(:field) { 'format_hsim' }
+
+  before do
+    allow(folio_record).to receive(:index_items).and_return(holdings)
+    allow(folio_record).to receive(:holdings).and_return(holdings)
+  end
+
+  let(:holdings) { [] }
+
+  describe 'format_hsim' do
+    context 'when record is a Manuscript' do
+      context 'when leader[6] = p' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cpm  2200457Ia 4500'
+          end
+        end
+
+        it 'maps to Archive/Manuscript' do
+          expect(result[field]).to eq ['Archive/Manuscript']
+        end
+      end
+
+      context 'when leader[6] = a and leader[7] = c' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cac  2200457Ia 4500'
+          end
+        end
+
+        it 'maps to Archive/Manuscript' do
+          expect(result[field]).to eq ['Archive/Manuscript']
+        end
+      end
+
+      context '245h contains manuscripts' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '01952c d  2200457Ia 4500'
+            # We expect [manuscript] to be in brackets in the string
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'manuscript: 245h'),
+                                         MARC::Subfield.new('h', '[manuscript]')))
+          end
+        end
+
+        it 'maps to Archive/Manuscript' do
+          expect(result[field]).to eq ['Archive/Manuscript']
+        end
+      end
+    end
+
+    context 'when record is a Book' do
+      context 'when leader[6] = a and leader[7] = m' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cam  2200457Ia 4500'
+          end
+        end
+
+        it 'maps to Book' do
+          expect(result[field]).to eq ['Book']
+        end
+      end
+
+      context 'when leader[7] = s and 008[21] = m' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = 'p1952cas  2200457Ia 4500'
+            r.append(MARC::ControlField.new('008', '000000000000000000000m000000000000000000'))
+          end
+        end
+
+        it 'maps to Book' do
+          expect(result[field]).to eq ['Book']
+        end
+      end
+
+      context 'when 006[0] = s and 006[4] = m' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(MARC::ControlField.new('006', 's000m00000000000000'))
+          end
+        end
+
+        it 'maps to Book' do
+          expect(result[field]).to eq ['Book']
+        end
+      end
+    end
+    context 'when record is a Database' do
+      context 'when leader[7] = s and 008[21] = d' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '0000000s0000000000000000'
+            r.append(MARC::ControlField.new('008', '000000000000000000000d000000000000000000'))
+          end
+        end
+
+        it 'maps to Database' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+
+      context 'when 006[0] = s and 006[4] = d' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.append(MARC::ControlField.new('006', 's000d00000000000000'))
+          end
+        end
+
+        it 'maps to Database' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+
+      context 'when leader[6] = m and 008[26] = j' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+            r.append(MARC::ControlField.new('008', '00000000000000000000000000j00000000000'))
+          end
+        end
+
+        it 'maps to Database' do
+          expect(result[field]).to eq ['Database']
+        end
+      end
+    end
+
+    context 'when record is a Dataset' do
+      context 'when leader[6] = m and 008[26] = a' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000m00000000000000000'
+            r.append(MARC::ControlField.new('008', '00000000000000000000000000a00000000000'))
+          end
+        end
+
+        it 'maps to Dataset' do
+          expect(result[field]).to eq ['Dataset']
+        end
+      end
+    end
+
+    # TODO: add Equipment test. Need to stub FOLIO record/holdings.
+    # context 'when record is Equipment' do
+    # end
+
+    context 'when record is an Image' do
+      context 'when leader[6] = k and 008[33] matches [aciklnopst 0-9|]' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000k00000000000000000'
+            r.append(MARC::ControlField.new('008', '000000000000000000000000000000000a0000'))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when leader[6] = g and 008[33] matches [ aciklnopst]' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000g00000000000000000'
+            r.append(MARC::ControlField.new('008', '000000000000000000000000000000000k0000'))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when record is an Image based on 245h terms' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000a00000000000000000'
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'Example title'),
+                                         MARC::Subfield.new('h', 'technical drawing')))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when record is an Image based on 007 and 245h = kit' do
+        let(:record) do
+          MARC::Record.new.tap do |r|
+            r.leader = '000000a00000000000000000'
+            r.append(MARC::ControlField.new('007', 'k0000000000'))
+            r.append(MARC::DataField.new('245', '1', ' ',
+                                         MARC::Subfield.new('a', 'Example kit title'),
+                                         MARC::Subfield.new('h', 'kit')))
+          end
+        end
+
+        it 'maps to Image' do
+          expect(result[field]).to eq ['Image']
+        end
+      end
+
+      context 'when record is an Image|Photo' do
+        context 'when 007[0] = k and 007[1] in [g, h, r, v]' do
+          let(:record) do
+            MARC::Record.new.tap do |r|
+              r.leader = '000000a00000000000000000'
+              r.append(MARC::ControlField.new('007', 'kg0000000000'))
+            end
+          end
+
+          it 'maps to Image|Photo' do
+            expect(result[field]).to eq ['Image', 'Image|Photo']
+          end
+        end
+      end
+
+      context 'when record is an Image|Poster' do
+        context 'when 007[0] = k and 007[1] = k' do
+          let(:record) do
+            MARC::Record.new.tap do |r|
+              r.leader = '000000a00000000000000000'
+              r.append(MARC::ControlField.new('007', 'kk0000000000'))
+            end
+          end
+
+          it 'maps to Image|Poster' do
+            expect(result[field]).to eq ['Image', 'Image|Poster']
+          end
+        end
+      end
+
+      context 'when record is an Image|Slide' do
+        context 'when 007[0] = g and 007[1] = s' do
+          let(:record) do
+            MARC::Record.new.tap do |r|
+              r.leader = '000000a00000000000000000'
+              r.append(MARC::ControlField.new('007', 'gs0000000000'))
+            end
+          end
+
+          it 'maps to Image|Slide' do
+            puts "Result: #{result[field]}"
+            expect(result[field]).to eq ['Image', 'Image|Slide']
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/traject/macros/extras_spec.rb
+++ b/spec/lib/traject/macros/extras_spec.rb
@@ -83,4 +83,12 @@ RSpec.describe Traject::Macros::Extras do
       end
     end
   end
+
+  describe 'literal_multiple' do
+    let(:macro) { literal_multiple('Image', 'Image|Slide') }
+
+    it 'adds all the literal values to the accumulator' do
+      expect(accumulator).to eq ['Image', 'Image|Slide']
+    end
+  end
 end

--- a/spec/lib/traject/macros/folio_format_spec.rb
+++ b/spec/lib/traject/macros/folio_format_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'marc'
+require_relative '../../../../lib/traject/macros/folio_format'
+
+RSpec.describe Traject::Macros::FolioFormat do
+  include described_class
+
+  let(:record) { MARC::Record.new }
+  let(:context) { Traject::Indexer::Context.new }
+  let(:accumulator) { [] }
+
+  describe '#all_conditions' do
+    let(:action) { ->(_record, accumulator, _context) { accumulator << 'Image' } }
+
+    it 'calls the action if all conditions pass' do
+      # Check 2 conditions
+      macro = all_conditions(->(_record, _context) { true }, ->(_record, _context) { true }, action)
+      macro.call(record, accumulator, context)
+      expect(accumulator).to include('Image')
+    end
+
+    it 'does not call the action if any condition fails' do
+      # Check 2 conditions, one fails
+      macro = all_conditions(->(_record, _context) { true }, ->(_record, _context) { false }, action)
+      macro.call(record, accumulator, context)
+      expect(accumulator).to be_empty
+    end
+  end
+
+  describe '#condition' do
+    let(:action) { ->(_record, accumulator, _context) { accumulator << 'Image' } }
+
+    it 'calls action when single condition is true' do
+      macro = condition(->(_record, _context) { true }, action)
+      macro.call(record, accumulator, context)
+      expect(accumulator).to include('Image')
+    end
+
+    it 'does not call action when single condition is false' do
+      macro = condition(->(_record, _context) { false }, action)
+      macro.call(record, accumulator, context)
+      expect(accumulator).to be_empty
+    end
+  end
+
+  describe '#leader?' do
+    before { record.leader = '00000cam a2200000 i 4500' }
+
+    it 'returns true when byte matches one of the values' do
+      expect(leader?(byte: 6, values: %(a b c)).call(record, context)).to be true
+    end
+
+    it 'returns false when byte does not match' do
+      expect(leader?(byte: 6, values: %(x y z)).call(record, context)).to be false
+    end
+
+    it 'returns false when leader is nil' do
+      allow(record).to receive(:leader).and_return(nil)
+      expect(leader?(byte: 6, values: %(a b c)).call(record, context)).to be false
+    end
+  end
+
+  describe '#marc_subfield?' do
+    before do
+      record.append(
+        MARC::DataField.new('245', '1', '0',
+                            MARC::Subfield.new('h', 'Manuscript'))
+      )
+    end
+
+    it 'matches using regex' do
+      condition = marc_subfield?('245', subfield: 'h', values: [/Manu/i])
+      expect(condition.call(record, context)).to be true
+    end
+
+    it 'returns false if no matching string' do
+      condition = marc_subfield?('245', subfield: 'h', values: ['Databse'])
+      expect(condition.call(record, context)).to be false
+    end
+
+    it 'returns false if no matching subfield' do
+      condition = marc_subfield?('245', subfield: 'z', values: ['Manuscript'])
+      expect(condition.call(record, context)).to be false
+    end
+  end
+
+  describe '#control_field_byte?' do
+    before do
+      record.append(
+        MARC::ControlField.new('008', '0a000000000000000000000000000000000000')
+      )
+    end
+
+    it 'returns true with a match' do
+      condition = control_field_byte?('008', byte: 1, values: %w[a b c])
+      expect(condition.call(record, context)).to be true
+    end
+
+    it 'returns false when no match' do
+      condition = control_field_byte?('008', byte: 32, values: %w[x])
+      expect(condition.call(record, context)).to be false
+    end
+
+    it 'handles regex matching' do
+      condition = control_field_byte?('008', byte: 31, values: [/0/])
+      expect(condition.call(record, context)).to be true
+    end
+
+    it 'returns false if field is too short' do
+      short_field = MARC::ControlField.new('006', '000')
+      record.append(short_field)
+
+      condition = control_field_byte?('006', byte: 10, values: ['x'])
+      expect(condition.call(record, context)).to be false
+    end
+  end
+end


### PR DESCRIPTION
- Introduce `ResourceType` Traject macro module
- Define reusable matchers leader?, control_field_byte?, marc_subfield?
- Add literal_multiple method to Traject macro Extras

For reference see these files with the proposed changes and rules:
https://docs.google.com/document/d/1xR0cInOS2wlMzqGGY9ZLbxRb5PdUJ3b6jhnO6xr_upE/edit?tab=t.0
https://docs.google.com/spreadsheets/d/1NK5M1Ti8UG0XSfnRBWkgnF-seevfZWe3nEBowlV7R1g/edit?gid=0#gid=0

This PR does not cover every line, only the first few resource types. After the pattern is established and merged, I can continue down the list.
So this won't fully close #1632 but gets us partway there.

The macros take inspiration from `traject_plus` as well as the conditional logic included in Exhibits indexing.
