### PR TITLE
Drop unused field dor_read_rights_ssim

### DIFF
--- a/lib/purl_record.rb
+++ b/lib/purl_record.rb
@@ -50,7 +50,7 @@ class PurlRecord
 
   delegate :mods, :collection?, :stanford_only?,
            :thumb, :dor_content_type, :dor_resource_content_type, :dor_file_mimetype,
-           :dor_resource_count, :dor_read_rights, :collections, :constituents,
+           :dor_resource_count, :collections, :constituents,
            :stanford_mods, :mods_display,
            :public_xml_doc, to: :public_xml
 

--- a/lib/traject/config/sdr_config.rb
+++ b/lib/traject/config/sdr_config.rb
@@ -403,14 +403,6 @@ to_field 'dor_resource_count_isi' do |record, accumulator|
   accumulator << record.dor_resource_count
 end
 
-# For finding fixtures with different types. Not currently used in Searchworks
-# The possible values are: "world", "group", "none", or "location"
-to_field 'dor_read_rights_ssim' do |record, accumulator|
-  record.dor_read_rights.uniq.each do |right|
-    accumulator << right
-  end
-end
-
 to_field 'context_source_ssi', literal('sdr')
 
 to_field 'context_version_ssi' do |_record, accumulator|

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -351,40 +351,6 @@ RSpec.describe 'SDR indexing' do
     end
   end
 
-  describe 'rights metadata' do
-    let(:druid) { 'abc' }
-    let(:xml_data) do
-      <<-XML
-        <publicObject>
-          <rightsMetadata>
-            <access type="discover">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <access type="read">
-              <machine>
-                <world/>
-              </machine>
-            </access>
-            <use>
-              <human type="useAndReproduction">Property rights reside with the repository.</human>
-            </use>
-          </rightsMetadata>
-          <mods xmlns="http://www.loc.gov/mods/v3"></mods>
-        </publicObject>
-      XML
-    end
-
-    before do
-      stub_purl_request(druid, xml: xml_data)
-    end
-
-    it 'maps the right data' do
-      expect(result['dor_read_rights_ssim']).to eq ['world']
-    end
-  end
-
   describe 'pub_country' do
     let(:druid) { 'abc' }
     let(:xml_data) do


### PR DESCRIPTION
The documentation said this could be used for finding fixtures of different types, but argo already serves this need. We also have an extensive list of fixtures documented here: https://github.com/sul-dlss/purl/blob/main/config/settings/development.yml\#L4-L47

This helps us decouple from XML metadata.