### PR TITLE
Use the label from the cocina record

### DIFF
--- a/lib/public_cocina_record.rb
+++ b/lib/public_cocina_record.rb
@@ -17,6 +17,10 @@ class PublicCocinaRecord
     @cocina_display = CocinaDisplay::CocinaRecord.new(@public_cocina_doc)
   end
 
+  def label
+    public_cocina_doc['label']
+  end
+
   def cocina_access
     @cocina_access ||= public_cocina_doc['access']
   end

--- a/lib/public_xml_record.rb
+++ b/lib/public_xml_record.rb
@@ -32,11 +32,6 @@ class PublicXmlRecord
       get_value(public_xml_doc.xpath("/publicObject/identityMetadata/otherId[@name='catkey']")).presence
   end
 
-  # @return objectLabel value from the DOR identity_metadata, or nil if there is no barcode
-  def label
-    get_value(public_xml_doc.xpath('/publicObject/identityMetadata/objectLabel'))
-  end
-
   def stanford_mods
     @stanford_mods ||= Stanford::Mods::Record.new.tap do |smods_rec|
       smods_rec.from_str(mods.to_s)

--- a/lib/purl_record.rb
+++ b/lib/purl_record.rb
@@ -45,7 +45,8 @@ class PurlRecord
   end
 
   # Ensure all objects, even those missing public xml/cocina have a (nil) catkey and a label
-  delegate :catkey, :label, to: :public_xml, allow_nil: true
+  delegate :catkey, to: :public_xml, allow_nil: true
+  delegate :label, to: :public_cocina, allow_nil: true
 
   delegate :mods, :collection?, :stanford_only?,
            :thumb, :dor_content_type, :dor_resource_content_type, :dor_file_mimetype,

--- a/spec/fixtures/files/hn730ks3626.json
+++ b/spec/fixtures/files/hn730ks3626.json
@@ -1,0 +1,68 @@
+{
+  "cocinaVersion": "0.104.1",
+  "type": "https://cocina.sul.stanford.edu/models/collection",
+  "externalIdentifier": "druid:hn730ks3626",
+  "label": "Stanford Libraries staff presentations, publications, and research",
+  "version": 7,
+  "access": { "view": "world" },
+  "administrative": { "hasAdminPolicy": "druid:zw306xn5593" },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Stanford Libraries staff presentations, publications, and research",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [],
+    "event": [],
+    "form": [],
+    "geographic": [],
+    "language": [],
+    "note": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Presentations, publications and research produced and contributed by the staff of Stanford Libraries on a broad range of topics relevant to academic and research libraries.",
+        "type": "abstract",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "identifier": [],
+    "subject": [],
+    "access": {
+      "url": [],
+      "physicalLocation": [],
+      "digitalLocation": [],
+      "accessContact": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "sdr-contact@lists.stanford.edu",
+          "type": "email",
+          "identifier": [],
+          "displayLabel": "Contact",
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "digitalRepository": [],
+      "note": []
+    },
+    "relatedResource": [],
+    "marcEncodedData": [],
+    "purl": "https://purl.stanford.edu/hn730ks3626"
+  },
+  "identification": { "catalogLinks": [], "sourceId": "hydrus:collection-76" },
+  "created": "2025-07-07T10:40:31.000+00:00",
+  "modified": "2025-07-07T10:40:32.000+00:00",
+  "lock": "druid:hn730ks3626=2=2"
+}

