### PR TITLE
Fix IIIF thumbnail URL generation

### DIFF
--- a/lib/purl_record.rb
+++ b/lib/purl_record.rb
@@ -72,7 +72,11 @@ class PurlRecord
       break if thumbnail_file.present?
     end if thumbnail_file.nil?
 
-    thumbnail_file&.iiif_id
+    # If still no thumbnail or it isn't available via IIIF, bail out
+    return unless thumbnail_file&.iiif_id.present?
+
+    # Image URL should include the .jp2 suffix
+    "#{thumbnail_file.iiif_id}.jp2"
   end
 
   # Ensure all objects, even those missing public cocina have a (nil) catkey and a label

--- a/spec/integration/sdr_config_spec.rb
+++ b/spec/integration/sdr_config_spec.rb
@@ -358,7 +358,7 @@ RSpec.describe 'SDR indexing' do
     end
 
     it 'maps the thumbnail IIIF ID' do
-      expect(result['file_id']).to eq ['bk264hq9320%2Fbk264hq9320_img_1']
+      expect(result['file_id']).to eq ['bk264hq9320%2Fbk264hq9320_img_1.jp2']
     end
 
     context 'with a virtual object' do
@@ -375,7 +375,7 @@ RSpec.describe 'SDR indexing' do
       end
 
       it 'uses the members to derive a thumbnail' do
-        expect(result['file_id']).to eq ['ts786ny5936%2FPC0170_s1_E_0204']
+        expect(result['file_id']).to eq ['ts786ny5936%2FPC0170_s1_E_0204.jp2']
       end
     end
   end


### PR DESCRIPTION
We were missing the .jp2 suffix. Fixes #1785.
