### PR TITLE
Update logic for detecting georeferenced items

### DIFF
--- a/lib/purl_record.rb
+++ b/lib/purl_record.rb
@@ -85,7 +85,7 @@ class PurlRecord
 
   delegate :collection?, :content_type, :files, :filesets, :cocina_doc, :world_access?,
            :modified_time, :created_time, :searchworks_url, :iiif_manifest_url,
-           :virtual_object?, :preferred_citation, :license, to: :public_cocina
+           :virtual_object?, :preferred_citation, :license, :display_title, to: :public_cocina
 
   delegate :released_to_earthworks?, :released_to_searchworks?, to: :public_meta_json
 end

--- a/lib/traject/config/geo_aardvark_config.rb
+++ b/lib/traject/config/geo_aardvark_config.rb
@@ -176,18 +176,19 @@ to_field 'dct_identifier_sm', cocina_display(:purl_url)
 to_field 'dct_identifier_sm', cocina_display(:doi_url)
 
 # https://opengeometadata.org/ogm-aardvark/#georeferenced
-# - currently anything with "(Raster Image)" in the title is known to be georeferenced
-to_field('gbl_georeferenced_b') { |_record, accumulator, context| accumulator << context.output_hash['dct_title_s'].first.include?('(Raster Image)') }
+to_field 'gbl_georeferenced_b', georeferenced?
 
 # https://opengeometadata.org/ogm-aardvark/#resource-class
 # - we use a regex-matching translation map to find "map" or "dataset" across various fields
-# - if georeferenced, it's always both a map and a dataset
+# - if georeferenced, we consider it a dataset
+# - the string "(Raster Image)" in the title indicates a georeferenced scanned map, so we assign "Maps" in that case
 # - if the item is a collection, set the resource class to "Collections" (only)
 # - if we didn't find anything, fall back to "Other" because the field is required
 to_field 'gbl_resourceClass_sm', cocina_display(:all_forms), transform(&:to_s), translation_map('geo_resource_class')
 to_field 'gbl_resourceClass_sm', cocina_display(:genres), translation_map('geo_resource_class')
 to_field 'gbl_resourceClass_sm', cocina_display(:subject_genres), translation_map('geo_resource_class')
-to_field('gbl_resourceClass_sm') { |_record, accumulator, context| accumulator.push('Maps', 'Datasets') if context.output_hash['gbl_georeferenced_b'].first }
+to_field('gbl_resourceClass_sm') { |_record, accumulator, context| accumulator << 'Datasets' if context.output_hash['gbl_georeferenced_b'].first }
+to_field('gbl_resourceClass_sm') { |record, accumulator, _context| accumulator << 'Maps' if record.display_title.include?('(Raster Image)') }
 to_field('gbl_resourceClass_sm') { |_record, accumulator, context| accumulator << 'Other' if context.output_hash['gbl_resourceClass_sm'].blank? }
 to_field('gbl_resourceClass_sm') { |record, _accumulator, context| context.output_hash['gbl_resourceClass_sm'] = ['Collections'] if record.collection? }
 

--- a/lib/traject/macros/cocina.rb
+++ b/lib/traject/macros/cocina.rb
@@ -161,14 +161,11 @@ module Traject
         end
       end
 
-      # Get all files from cocina structural whose filename matches the pattern
-      # And/or whose mime type matches the mime type pattern
-      # Filters the accumulator if it is not empty; otherwise search all files
-      def select_files(filename: nil, mime_type: nil)
+      # Call record.files and add results to the accumulator.
+      # See CocinaDisplay::CocinaRecord.files for available filters.
+      def select_files(*args, **kwargs)
         lambda do |record, accumulator, _context|
-          accumulator.concat record.files if accumulator.empty?
-          accumulator.select! { |file| file.filename.match?(filename) } if filename
-          accumulator.select! { |file| file.mime_type.match?(mime_type) } if mime_type
+          accumulator.concat record.files(*args, **kwargs)
         end
       end
 

--- a/lib/traject/macros/geo.rb
+++ b/lib/traject/macros/geo.rb
@@ -12,6 +12,25 @@ module Traject
           accumulator.map! { |reference| { uri => reference } }
         end
       end
+
+      # Determine if an object is georeferenced
+      # Used for the gbl_georeferenced_b field:
+      # https://opengeometadata.org/ogm-aardvark/#georeferenced
+      def georeferenced?
+        lambda do |record, accumulator, _context|
+          # All vector data types are georeferenced by definition
+          return accumulator.replace([true]) if record.files(filename: /\.(geojson|shp|fgb)$/).any?
+
+          # For raster data, check for geotiff/COG MIME type or presence of a world file
+          return accumulator.replace([true]) if record.files(mime_type: /application=geotiff/).any?
+          return accumulator.replace([true]) if record.files(filename: /\.tfw$/).any?
+
+          # For a IIIF image/map, check for the presence of georeference annotations
+          return accumulator.replace([true]) if record.files(filename: /\.json$/, use: 'annotations').any?
+
+          accumulator.replace([false])
+        end
+      end
     end
   end
 end

