### PR TITLE
Adjust formatting of SDR publication year and date fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 gem 'activesupport', '~> 8.0'
 gem 'slop'
 
-gem 'cocina_display', '~> 1'
+gem 'cocina_display', '~> 2'
 gem 'dor-event-client'
 gem 'factory_bot', '~> 6.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina_display (1.12.2)
+    cocina_display (2.0.0)
       activesupport (>= 7)
       edtf (~> 3.2)
       geo_coord (~> 0.2)
@@ -275,7 +275,7 @@ DEPENDENCIES
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-shared_configs
-  cocina_display (~> 1)
+  cocina_display (~> 2)
   config
   csv
   debouncer
@@ -323,7 +323,7 @@ CHECKSUMS
   capistrano-one_time_key (0.2.0) sha256=88630a99de2113befd9885242cc8b3bc58536f4e06507363cc3ee064080a0375
   capistrano-shared_configs (0.2.2) sha256=905d1c51f0be6efd8ddb262aea7fae32c62d947297ff6b83f5cbccac3b138b36
   chronic (0.10.2) sha256=766f2fcce6ac3cc152249ed0f2b827770d3e517e2e87c5fba7ed74f4889d2dc3
-  cocina_display (1.12.2) sha256=7b263d108975d02a87ff462e271cbb10a52954db764193b9f35307ac602e6c88
+  cocina_display (2.0.0) sha256=d0422e09fbdb9bdca8abd141ad9e147d274f07b9f0a0d6c6df142f3d3f7218d7
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   config (5.6.1) sha256=a9f0f0f9ffa6d12d43147a3fa1ab8486fe484c3098a350c6a2e0f32430e0d1cc
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a

--- a/lib/traject/config/sdr_config.rb
+++ b/lib/traject/config/sdr_config.rb
@@ -155,13 +155,10 @@ to_field 'era_facet', cocina_display(:subject_temporal)
 
 ##
 # Publication Fields
-# TODO: remove pub_date and pub_date_sort; see: https://github.com/sul-dlss/SearchWorks/issues/6410
-to_field 'pub_date', cocina_display(:pub_year_str)
-to_field 'pub_date_sort', cocina_display(:pub_year_str)
-to_field 'pub_search', cocina_display(:publication_places)
-to_field 'publication_year_isi', cocina_display(:pub_year_int)
+to_field 'pub_date', cocina_display(:pub_date_str)
 to_field 'pub_year_ss', cocina_display(:pub_year_str)
-to_field 'imprint_display', cocina_display(:imprint_str)
+to_field 'pub_date_sort', cocina_display(:pub_date_sort_str)
+to_field 'pub_search', cocina_display(:imprint_str)
 to_field 'pub_country', cocina_display(:publication_countries)
 to_field 'pub_year_tisim', cocina_display(:pub_year_ints)
 

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -202,22 +202,24 @@ RSpec.describe 'SDR indexing' do
     let(:druid) { 'bm971cx9348' }
     let(:collection_druid) { 'yh583fk3400' }
 
-    it 'maps the publication year as a string for display/sort' do
+    it 'maps the publication date as a string for search' do
       expect(result['pub_date']).to eq ['1920 -']
+    end
+
+    it 'maps the publication date as a string for sorting' do
+      expect(result['pub_date_sort']).to eq ['19200000']
+    end
+
+    it 'maps the publication year for display on search results' do
       expect(result['pub_year_ss']).to eq ['1920 -']
-      expect(result['pub_date_sort']).to eq ['1920 -']
     end
 
-    it 'maps the places of publication for search' do
-      expect(result['pub_search']).to eq %w[England London]
+    it 'maps the publication year range as integers' do
+      expect(result['pub_year_tisim']).to eq (1920..Date.today.year).to_a
     end
 
-    it 'maps the publication year as an integer' do
-      expect(result['publication_year_isi']).to eq [1920]
-    end
-
-    it 'maps the full imprint statement for display' do
-      expect(result['imprint_display']).to eq ['2nd ed. - London : H.M. Stationery Off., [192-?]-[193-?]']
+    it 'maps the full imprint statement for search' do
+      expect(result['pub_search']).to eq ['2nd ed. - London : H.M. Stationery Off., [192-?]-[193-?]']
     end
 
     it 'maps the publication country' do


### PR DESCRIPTION
Switches up the contents of the various publication date/year
fields to more accurately reflect how these fields are populated
from MARC:

- pub_date is the full string, used for searching
- pub_year_ss is the year(s), displayed on search results
- pub_date_sort is a special string for sorting

Also removes some fields that aren't relevant for Cocina data
because the show page is rendered from JSON instead of using
Solr.

Fixes #1780
