### PR TITLE
Do not index CALDOC call numbers as SUDOCs

### DIFF
--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -1879,6 +1879,7 @@ to_field 'sudoc_callnum_search' do |record, accumulator, context|
     next if item.skipped?
     next unless item.call_number_type == 'SUDOC'
     next if item.call_number.ignored_call_number?
+    next if item.call_number.valid_caldoc? # About a dozen items in Folio have CALDOC call numbers marked as SUDOCs (e.g., in00000451152)
 
     call_number = item.call_number.to_s
     call_number = call_number.strip


### PR DESCRIPTION
About a dozen items in Folio have Caldocs marked as Sudocs, resulting in the call number being stored twice. This is a relevancy issue because they have double the term frequency.