--- a/spec/fixtures/files/nj770kg7809.json
+++ b/spec/fixtures/files/nj770kg7809.json
@@ -1,0 +1,458 @@
+{
+  "cocinaVersion": "0.75.0",
+  "type": "https://cocina.sul.stanford.edu/models/collection",
+  "externalIdentifier": "druid:nj770kg7809",
+  "label": "Stanford University, News and Publication Service, audiovisual recordings, 1936-2011 (inclusive)",
+  "version": 1,
+  "access": {
+    "view": "world",
+    "useAndReproductionStatement": "The materials are open for research use and may be used freely for non-commercial purposes with an attribution. For commercial permission requests, please contact the Stanford University Archives (archivesref@stanford.edu)."
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:yf767bj4831",
+    "releaseTags": [
+      {
+        "who": "dhartwig",
+        "what": "collection",
+        "date": "2017-06-20T21:05:06.000+00:00",
+        "to": "Searchworks",
+        "release": true
+      }
+    ]
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Stanford University, News and Publication Service, audiovisual recordings, 1936-2011 (inclusive)",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "Stanford University",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "News Service.",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "organization",
+        "role": [],
+        "identifier": [],
+        "note": [],
+        "parallelContributor": []
+      }
+    ],
+    "event": [
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1936",
+                "type": "start",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "2011",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "publication",
+            "encoding": { "code": "marc", "note": [] },
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [],
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "monographic",
+            "type": "issuance",
+            "identifier": [],
+            "source": { "value": "MODS issuance terms", "note": [] },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelEvent": []
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Audiotapes.",
+        "type": "genre",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Interviews.",
+        "type": "genre",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "mixed material",
+        "type": "resource type",
+        "identifier": [],
+        "source": { "value": "MODS resource types", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "manuscript",
+        "identifier": [],
+        "source": { "value": "MODS resource types", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "collection",
+        "identifier": [],
+        "source": { "value": "MODS resource types", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "63 linear feet",
+        "type": "extent",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "17.4 gigabytes",
+        "type": "extent",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "geographic": [],
+    "language": [
+      {
+        "appliesTo": [],
+        "code": "eng",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": { "code": "iso639-2b", "note": [] },
+        "structuredValue": []
+      }
+    ],
+    "note": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "The materials consist of audio and video recordings done by the News and Publication Service.",
+        "type": "abstract",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "[identification of item], Stanford University, News and Publication Service, Audiovisual Recordings (SC1125). Dept. of Special Collections and University Archives, Stanford University Libraries, Stanford, Calif.",
+        "type": "preferred citation",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "All requests to reproduce, publish, quote from, or otherwise use collection materials must be submitted in writing to the Head of Special Collections and University Archives, Stanford University Libraries, Stanford, California 94305-6064. Consent is given on behalf of Special Collections as the owner of the physical items and is not intended to include or imply permission from the copyright owner. Such permission must be obtained from the copyright owner, heir(s) or assigns. See: http://library.stanford.edu/depts/spc/pubserv/permissions.html. Restrictions also apply to digital representations of the original materials. Use of digital files is restricted to research and educational purposes.",
+        "type": "acquisition",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "identifier": [],
+    "subject": [
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Stanford University",
+            "type": "organization",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Administration",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Stanford University",
+            "type": "organization",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Faculty",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "access": {
+      "url": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "http://www.oac.cdlib.org/findaid/ark:/13030/c8dn43sv",
+          "status": "primary",
+          "identifier": [],
+          "displayLabel": "Finding aid",
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "physicalLocation": [],
+      "digitalLocation": [],
+      "accessContact": [],
+      "digitalRepository": [],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "The materials are open for research use. Audio-visual materials are not available in original format, and must be reformatted to a digital use copy.",
+          "type": "access restriction",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ]
+    },
+    "relatedResource": [],
+    "marcEncodedData": [],
+    "adminMetadata": {
+      "contributor": [
+        {
+          "name": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "code": "CSt",
+              "identifier": [],
+              "source": { "code": "marcorg", "note": [] },
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "type": "organization",
+          "role": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "original cataloging agency",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "identifier": [],
+          "note": [],
+          "parallelContributor": []
+        }
+      ],
+      "event": [
+        {
+          "structuredValue": [],
+          "type": "creation",
+          "date": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "120724",
+              "encoding": { "code": "marc", "note": [] },
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "contributor": [],
+          "location": [],
+          "identifier": [],
+          "note": [],
+          "parallelEvent": []
+        },
+        {
+          "structuredValue": [],
+          "type": "modification",
+          "date": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "20120729011058.0",
+              "encoding": { "code": "iso8601", "note": [] },
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "contributor": [],
+          "location": [],
+          "identifier": [],
+          "note": [],
+          "parallelEvent": []
+        }
+      ],
+      "language": [],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)",
+          "type": "record origin",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "metadataStandard": [
+        { "code": "aacr", "note": [] },
+        { "code": "dacs", "note": [] }
+      ],
+      "identifier": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "a9665836",
+          "type": "SIRSI",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ]
+    },
+    "purl": "https://purl.stanford.edu/nj770kg7809"
+  },
+  "identification": {
+    "catalogLinks": [
+      { "catalog": "folio", "refresh": true, "catalogRecordId": "a9665836" },
+      { "catalog": "symphony", "refresh": true, "catalogRecordId": "9665836" }
+    ]
+  },
+  "created": "2022-04-29T12:50:24.000+00:00",
+  "modified": "2022-04-29T12:50:24.000+00:00",
+  "lock": "druid:nj770kg7809=0"
+}

