### PR TITLE
Bump cocina_display to ~>2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,7 @@ end
 gem 'activesupport', '~> 8.0'
 gem 'slop'
 
-gem 'cocina_display', '~> 2'
+gem 'cocina_display', '~> 2.2'
 gem 'dor-event-client'
 gem 'factory_bot', '~> 6.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,7 +38,7 @@ GEM
       capistrano (~> 3.0)
     capistrano-shared_configs (0.2.2)
     chronic (0.10.2)
-    cocina_display (2.1.0)
+    cocina_display (2.2.0)
       activesupport (>= 7)
       edtf (~> 3.2)
       geo_coord (~> 0.2)
@@ -269,7 +269,7 @@ DEPENDENCIES
   capistrano (~> 3.0)
   capistrano-bundler
   capistrano-shared_configs
-  cocina_display (~> 2)
+  cocina_display (~> 2.2)
   config
   csv
   debouncer
@@ -317,7 +317,7 @@ CHECKSUMS
   capistrano-one_time_key (0.2.0) sha256=88630a99de2113befd9885242cc8b3bc58536f4e06507363cc3ee064080a0375
   capistrano-shared_configs (0.2.2) sha256=905d1c51f0be6efd8ddb262aea7fae32c62d947297ff6b83f5cbccac3b138b36
   chronic (0.10.2) sha256=766f2fcce6ac3cc152249ed0f2b827770d3e517e2e87c5fba7ed74f4889d2dc3
-  cocina_display (2.1.0) sha256=7dc77608b5ba009cf16292d23ea50fc3287c25be1f2a559c6f8d4907850ea901
+  cocina_display (2.2.0) sha256=12baef5c3d9de95f1a7a4f1f47fd57e93f467b6e53d8ef8061ccd69a5e2635dd
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   config (5.6.1) sha256=a9f0f0f9ffa6d12d43147a3fa1ab8486fe484c3098a350c6a2e0f32430e0d1cc
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a


### PR DESCRIPTION
This prevents traject from caching values that cocina_display < 2.2.0 had been mutating, which caused incorrect URIs to be created for oembed links for earthworks