--- a/spec/lib/traject/macros/cocina_spec.rb
+++ b/spec/lib/traject/macros/cocina_spec.rb
@@ -47,41 +47,19 @@ RSpec.describe Traject::Macros::Cocina do
   end
 
   describe 'select_files' do
-    context 'with a filename string' do
-      let(:macro) { select_files(filename: 'preview.jpg') }
+    let(:macro) { select_files(filename: /\.xml$/) }
 
-      it 'returns the files with the matching filename' do
-        expect(accumulator.map(&:filename)).to eq ['preview.jpg']
-      end
-    end
-
-    context 'with a filename regex' do
-      let(:macro) { select_files(filename: /\.xml$/) }
-
-      it 'returns the files with filenames matching the regex' do
-        expect(accumulator.map(&:filename)).to eq [
-          'Stanford_Temperature_Model_4km.geojson.xml',
-          'Stanford_Temperature_Model_4km-iso19139.xml',
-          'Stanford_Temperature_Model_4km-iso19110.xml',
-          'Stanford_Temperature_Model_4km-fgdc.xml'
-        ]
-      end
-    end
-
-    context 'with a filtered list of files' do
-      let(:accumulator) { record.filesets[2].files }
-      let(:macro) { select_files(filename: /-iso/) }
-
-      it 'operates on the files in the list' do
-        expect(accumulator.map(&:filename)).to eq [
-          'Stanford_Temperature_Model_4km-iso19139.xml',
-          'Stanford_Temperature_Model_4km-iso19110.xml'
-        ]
-      end
+    it 'returns the files with filenames matching the regex' do
+      expect(accumulator.map(&:filename)).to eq [
+        'Stanford_Temperature_Model_4km.geojson.xml',
+        'Stanford_Temperature_Model_4km-iso19139.xml',
+        'Stanford_Temperature_Model_4km-iso19110.xml',
+        'Stanford_Temperature_Model_4km-fgdc.xml'
+      ]
     end
 
     context 'when there are no matches' do
-      let(:macro) { select_files(filename: 'missing.jpg') }
+      let(:macro) { select_files(filename: /missing.jpg/) }
 
       it 'returns an empty array' do
         expect(accumulator).to eq []
@@ -90,24 +68,14 @@ RSpec.describe Traject::Macros::Cocina do
   end
 
   describe 'find_file' do
-    context 'with a filename string' do
-      let(:macro) { find_file(filename: 'preview.jpg') }
+    let(:macro) { find_file(filename: /\.xml$/) }
 
-      it 'returns the file with the matching filename' do
-        expect(accumulator.first.filename).to eq 'preview.jpg'
-      end
-    end
-
-    context 'with a filename regex' do
-      let(:macro) { find_file(filename: /\.xml$/) }
-
-      it 'returns the first file with a filename matching the regex' do
-        expect(accumulator.first.filename).to eq 'Stanford_Temperature_Model_4km.geojson.xml'
-      end
+    it 'returns the first file with a filename matching the regex' do
+      expect(accumulator.first.filename).to eq 'Stanford_Temperature_Model_4km.geojson.xml'
     end
 
     context 'when the file is not found' do
-      let(:macro) { find_file(filename: 'missing.jpg') }
+      let(:macro) { find_file(filename: /missing.jpg/) }
 
       it 'returns an empty array' do
         expect(accumulator).to eq []
@@ -149,20 +117,10 @@ RSpec.describe Traject::Macros::Cocina do
         }.to_json
       end
 
-      context 'with a string match' do
-        let(:macro) { find_file(mime_type: 'image/tiff') }
+      let(:macro) { find_file(mime_type: /profile=cloud-optimized/) }
 
-        it 'returns the first file with a mime type containing the string' do
-          expect(accumulator.first.filename).to eq 'my_geotiff.tif'
-        end
-      end
-
-      context 'with a regex match' do
-        let(:macro) { find_file(mime_type: /profile=cloud-optimized/) }
-
-        it 'returns the first file with a mime type matching the regex' do
-          expect(accumulator.first.filename).to eq 'my_cog.tif'
-        end
+      it 'returns the first file with a mime type matching the regex' do
+        expect(accumulator.first.filename).to eq 'my_cog.tif'
       end
     end
   end


### PR DESCRIPTION
This makes our georeference detection smarter, and apply to more
items, so that we can eventually add a georeference filter to the
Earthworks frontend if we want.

Fixes sul-dlss/earthworks#1678