--- a/spec/fixtures/files/sg213ph2100.json
+++ b/spec/fixtures/files/sg213ph2100.json
@@ -1,0 +1,783 @@
+{
+  "cocinaVersion": "0.75.0",
+  "type": "https://cocina.sul.stanford.edu/models/collection",
+  "externalIdentifier": "druid:sg213ph2100",
+  "label": "Reid W. Dennis collection of California lithographs, 1850-1906",
+  "version": 4,
+  "access": {
+    "view": "world",
+    "copyright": "Copyright © Stanford University. All Rights Reserved.",
+    "useAndReproductionStatement": "Property rights reside with the repository. Literary rights reside with the creators of the documents or their heirs. To obtain permission to publish or reproduce, please contact the Special Collections Public Services Librarian at speccollref@stanford.edu."
+  },
+  "administrative": {
+    "hasAdminPolicy": "druid:sd064kn5856",
+    "releaseTags": [
+      {
+        "who": "lauraw15",
+        "what": "self",
+        "date": "2016-03-22T20:27:58.000+00:00",
+        "to": "Searchworks",
+        "release": true
+      }
+    ]
+  },
+  "description": {
+    "title": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Reid W. Dennis collection of California lithographs, 1850-1906",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "contributor": [
+      {
+        "name": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Dennis, Reid W.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "type": "person",
+        "status": "primary",
+        "role": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "collector.",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [],
+        "parallelContributor": []
+      }
+    ],
+    "event": [
+      {
+        "structuredValue": [],
+        "date": [
+          {
+            "structuredValue": [
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1850",
+                "type": "start",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              },
+              {
+                "structuredValue": [],
+                "parallelValue": [],
+                "groupedValue": [],
+                "value": "1906",
+                "type": "end",
+                "identifier": [],
+                "note": [],
+                "appliesTo": []
+              }
+            ],
+            "parallelValue": [],
+            "groupedValue": [],
+            "type": "publication",
+            "encoding": { "code": "marc", "note": [] },
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "contributor": [],
+        "location": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "code": "cau",
+            "identifier": [],
+            "source": { "code": "marccountry", "note": [] },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "monographic",
+            "type": "issuance",
+            "identifier": [],
+            "source": { "value": "MODS issuance terms", "note": [] },
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelEvent": []
+      }
+    ],
+    "form": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Lithographs.",
+        "type": "genre",
+        "identifier": [],
+        "source": { "code": "ftamc", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "mixed material",
+        "type": "resource type",
+        "identifier": [],
+        "source": { "value": "MODS resource types", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "manuscript",
+        "identifier": [],
+        "source": { "value": "MODS resource types", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "collection",
+        "identifier": [],
+        "source": { "value": "MODS resource types", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "51 prints and 1 lithograph stone.",
+        "type": "extent",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "geographic": [],
+    "language": [
+      {
+        "appliesTo": [],
+        "code": "eng",
+        "groupedValue": [],
+        "note": [],
+        "parallelValue": [],
+        "source": { "code": "iso639-2b", "note": [] },
+        "structuredValue": []
+      }
+    ],
+    "note": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "This collection of prints, mostly lithographs (including chromolithographs and colored lithographs), as well as one engraving, primarily portray San Francisco city views, public buildings, and landscapes. Subjects also include San Jose, Stanford University, the U.S. Navy Yard at Mare Island, San Diego, and San Luis Rey. Included is a lithograph stone with an image of San Francisco.",
+        "type": "abstract",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Gift of Reid W. Dennis, 2004, 2007, and 2013. Accessions 2004-095 (49 prints), 2007-076 (1 print), and 2013-143 (1 print)",
+        "type": "acquisition",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "identifier": [],
+    "subject": [
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Baker, George H",
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "lithographer.",
+            "type": "role",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Couts, Cave Johnson",
+            "type": "name",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "1821-1874",
+            "type": "life dates",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Dennis, Reid W",
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "collector.",
+            "type": "role",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Kuchel, Charles Conrad",
+            "type": "name",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "1820-",
+            "type": "life dates",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "McMurtrie, W. B. (William Birch)",
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Méryon, Charles",
+            "type": "name",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "1821-1868",
+            "type": "life dates",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Nahl, Charles Christian",
+            "type": "name",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "1818-1878",
+            "type": "life dates",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Swasey, W. F. (William F.)",
+        "type": "person",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Beach, Ghilion",
+        "type": "person",
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "publisher.",
+            "type": "role",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Bridgens, R.P",
+        "type": "person",
+        "identifier": [],
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Bosqui Eng. \u0026 Print. Co.",
+        "type": "organization",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Britton \u0026 Rey.",
+        "type": "organization",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Elliott Lithography Company (San Francisco)",
+        "type": "organization",
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [],
+        "parallelValue": [],
+        "groupedValue": [],
+        "value": "Gray (W. Vallance) \u0026 C.B. Gifford,",
+        "type": "organization",
+        "identifier": [],
+        "note": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "lithographers.",
+            "type": "role",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "San Francisco (Calif.)",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "History",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Pictorial works",
+            "type": "genre",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "San Diego (Calif.)",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "History",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Pictorial works",
+            "type": "genre",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "San Jose (Calif.)",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "History",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Pictorial works",
+            "type": "genre",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      },
+      {
+        "structuredValue": [
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "San Luis Rey (Calif.)",
+            "type": "place",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "History",
+            "type": "topic",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          },
+          {
+            "structuredValue": [],
+            "parallelValue": [],
+            "groupedValue": [],
+            "value": "Pictorial works",
+            "type": "genre",
+            "identifier": [],
+            "note": [],
+            "appliesTo": []
+          }
+        ],
+        "parallelValue": [],
+        "groupedValue": [],
+        "identifier": [],
+        "source": { "code": "lcsh", "note": [] },
+        "note": [],
+        "appliesTo": []
+      }
+    ],
+    "access": {
+      "url": [],
+      "physicalLocation": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Department of Special Collections, Stanford University Libraries, Stanford, CA 94305.",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "digitalLocation": [],
+      "accessContact": [],
+      "digitalRepository": [],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Open for research; material must be requested at least 36 hours in advance of intended use.",
+          "type": "access restriction",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ]
+    },
+    "relatedResource": [],
+    "marcEncodedData": [],
+    "adminMetadata": {
+      "contributor": [
+        {
+          "name": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "code": "CSt",
+              "identifier": [],
+              "source": { "code": "marcorg", "note": [] },
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "type": "organization",
+          "role": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "original cataloging agency",
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "identifier": [],
+          "note": [],
+          "parallelContributor": []
+        }
+      ],
+      "event": [
+        {
+          "structuredValue": [],
+          "type": "creation",
+          "date": [
+            {
+              "structuredValue": [],
+              "parallelValue": [],
+              "groupedValue": [],
+              "value": "070403",
+              "encoding": { "code": "marc", "note": [] },
+              "identifier": [],
+              "note": [],
+              "appliesTo": []
+            }
+          ],
+          "contributor": [],
+          "location": [],
+          "identifier": [],
+          "note": [],
+          "parallelEvent": []
+        }
+      ],
+      "language": [],
+      "note": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "Converted from MARCXML to MODS version 3.4 using MARC21slim2MODS3-4_SDR.xsl (Version 1.2.5 2013/08/11)",
+          "type": "record origin",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ],
+      "metadataStandard": [{ "code": "dacs", "note": [] }],
+      "identifier": [
+        {
+          "structuredValue": [],
+          "parallelValue": [],
+          "groupedValue": [],
+          "value": "a6780453",
+          "type": "SIRSI",
+          "identifier": [],
+          "note": [],
+          "appliesTo": []
+        }
+      ]
+    },
+    "purl": "https://purl.stanford.edu/sg213ph2100"
+  },
+  "identification": {
+    "catalogLinks": [
+      { "catalog": "folio", "refresh": true, "catalogRecordId": "a6780453" },
+      { "catalog": "symphony", "refresh": true, "catalogRecordId": "6780453" }
+    ]
+  },
+  "created": "2022-04-30T20:54:14.000+00:00",
+  "modified": "2022-04-30T20:54:14.000+00:00",
+  "lock": "druid:sg213ph2100=0"
+}

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -13,12 +13,9 @@ RSpec.describe 'SDR indexing' do
   let(:record) { PurlRecord.new(druid, purl_url: 'https://purl.stanford.edu') }
   let(:earthworks) { true }
 
