### PR TITLE
Remove title_245a_display from SDR objects

### DIFF
--- a/lib/traject/config/sdr_config.rb
+++ b/lib/traject/config/sdr_config.rb
@@ -158,7 +158,6 @@ to_field 'title_245a_search', stanford_mods(:sw_short_title, default: '[Untitled
 to_field 'title_245_search', stanford_mods(:sw_full_title, default: '[Untitled]')
 to_field 'title_variant_search', stanford_mods(:sw_addl_titles)
 to_field 'title_sort', stanford_mods(:sw_sort_title, default: '[Untitled]')
-to_field 'title_245a_display', stanford_mods(:sw_sort_title, default: '[Untitled]')
 to_field 'title_display', stanford_mods(:sw_title_display, default: '[Untitled]')
 to_field 'title_full_display', stanford_mods(:sw_full_title, default: '[Untitled]')
 

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -52,7 +52,6 @@ RSpec.describe 'SDR indexing' do
           'title_245a_search' => ['Trustees Demo reel'],
           'title_245_search' => ['Trustees Demo reel.'],
           'title_sort' => ['Trustees Demo reel'],
-          'title_245a_display' => ['Trustees Demo reel'],
           'title_display' => ['Trustees Demo reel'],
           'title_full_display' => ['Trustees Demo reel.'],
           'author_7xx_search' => ['Stanford University. News and Publications Service'],


### PR DESCRIPTION
This field is only ever used by databases, which are not in SDR.  We are currently using the sort method for this value, which strips punctuation, so this implementation would not be appropriate anyway.