### PR TITLE
LC E + F prefixes never have subcategories.

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -1706,7 +1706,7 @@ to_field 'callnum_facet_hsim' do |record, accumulator, context|
     accumulator << [
       'LC Classification',
       translation_map[first_letter],
-      translation_map[letters]
+      (translation_map[letters] unless first_letter.in?(%w[E F]))
     ].compact.join('|')
   end
 end
@@ -1752,7 +1752,7 @@ to_field 'callnum_facet_hsim', extract_marc('050ab') do |record, accumulator, co
     [
       'LC Classification',
       translation_map[first_letter],
-      translation_map[letters]
+      (translation_map[letters] unless first_letter.in?(%w[E F]))
     ].compact.join('|')
   end
 
@@ -1776,7 +1776,7 @@ to_field 'callnum_facet_hsim', extract_marc('090ab') do |record, accumulator, co
     [
       'LC Classification',
       translation_map[first_letter],
-      translation_map[letters]
+      (translation_map[letters] unless first_letter.in?(%w[E F]))
     ].compact.join('|')
   end
 

--- a/spec/lib/traject/config/callnum_facet_spec.rb
+++ b/spec/lib/traject/config/callnum_facet_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Call Number Facet' do
 
       context 'with F call' do
         let(:call_number) { 'F1356 .M464 2005' }
-        it { is_expected.to eq ['LC Classification|F - United States, British, Dutch, French, Latin America (Local History)|F - United States, British, Dutch, French, Latin America (Local History)'] }
+        it { is_expected.to eq ['LC Classification|F - United States, British, Dutch, French, Latin America (Local History)'] }
       end
 
       context 'with M call' do


### PR DESCRIPTION
Fixes https://github.com/sul-dlss/SearchWorks/issues/5733