-  def stub_purl_request(druid, body)
-    stub_request(:get, "https://purl.stanford.edu/#{druid}.xml").to_return(status: 200, body:)
-  end
-
-  before do
-    stub_request(:get, "https://purl.stanford.edu/#{druid}.json").to_return(status: 404)
+  def stub_purl_request(druid, xml:, json: nil)
+    stub_request(:get, "https://purl.stanford.edu/#{druid}.xml").to_return(status: 200, body: xml)
+    stub_request(:get, "https://purl.stanford.edu/#{druid}.json").to_return(status: 200, body: json) if json
   end
 
   before do
@@ -42,8 +39,8 @@ RSpec.describe 'SDR indexing' do
     let(:collection_druid) { 'nj770kg7809' }
 
     before do
-      stub_purl_request(druid, File.read(file_fixture("#{druid}.xml").to_s))
-      stub_purl_request(collection_druid, File.read(file_fixture("#{collection_druid}.xml").to_s))
+      stub_purl_request(druid, xml: File.read(file_fixture("#{druid}.xml").to_s))
+      stub_purl_request(collection_druid, xml: File.read(file_fixture("#{collection_druid}.xml").to_s), json: File.read(file_fixture("#{collection_druid}.json").to_s))
     end
 
     it 'maps the data the same way as it does currently' do
@@ -102,8 +99,8 @@ RSpec.describe 'SDR indexing' do
     let(:collection_druid) { 'zc193vn8689' }
 
     before do
-      stub_purl_request(druid, File.read(file_fixture("#{druid}.xml").to_s))
-      stub_purl_request(collection_druid, File.read(file_fixture("#{collection_druid}.xml").to_s))
+      stub_purl_request(druid, xml: File.read(file_fixture("#{druid}.xml").to_s))
+      stub_purl_request(collection_druid, xml: File.read(file_fixture("#{collection_druid}.xml").to_s))
     end
 
     context 'geo is released to earthworks' do
@@ -175,7 +172,7 @@ RSpec.describe 'SDR indexing' do
     let(:druid) { 'abc' }
     let(:collection_druid) { 'abccoll' }
     let(:collection_label) { '' }
-    let(:data) do
+    let(:xml_data) do
       <<-XML
         <publicObject>
           <mods xmlns="http://www.loc.gov/mods/v3">
@@ -189,7 +186,7 @@ RSpec.describe 'SDR indexing' do
         </publicObject>
       XML
     end
-    let(:collection_data) do
+    let(:collection_xml_data) do
       <<-XML
       <publicObject>
         <identityMetadata>
@@ -198,10 +195,15 @@ RSpec.describe 'SDR indexing' do
       </publicObject>
       XML
     end
+    let(:collection_json_data) do
+      {
+        'label' => collection_label
+      }.to_json
+    end
 
     before do
-      stub_purl_request(druid, data)
-      stub_purl_request(collection_druid, collection_data)
+      stub_purl_request(druid, xml: xml_data)
+      stub_purl_request(collection_druid, xml: collection_xml_data, json: collection_json_data)
     end
 
     context 'with an honors thesis' do
@@ -284,7 +286,7 @@ RSpec.describe 'SDR indexing' do
 
   describe 'identifiers' do
     let(:druid) { 'abc' }
-    let(:data) do
+    let(:xml_data) do
       <<-XML
         <publicObject>
           <mods xmlns="http://www.loc.gov/mods/v3">
@@ -301,7 +303,7 @@ RSpec.describe 'SDR indexing' do
     end
 
     before do
-      stub_purl_request(druid, data)
+      stub_purl_request(druid, xml: xml_data)
     end
 
     it 'maps the appropriate identifier types' do
@@ -316,7 +318,7 @@ RSpec.describe 'SDR indexing' do
 
   describe 'content metadata' do
     let(:druid) { 'abc' }
-    let(:data) do
+    let(:xml_data) do
       <<-XML
         <publicObject>
           <contentMetadata type="image">
@@ -338,7 +340,7 @@ RSpec.describe 'SDR indexing' do
     end
 
     before do
-      stub_purl_request(druid, data)
+      stub_purl_request(druid, xml: xml_data)
     end
 
     it 'maps the right data' do
@@ -351,7 +353,7 @@ RSpec.describe 'SDR indexing' do
 
   describe 'rights metadata' do
     let(:druid) { 'abc' }
-    let(:data) do
+    let(:xml_data) do
       <<-XML
         <publicObject>
           <rightsMetadata>
@@ -375,7 +377,7 @@ RSpec.describe 'SDR indexing' do
     end
 
     before do
-      stub_purl_request(druid, data)
+      stub_purl_request(druid, xml: xml_data)
     end
 
     it 'maps the right data' do
@@ -385,7 +387,7 @@ RSpec.describe 'SDR indexing' do
 
   describe 'pub_country' do
     let(:druid) { 'abc' }
-    let(:data) do
+    let(:xml_data) do
       <<-XML
         <publicObject>
           <mods xmlns="http://www.loc.gov/mods/v3">
@@ -407,7 +409,7 @@ RSpec.describe 'SDR indexing' do
     end
 
     before do
-      stub_purl_request(druid, data)
+      stub_purl_request(druid, xml: xml_data)
     end
 
     it 'maps the right data' do
@@ -420,8 +422,8 @@ RSpec.describe 'SDR indexing' do
     let(:collection_druid) { 'sg213ph2100' }
 
     before do
-      stub_purl_request(druid, File.read(file_fixture("#{druid}.xml").to_s))
-      stub_purl_request(collection_druid, File.read(file_fixture("#{collection_druid}.xml").to_s))
+      stub_purl_request(druid, xml: File.read(file_fixture("#{druid}.xml").to_s))
+      stub_purl_request(collection_druid, xml: File.read(file_fixture("#{collection_druid}.xml").to_s), json: File.read(file_fixture("#{collection_druid}.json").to_s))
     end
 
     it 'maps the data' do
@@ -439,8 +441,8 @@ RSpec.describe 'SDR indexing' do
     let(:collection_druid) { 'hn730ks3626' }
 
     before do
-      stub_purl_request(druid, File.read(file_fixture("#{druid}.xml").to_s))
-      stub_purl_request(collection_druid, File.read(file_fixture("#{collection_druid}.xml").to_s))
+      stub_purl_request(druid, xml: File.read(file_fixture("#{druid}.xml").to_s))
+      stub_purl_request(collection_druid, xml: File.read(file_fixture("#{collection_druid}.xml").to_s), json: File.read(file_fixture("#{collection_druid}.json").to_s))
     end
 
     it 'turns mods author data into a structure' do
@@ -465,8 +467,8 @@ RSpec.describe 'SDR indexing' do
     let(:collection_druid) { 'nj770kg7809' }
 
     before do
-      stub_purl_request(druid, File.read(file_fixture("#{druid}.xml").to_s))
-      stub_purl_request(collection_druid, File.read(file_fixture("#{collection_druid}.xml").to_s))
+      stub_purl_request(druid, xml: File.read(file_fixture("#{druid}.xml").to_s))
+      stub_purl_request(collection_druid, xml: File.read(file_fixture("#{collection_druid}.xml").to_s), json: File.read(file_fixture("#{collection_druid}.json").to_s))
       allow(Settings.sdr_events).to receive(:enabled).and_return(true)
       allow(SdrEvents).to receive_messages(
         report_indexing_success: true,


### PR DESCRIPTION
This is a step toward decoupling from public XML and getting the values directly from the canonical Cocina