### PR TITLE
Handle holdings records with multiple bound-with parents correctly

### DIFF
--- a/lib/folio/marc_record_mapper.rb
+++ b/lib/folio/marc_record_mapper.rb
@@ -73,7 +73,7 @@ module Folio
       return if record.fields('590').any? { |f| f['a'] && f['c'] }
 
       # if 590 or one of its Bound-with related subfields is missing, and FOLIO says this record is Bound-with, append the relevant data from FOLIO
-      folio_record.bound_with_holdings.each do |item|
+      folio_record.bound_with_holdings_stub_items.each do |item|
         field590 = MARC::DataField.new('590', ' ', ' ')
         field590.subfields << MARC::Subfield.new('a', "#{item.holding['callNumber']} bound with #{item.holding.dig('boundWith', 'instance', 'title')}")
         field590.subfields << MARC::Subfield.new('c', "#{item.holding.dig('boundWith', 'instance', 'hrid')} (parent record)")

--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -31,7 +31,7 @@ class FolioItem
   def initialize(item: nil, holding: nil, instance: nil,
                  course_reserves: [],
                  type: nil, status: nil,
-                 library: nil, record: nil, bound_with_child: false)
+                 library: nil, record: nil, bound_with_child: false, bound_with_principal: false)
     @item = item
     @holding = holding
     @instance = instance
@@ -43,6 +43,7 @@ class FolioItem
     @course_reserves = course_reserves
     @record = record
     @bound_with_child = bound_with_child
+    @bound_with_principal = bound_with_principal
   end
   # rubocop:enable Metrics/ParameterLists
 
@@ -140,12 +141,6 @@ class FolioItem
       enumeration: item['enumeration'],
       chronology: item['chronology']
     }
-  end
-
-  def bound_with_principal?
-    return false if bound_with? || holding.blank?
-
-    holding['boundWith'].present? && item['id'] == holding['boundWith']['item']['id']
   end
 
   def course_reserves_data

--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -31,7 +31,7 @@ class FolioItem
   def initialize(item: nil, holding: nil, instance: nil,
                  course_reserves: [],
                  type: nil, status: nil,
-                 library: nil, record: nil, bound_with: false)
+                 library: nil, record: nil, bound_with_child: false)
     @item = item
     @holding = holding
     @instance = instance
@@ -42,7 +42,7 @@ class FolioItem
     @barcode = @item&.dig('barcode')
     @course_reserves = course_reserves
     @record = record
-    @bound_with = bound_with
+    @bound_with_child = bound_with_child
   end
   # rubocop:enable Metrics/ParameterLists
 
@@ -164,14 +164,18 @@ class FolioItem
     }
   end
 
-  def bound_with
-    return unless bound_with?
+  def bound_with_principal?
+    @bound_with_principal
+  end
 
-    holding&.dig('boundWith')
+  def bound_with
+    return @bound_with if defined?(@bound_with)
+
+    @bound_with ||= holding&.dig('boundWith') if @bound_with_child
   end
 
   def bound_with?
-    @bound_with && holding&.dig('boundWith').present?
+    bound_with.present?
   end
 
   def equipment?

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -155,7 +155,8 @@ class FolioRecord
         holding:,
         instance:,
         course_reserves: courses.select { |c| c[:listing_id] == item['courseListingId'] },
-        record: self
+        record: self,
+        bound_with_principal: bound_with_children.any? { |child| child['itemId'] == item['id'] }
       )
     end
   end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -217,6 +217,10 @@ class FolioRecord
     @all_holdings ||= load('holdings')
   end
 
+  def bound_with_children
+    @bound_with_children ||= record['bound_with_parts'] || []
+  end
+
   def items_and_holdings
     @items_and_holdings ||= client.items_and_holdings(instance_id:)
   end

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -46,9 +46,9 @@ class FolioRecord
 
   def index_items
     @index_items ||= begin
-      items = item_holdings.concat(bound_with_holdings)
+      items = item_holdings.concat(bound_with_holdings_stub_items)
 
-      items = on_order_holdings if !(all_items.any? || eresource?) && items.empty?
+      items = on_order_holdings_items if !(all_items.any? || eresource?) && items.empty?
 
       items
     end
@@ -160,11 +160,17 @@ class FolioRecord
     end
   end
 
+  def bound_with_holdings_records
+    holdings.select do |holding|
+      holding['boundWith'].present? || (holding.dig('holdingsType', 'name') || holding.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName')) == 'Bound-with'
+    end
+  end
+
   # since FOLIO Bound-with records don't have items, we generate a FolioItem using data from the parent
   # item and child holding, or, if there is no parent item, we generate a stub FolioItem from the original
   # bound-with holding.
-  def bound_with_holdings
-    @bound_with_holdings ||= holdings.select { |holding| holding['boundWith'].present? || (holding.dig('holdingsType', 'name') || holding.dig('location', 'effectiveLocation', 'details', 'holdingsTypeName')) == 'Bound-with' }.filter_map do |holding|
+  def bound_with_holdings_stub_items
+    @bound_with_holdings_stub_items ||= bound_with_holdings_records.filter_map do |holding|
       parent_item = holding.dig('boundWith', 'item') || {}
 
       # bound-with "principals" appear as if they're bound-with themselves. See SW-4330.
@@ -175,14 +181,14 @@ class FolioRecord
         holding:,
         instance:,
         record: self,
-        bound_with: true
+        bound_with_child: true
       )
     end
   end
 
   private
 
-  def on_order_holdings
+  def on_order_holdings_items
     on_order_holdings = holdings.select do |holding|
       pieces.any? { |p| p['holdingId'] == holding['id'] && p['receivingStatus'] == 'Expected' && !p['discoverySuppress'] }
     end

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -461,7 +461,8 @@ module Traject
                   )
                 ) FILTER (WHERE hr.id IS NOT NULL), '[]'::jsonb
               ),
-            'po_lines', COUNT(po_line.id)
+            'po_lines', COUNT(po_line.id),
+            'bound_with_parts', jsonb_agg(DISTINCT bw.jsonb || jsonb_build_object('instanceId', parentInstance.id)) FILTER (WHERE bw.id IS NOT NULL)
             )
       FROM sul_mod_inventory_storage.instance vi
       LEFT JOIN sul_mod_inventory_storage.holdings_record hr

--- a/spec/factories/holdings.rb
+++ b/spec/factories/holdings.rb
@@ -27,7 +27,7 @@ FactoryBot.define do
     end
     library { 'GREEN' }
     type { '' }
-    bound_with { false }
+    bound_with_child { false }
 
     initialize_with { new(**attributes, holding:, item: default_item_attributes.merge(item).merge(additional_item_attributes.deep_stringify_keys)) }
 
@@ -67,7 +67,7 @@ FactoryBot.define do
     end
 
     trait :bound_with do
-      bound_with { true }
+      bound_with_child { true }
       additional_item_attributes do
         {
           'id' => 'f947bd93-a1eb-5613-8745-1063f948c461',

--- a/spec/fixtures/files/folio_bw_principal.json
+++ b/spec/fixtures/files/folio_bw_principal.json
@@ -1,4 +1,18 @@
 {
+  "bound_with_parts" : [
+    {
+        "holdingsRecordId" : "61a02b20-39db-52a1-879a-34e3be8f0368",
+        "id" : "8335769b-7200-4b57-aa24-951fd3b38314",
+        "instanceId" : "0bd14032-6811-5361-a55b-14e0bafbbf0f",
+        "itemId" : "2b9ba8c6-f25c-5ba2-a159-418a0c335703",
+        "metadata" : {
+          "createdByUserId" : "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+          "createdDate" : "2024-05-20T17:25:17.782Z",
+          "updatedByUserId" : "58d0aaf6-dcda-4d5e-92da-012e6b7dd766",
+          "updatedDate" : "2024-05-20T17:25:17.782Z"
+        }
+    }
+  ],
   "pieces": [
     null
   ],

--- a/spec/fixtures/files/in00000064624.json
+++ b/spec/fixtures/files/in00000064624.json
@@ -1,0 +1,1474 @@
+{
+   "bound_with_parts" : [
+      {
+         "holdingsRecordId" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "id" : "0bc9fdfc-a532-4f2a-8208-9c8ee9f3bb3d",
+         "instanceId" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+         "itemId" : "4ab67ace-b7d1-4a49-8405-5b464c42e27e",
+         "metadata" : {
+            "createdDate" : "2026-07-30T18:25:20.409Z",
+            "updatedDate" : "2026-07-30T18:25:20.409Z"
+         }
+      },
+      {
+         "holdingsRecordId" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "id" : "2d8b5c38-f75b-472a-bb23-814ee9f7274c",
+         "instanceId" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+         "itemId" : "8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8",
+         "metadata" : {
+            "createdDate" : "2026-07-24T20:12:12.980Z",
+            "updatedDate" : "2026-07-24T20:12:12.980Z"
+         }
+      }
+   ],
+   "holdingSummaries" : [
+      {
+         "orderCloseReason" : {
+            "reason" : "Complete"
+         },
+         "orderSentDate" : "2024-03-05T17:08:18.508+00:00",
+         "orderStatus" : "Closed",
+         "orderType" : "One-Time",
+         "poLineId" : "87a7f8d9-4687-482d-8439-c69a0a0041f0",
+         "poLineNumber" : "59168-1",
+         "polReceiptStatus" : "Fully Received"
+      }
+   ],
+   "holdings" : [
+      {
+         "_version" : 2,
+         "administrativeNotes" : [],
+         "boundWith" : {
+            "holding" : {
+               "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+               "location" : {
+                  "effectiveLocation" : {
+                     "campus" : {
+                        "code" : "SUL",
+                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "name" : "Stanford Libraries"
+                     },
+                     "code" : "SPEC-RARE-BOOKS",
+                     "details" : {
+                        "pageAeonSite" : "SPECUA"
+                     },
+                     "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+                     "institution" : {
+                        "code" : "SU",
+                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                        "name" : "Stanford University"
+                     },
+                     "isActive" : true,
+                     "library" : {
+                        "code" : "SPEC-COLL",
+                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "name" : "Special Collections"
+                     },
+                     "name" : "Rare Books Collection"
+                  }
+               },
+               "suppressFromDiscovery" : false
+            },
+            "instance" : {
+               "hrid" : "in00000064624",
+               "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+               "suppressFromDiscovery" : false,
+               "title" : "[Collection of Restoration plays]"
+            },
+            "item" : {
+               "barcode" : "36105244284563",
+               "callNumber" : {
+                  "callNumber" : "PR1266.C65 1670",
+                  "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
+               },
+               "chronology" : null,
+               "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+               "enumeration" : "v.2",
+               "hrid" : "it00000479304",
+               "id" : "4ab67ace-b7d1-4a49-8405-5b464c42e27e",
+               "location" : {
+                  "effectiveLocation" : {
+                     "campus" : {
+                        "code" : "SUL",
+                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "name" : "Stanford Libraries"
+                     },
+                     "code" : "SPEC-INPROCESS-RWC",
+                     "details" : {
+                        "availabilityClass" : "In_process_non_requestable"
+                     },
+                     "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
+                     "institution" : {
+                        "code" : "SU",
+                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                        "name" : "Stanford University"
+                     },
+                     "isActive" : true,
+                     "library" : {
+                        "code" : "SPEC-COLL",
+                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "name" : "Special Collections"
+                     },
+                     "name" : "In process"
+                  }
+               },
+               "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+               "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+               "status" : "In process (non-requestable)",
+               "suppressFromDiscovery" : false,
+               "temporaryLoanTypeId" : null,
+               "volume" : null
+            }
+         },
+         "callNumber" : "PR1266.C65 1670",
+         "callNumberType" : {
+            "id" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "name" : "Library of Congress classification",
+            "source" : "system"
+         },
+         "callNumberTypeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+         "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+         "electronicAccess" : [],
+         "formerIds" : [],
+         "holdingsStatements" : [],
+         "holdingsStatementsForIndexes" : [],
+         "holdingsStatementsForSupplements" : [],
+         "holdingsType" : {
+            "id" : "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+            "name" : "Book",
+            "source" : "local"
+         },
+         "holdingsTypeId" : "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+         "hrid" : "ho00000079375",
+         "id" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "illPolicy" : null,
+         "instanceId" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+         "location" : {
+            "effectiveLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-RARE-BOOKS",
+               "details" : {
+                  "pageAeonSite" : "SPECUA"
+               },
+               "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "Rare Books Collection"
+            },
+            "permanentLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-RARE-BOOKS",
+               "details" : {
+                  "pageAeonSite" : "SPECUA"
+               },
+               "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "Rare Books Collection"
+            }
+         },
+         "metadata" : {
+            "createdByUserId" : "7ced6673-ff0d-4619-997d-34c41d17baec",
+            "createdDate" : "2024-03-05T17:08:19.509Z",
+            "updatedByUserId" : "b8585498-1d18-4269-8044-1a44fb8bcaa6",
+            "updatedDate" : "2026-07-24T18:55:53.902Z"
+         },
+         "notes" : [],
+         "permanentLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+         "sourceId" : "f32d531e-df79-46b3-8932-cdd35f7a2264",
+         "statisticalCodeIds" : [],
+         "suppressFromDiscovery" : false
+      },
+      {
+         "_version" : 2,
+         "administrativeNotes" : [],
+         "boundWith" : {
+            "holding" : {
+               "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+               "location" : {
+                  "effectiveLocation" : {
+                     "campus" : {
+                        "code" : "SUL",
+                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "name" : "Stanford Libraries"
+                     },
+                     "code" : "SPEC-RARE-BOOKS",
+                     "details" : {
+                        "pageAeonSite" : "SPECUA"
+                     },
+                     "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+                     "institution" : {
+                        "code" : "SU",
+                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                        "name" : "Stanford University"
+                     },
+                     "isActive" : true,
+                     "library" : {
+                        "code" : "SPEC-COLL",
+                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "name" : "Special Collections"
+                     },
+                     "name" : "Rare Books Collection"
+                  }
+               },
+               "suppressFromDiscovery" : false
+            },
+            "instance" : {
+               "hrid" : "in00000064624",
+               "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+               "suppressFromDiscovery" : false,
+               "title" : "[Collection of Restoration plays]"
+            },
+            "item" : {
+               "barcode" : "36105236764440",
+               "callNumber" : {
+                  "callNumber" : "PR1266.C65 1670",
+                  "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
+               },
+               "chronology" : null,
+               "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+               "enumeration" : "v.1",
+               "hrid" : "it00000080179",
+               "id" : "8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8",
+               "location" : {
+                  "effectiveLocation" : {
+                     "campus" : {
+                        "code" : "SUL",
+                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                        "name" : "Stanford Libraries"
+                     },
+                     "code" : "SPEC-INPROCESS-RWC",
+                     "details" : {
+                        "availabilityClass" : "In_process_non_requestable"
+                     },
+                     "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
+                     "institution" : {
+                        "code" : "SU",
+                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                        "name" : "Stanford University"
+                     },
+                     "isActive" : true,
+                     "library" : {
+                        "code" : "SPEC-COLL",
+                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                        "name" : "Special Collections"
+                     },
+                     "name" : "In process"
+                  }
+               },
+               "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+               "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+               "status" : "In process (non-requestable)",
+               "suppressFromDiscovery" : false,
+               "temporaryLoanTypeId" : null,
+               "volume" : null
+            }
+         },
+         "callNumber" : "PR1266.C65 1670",
+         "callNumberType" : {
+            "id" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "name" : "Library of Congress classification",
+            "source" : "system"
+         },
+         "callNumberTypeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+         "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+         "electronicAccess" : [],
+         "formerIds" : [],
+         "holdingsStatements" : [],
+         "holdingsStatementsForIndexes" : [],
+         "holdingsStatementsForSupplements" : [],
+         "holdingsType" : {
+            "id" : "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+            "name" : "Book",
+            "source" : "local"
+         },
+         "holdingsTypeId" : "5684e4a3-9279-4463-b6ee-20ae21bbec07",
+         "hrid" : "ho00000079375",
+         "id" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "illPolicy" : null,
+         "instanceId" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+         "location" : {
+            "effectiveLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-RARE-BOOKS",
+               "details" : {
+                  "pageAeonSite" : "SPECUA"
+               },
+               "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "Rare Books Collection"
+            },
+            "permanentLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-RARE-BOOKS",
+               "details" : {
+                  "pageAeonSite" : "SPECUA"
+               },
+               "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "Rare Books Collection"
+            }
+         },
+         "metadata" : {
+            "createdByUserId" : "7ced6673-ff0d-4619-997d-34c41d17baec",
+            "createdDate" : "2024-03-05T17:08:19.509Z",
+            "updatedByUserId" : "b8585498-1d18-4269-8044-1a44fb8bcaa6",
+            "updatedDate" : "2026-07-24T18:55:53.902Z"
+         },
+         "notes" : [],
+         "permanentLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+         "sourceId" : "f32d531e-df79-46b3-8932-cdd35f7a2264",
+         "statisticalCodeIds" : [],
+         "suppressFromDiscovery" : false
+      }
+   ],
+   "instance" : {
+      "_version" : 19,
+      "administrativeNotes" : [],
+      "alternativeTitles" : [
+         {
+            "alternativeTitle" : "Plays",
+            "alternativeTitleTypeId" : "35bbe7f2-1a49-11ed-861d-0242ac120002"
+         }
+      ],
+      "catalogedDate" : "2026-07-24",
+      "classifications" : [],
+      "contributors" : [
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Lee, Nathaniel, 1653?-1692. Massacre of Paris",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Behn, Aphra, 1640-1689. Young king",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Boyle, Roger, Earl of Orrery, 1621-1679. Mr. Anthony",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Dryden, John, 1631-1700. Duke of Guise. Prologue",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Lee, Nathaniel, 1653?-1692. Duke of Guise",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Mountfort, William, 1664?-1692. Injur'd lovers",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Banks, John, -1706. Island queens",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Shadwell, Thomas, 1642?-1692. Epsom Wells",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Shadwell, Thomas, 1642?-1692. Sullen lovers",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Tate, Nahum, 1652-1715. Ingratitude of a commonwealth",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Shadwell, Thomas, 1642?-1692. Squire of Alsatia",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Lacy, John, -1681. Old troop",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Shadwell, Thomas, 1642?-1692. Humorists",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Crown, Mr. (John), 1640?-1712. City politiques",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Shadwell, Thomas, 1642?-1692. Virtuoso",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Ravenscroft, Edward, 1654?-1707. Citizen turn'd gentleman",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe2a",
+            "name" : "Brome, Richard, -1652? Northern lasse",
+            "primary" : false
+         },
+         {
+            "contributorNameTypeId" : "2e48e713-17f3-4c13-a9f8-23845bb210aa",
+            "contributorTypeId" : "5c3abceb-6bd8-43aa-b08d-1187ae78b15b",
+            "name" : "Cornwell House",
+            "primary" : false
+         }
+      ],
+      "dates" : {
+         "date1" : "1670",
+         "date2" : "1690",
+         "dateTypeId" : "8fa6d067-41ff-4362-96a0-96b16ddce267"
+      },
+      "deleted" : false,
+      "discoverySuppress" : false,
+      "editions" : [],
+      "electronicAccess" : [],
+      "holdingsRecords2" : [],
+      "hrid" : "in00000064624",
+      "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+      "identifiers" : [
+         {
+            "identifierTypeId" : "439bfbae-75bc-4f74-9fc7-b2a2d47ce3ef",
+            "value" : "(OCoLC-M)1607860013"
+         }
+      ],
+      "indexTitle" : "[Collection of Restoration plays]",
+      "instanceFormatIds" : [],
+      "instanceFormats" : [],
+      "instanceTypeId" : "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
+      "languages" : [
+         "eng"
+      ],
+      "metadata" : {
+         "createdByUserId" : "7ced6673-ff0d-4619-997d-34c41d17baec",
+         "createdDate" : "2024-03-05T17:06:10.723Z",
+         "updatedByUserId" : "07e8be0e-1cf5-5061-b5b3-4517d9a74d77",
+         "updatedDate" : "2026-08-02T16:02:56.724Z"
+      },
+      "modeOfIssuanceId" : "9d18a02f-5897-4c31-9106-c9abb5c7ae8b",
+      "natureOfContentTermIds" : [],
+      "notes" : [
+         {
+            "instanceNoteTypeId" : "6a2533a7-4de2-4e64-8466-074c2fa9308c",
+            "note" : "Title supplied by cataloger",
+            "staffOnly" : false
+         },
+         {
+            "instanceNoteTypeId" : "5ba8e385-0e27-462e-a571-ffa1fa34ea54",
+            "note" : "Volume 1: Lee, Nathaniel. The massacre of Paris. London : Printed for R. Bentley and M. Magnes ..., 1690 -- Behn, Aphra. The young king. London : Printed for D. Brown ..., T. Benskin ..., and H. Rhodes, 1683 -- Boyle, Roger. Mr. Anthony. London : Printed for James Knapton ..., 1690 -- Dryden, John and Lee, Nathaniel. The Duke of Guise. London : Printed by T.H. for R. Bentley ..., and J. Tonson ..., [1683] -- Mountfort, William. The injur'd lovers. London : Printed for Sam. Manship ..., [1688] -- Romulus and Hersilia. London : D. Brown ..., and T. Benskin ..., 1683 -- Banks, John. The island queens. London : Printed for R. Bentley ..., 1684 -- Shadwell, Thomas. Epsom Wells. London : Printed by J.M. for Henry Herringman ..., 1676 -- Shadwell, Thomas. Sullen lovers. London : Printed for Henry Herringman ..., 1670 -- Volume 2: Tate, Nahum.  The ingratitude of a commonwealth. London : Printed by T.M. for Joseph Hindmarsh ..., 1682 -- Shadwell, Thomas. The squire of Alsatia. London : Printed for James Knapton ..., 1688 -- Lacy, John. The old troop. London : Printed for William Crook and Thomas Dring ..., 1672 -- Shadwell, Thomas. The humorists. London : Printed for Henry Herringman ..., 1671 -- Crown, Mr. (John). City politiques. London : Printed for R. Bently ..., and Joseph Hindmarsh ..., [1683] -- Shadwell, Thomas. The virtuoso. London : Printed by T.N. for Henry Herringman ..., 1676 -- Ravenscroft, Edward. The citizen turn'd gentleman. London : Printed for Thomas Dring ..., 1672 -- Brome, Richard. The Northern lass. London : Printed for D. Newman ..., 1684",
+            "staffOnly" : false
+         },
+         {
+            "instanceNoteTypeId" : "10e2e11b-450f-45c8-b09b-0f819999966e",
+            "note" : "17 plays published in London between 1670 and 1690, bound together in two matching volumes. Each play fully cataloged separately; see links to records under call numbers for full descriptions",
+            "staffOnly" : false
+         },
+         {
+            "instanceNoteTypeId" : "265c4910-3997-4242-9269-6a4a2e91392b",
+            "note" : "Special Collections & University Archives copy 1: Binding: speckled calf with raised bands, gilt panel decorations, gilt spine titles reading \"Plays 1\" and \"Plays 2\", and red speckled edges. Provenance: Cornwell House (ink-stamp)",
+            "staffOnly" : false
+         },
+         {
+            "instanceNoteTypeId" : "24f68106-611a-4944-9241-40f92b9a2ffa",
+            "note" : "England London, publication place. http://id.loc.gov/vocabulary/relators/pup",
+            "staffOnly" : false
+         }
+      ],
+      "physicalDescriptions" : [
+         "2 volumes (17 plays) ; 22 cm"
+      ],
+      "previouslyHeld" : false,
+      "publication" : [
+         {
+            "dateOfPublication" : "1670-1690",
+            "place" : "London",
+            "publisher" : "[various publishers]",
+            "role" : "Publication"
+         }
+      ],
+      "publicationFrequency" : [],
+      "publicationRange" : [],
+      "series" : [],
+      "source" : "MARC",
+      "staffSuppress" : false,
+      "statisticalCodeIds" : [
+         "36dfb19d-8d6b-4c4f-a8cc-8b403452bce5"
+      ],
+      "statisticalCodes" : [],
+      "statusId" : "9634a5ab-9228-4703-baf2-4d12ebc77d56",
+      "statusUpdatedDate" : "2026-07-24T18:59:17.325Z",
+      "subjects" : [
+         {
+            "sourceId" : "e894d0dc-621d-4b1d-98f6-6f7120eb0d40",
+            "typeId" : "d6488f88-1e74-40ce-81b5-b19a928ff5b7",
+            "value" : "English drama--Restoration, 1660-1700"
+         },
+         {
+            "typeId" : "d6488f88-1e74-40ce-81b5-b19a928ff511",
+            "value" : "Drama"
+         },
+         {
+            "typeId" : "d6488f88-1e74-40ce-81b5-b19a928ff511",
+            "value" : "Fiction"
+         }
+      ],
+      "suppressFromDiscovery" : false,
+      "tags" : {
+         "tagList" : []
+      },
+      "title" : "[Collection of Restoration plays]"
+   },
+   "items" : [
+      {
+         "_version" : 2,
+         "administrativeNotes" : [],
+         "barcode" : "36105244284563",
+         "callNumber" : {
+            "callNumber" : "PR1266.C65 1670",
+            "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "typeName" : "Library of Congress classification"
+         },
+         "callNumberType" : {
+            "id" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "name" : "Library of Congress classification",
+            "source" : "system"
+         },
+         "circulationNotes" : [],
+         "courses" : [],
+         "effectiveCallNumberComponents" : {
+            "callNumber" : "PR1266.C65 1670",
+            "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
+         },
+         "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+         "effectiveShelvingOrder" : "PR 41266 C65 41670 V 12",
+         "electronicAccess" : [],
+         "enumeration" : "v.2",
+         "formerIds" : [],
+         "holdingsRecordId" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "hrid" : "it00000479304",
+         "id" : "4ab67ace-b7d1-4a49-8405-5b464c42e27e",
+         "itemDamagedStatus" : null,
+         "location" : {
+            "effectiveLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-INPROCESS-RWC",
+               "details" : {
+                  "availabilityClass" : "In_process_non_requestable"
+               },
+               "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "In process"
+            },
+            "temporaryLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-INPROCESS-RWC",
+               "details" : {
+                  "availabilityClass" : "In_process_non_requestable"
+               },
+               "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "In process"
+            }
+         },
+         "materialType" : "book",
+         "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+         "metadata" : {
+            "createdByUserId" : "b8585498-1d18-4269-8044-1a44fb8bcaa6",
+            "createdDate" : "2026-07-24T18:57:45.298Z",
+            "updatedByUserId" : "b8585498-1d18-4269-8044-1a44fb8bcaa6",
+            "updatedDate" : "2026-07-24T18:57:57.135Z"
+         },
+         "notes" : [],
+         "permanentLoanType" : "Non-circulating",
+         "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+         "request" : null,
+         "statisticalCodeIds" : [],
+         "status" : "In process (non-requestable)",
+         "suppressFromDiscovery" : false,
+         "tags" : {
+            "tagList" : []
+         },
+         "temporaryLoanType" : null,
+         "temporaryLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+         "yearCaption" : []
+      },
+      {
+         "_version" : 12,
+         "administrativeNotes" : [],
+         "barcode" : "36105236764440",
+         "callNumber" : {
+            "callNumber" : "PR1266.C65 1670",
+            "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "typeName" : "Library of Congress classification"
+         },
+         "callNumberType" : {
+            "id" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
+            "name" : "Library of Congress classification",
+            "source" : "system"
+         },
+         "circulationNotes" : [],
+         "courses" : [],
+         "discoverySuppress" : false,
+         "effectiveCallNumberComponents" : {
+            "callNumber" : "PR1266.C65 1670",
+            "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
+         },
+         "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+         "effectiveShelvingOrder" : "PR 41266 C65 41670 V 11",
+         "electronicAccess" : [],
+         "enumeration" : "v.1",
+         "formerIds" : [],
+         "holdingsRecordId" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "hrid" : "it00000080179",
+         "id" : "8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8",
+         "inTransitDestinationServicePointId" : "0e924af7-785c-46eb-a5e2-060394822016",
+         "itemDamagedStatus" : null,
+         "location" : {
+            "effectiveLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-INPROCESS-RWC",
+               "details" : {
+                  "availabilityClass" : "In_process_non_requestable"
+               },
+               "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "In process"
+            },
+            "temporaryLocation" : {
+               "campus" : {
+                  "code" : "SUL",
+                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
+                  "name" : "Stanford Libraries"
+               },
+               "code" : "SPEC-INPROCESS-RWC",
+               "details" : {
+                  "availabilityClass" : "In_process_non_requestable"
+               },
+               "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
+               "institution" : {
+                  "code" : "SU",
+                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
+                  "name" : "Stanford University"
+               },
+               "isActive" : true,
+               "library" : {
+                  "code" : "SPEC-COLL",
+                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
+                  "name" : "Special Collections"
+               },
+               "name" : "In process"
+            }
+         },
+         "materialType" : "book",
+         "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+         "metadata" : {
+            "createdByUserId" : "7ced6673-ff0d-4619-997d-34c41d17baec",
+            "createdDate" : "2024-03-05T17:08:19.568Z",
+            "updatedByUserId" : "b8585498-1d18-4269-8044-1a44fb8bcaa6",
+            "updatedDate" : "2026-07-24T18:56:21.932Z"
+         },
+         "notes" : [],
+         "permanentLoanType" : "Non-circulating",
+         "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+         "purchaseOrderLineIdentifier" : "87a7f8d9-4687-482d-8439-c69a0a0041f0",
+         "request" : null,
+         "statisticalCodeIds" : [],
+         "status" : "In process (non-requestable)",
+         "suppressFromDiscovery" : false,
+         "tags" : {
+            "tagList" : []
+         },
+         "temporaryLoanType" : null,
+         "temporaryLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+         "yearCaption" : []
+      }
+   ],
+   "pieces" : [
+      {
+         "comment" : "2 v.",
+         "displayOnHolding" : true,
+         "format" : "Physical",
+         "holdingId" : "212b61ac-a336-4b07-a780-01a49c878f04",
+         "id" : "9db688ba-6a52-4199-9c1c-aef6accd343b",
+         "isBound" : false,
+         "itemId" : "8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8",
+         "poLineId" : "87a7f8d9-4687-482d-8439-c69a0a0041f0",
+         "receivedDate" : "2024-04-02T23:16:06.335+00:00",
+         "receivingStatus" : "Received",
+         "supplement" : false,
+         "titleId" : "c0e35ae1-fc97-4d30-a905-61a499614ae8"
+      }
+   ],
+   "source_record" : [
+      {
+         "fields" : [
+            {
+               "001" : "in00000064624"
+            },
+            {
+               "008" : "260724m16701690enk           000 d eng d"
+            },
+            {
+               "005" : "20260802160243.1"
+            },
+            {
+               "035" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "(OCoLC-M)1607860013"
+                     }
+                  ]
+               }
+            },
+            {
+               "040" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "STF"
+                     },
+                     {
+                        "b" : "eng"
+                     },
+                     {
+                        "e" : "rda"
+                     },
+                     {
+                        "e" : "dcrmb"
+                     },
+                     {
+                        "c" : "STF"
+                     },
+                     {
+                        "d" : "UtOrBLW"
+                     }
+                  ]
+               }
+            },
+            {
+               "245" : {
+                  "ind1" : "0",
+                  "ind2" : "0",
+                  "subfields" : [
+                     {
+                        "a" : "[Collection of Restoration plays]"
+                     }
+                  ]
+               }
+            },
+            {
+               "246" : {
+                  "ind1" : "1",
+                  "ind2" : "8",
+                  "subfields" : [
+                     {
+                        "a" : "Plays"
+                     }
+                  ]
+               }
+            },
+            {
+               "264" : {
+                  "ind1" : " ",
+                  "ind2" : "1",
+                  "subfields" : [
+                     {
+                        "a" : "London :"
+                     },
+                     {
+                        "b" : "[various publishers],"
+                     },
+                     {
+                        "c" : "1670-1690"
+                     }
+                  ]
+               }
+            },
+            {
+               "300" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "2 volumes (17 plays) ;"
+                     },
+                     {
+                        "c" : "22 cm"
+                     }
+                  ]
+               }
+            },
+            {
+               "336" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "text"
+                     },
+                     {
+                        "2" : "rdacontent"
+                     },
+                     {
+                        "0" : "http://rdaregistry.info/termList/RDAContentType/1020"
+                     }
+                  ]
+               }
+            },
+            {
+               "337" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "unmediated"
+                     },
+                     {
+                        "2" : "rdamedia"
+                     },
+                     {
+                        "0" : "http://rdaregistry.info/termList/RDAMediaType/1007"
+                     }
+                  ]
+               }
+            },
+            {
+               "338" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "volume"
+                     },
+                     {
+                        "2" : "rdacarrier"
+                     },
+                     {
+                        "0" : "http://rdaregistry.info/termList/RDACarrierType/1049"
+                     }
+                  ]
+               }
+            },
+            {
+               "500" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "Title supplied by cataloger"
+                     }
+                  ]
+               }
+            },
+            {
+               "505" : {
+                  "ind1" : "0",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "Volume 1: Lee, Nathaniel. The massacre of Paris. London : Printed for R. Bentley and M. Magnes ..., 1690 -- Behn, Aphra. The young king. London : Printed for D. Brown ..., T. Benskin ..., and H. Rhodes, 1683 -- Boyle, Roger. Mr. Anthony. London : Printed for James Knapton ..., 1690 -- Dryden, John and Lee, Nathaniel. The Duke of Guise. London : Printed by T.H. for R. Bentley ..., and J. Tonson ..., [1683] -- Mountfort, William. The injur'd lovers. London : Printed for Sam. Manship ..., [1688] -- Romulus and Hersilia. London : D. Brown ..., and T. Benskin ..., 1683 -- Banks, John. The island queens. London : Printed for R. Bentley ..., 1684 -- Shadwell, Thomas. Epsom Wells. London : Printed by J.M. for Henry Herringman ..., 1676 -- Shadwell, Thomas. Sullen lovers. London : Printed for Henry Herringman ..., 1670 -- Volume 2: Tate, Nahum.  The ingratitude of a commonwealth. London : Printed by T.M. for Joseph Hindmarsh ..., 1682 -- Shadwell, Thomas. The squire of Alsatia. London : Printed for James Knapton ..., 1688 -- Lacy, John. The old troop. London : Printed for William Crook and Thomas Dring ..., 1672 -- Shadwell, Thomas. The humorists. London : Printed for Henry Herringman ..., 1671 -- Crown, Mr. (John). City politiques. London : Printed for R. Bently ..., and Joseph Hindmarsh ..., [1683] -- Shadwell, Thomas. The virtuoso. London : Printed by T.N. for Henry Herringman ..., 1676 -- Ravenscroft, Edward. The citizen turn'd gentleman. London : Printed for Thomas Dring ..., 1672 -- Brome, Richard. The Northern lass. London : Printed for D. Newman ..., 1684"
+                     }
+                  ]
+               }
+            },
+            {
+               "520" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "17 plays published in London between 1670 and 1690, bound together in two matching volumes. Each play fully cataloged separately; see links to records under call numbers for full descriptions"
+                     }
+                  ]
+               }
+            },
+            {
+               "590" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "Special Collections & University Archives copy 1: Binding: speckled calf with raised bands, gilt panel decorations, gilt spine titles reading \"Plays 1\" and \"Plays 2\", and red speckled edges. Provenance: Cornwell House (ink-stamp)."
+                     }
+                  ]
+               }
+            },
+            {
+               "650" : {
+                  "ind1" : " ",
+                  "ind2" : "0",
+                  "subfields" : [
+                     {
+                        "a" : "English drama"
+                     },
+                     {
+                        "y" : "Restoration, 1660-1700."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/subjects/sh85043342"
+                     }
+                  ]
+               }
+            },
+            {
+               "655" : {
+                  "ind1" : " ",
+                  "ind2" : "7",
+                  "subfields" : [
+                     {
+                        "a" : "Drama."
+                     },
+                     {
+                        "2" : "lcgft"
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/genreForms/gf2014026297"
+                     }
+                  ]
+               }
+            },
+            {
+               "655" : {
+                  "ind1" : " ",
+                  "ind2" : "7",
+                  "subfields" : [
+                     {
+                        "a" : "Fiction."
+                     },
+                     {
+                        "2" : "lcgft"
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/genreForms/gf2014026339"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Lee, Nathaniel,"
+                     },
+                     {
+                        "d" : "1653?-1692."
+                     },
+                     {
+                        "t" : "Massacre of Paris."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n2019042590"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Behn, Aphra,"
+                     },
+                     {
+                        "d" : "1640-1689."
+                     },
+                     {
+                        "t" : "Young king."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Boyle, Roger,"
+                     },
+                     {
+                        "c" : "Earl of Orrery,"
+                     },
+                     {
+                        "d" : "1621-1679."
+                     },
+                     {
+                        "t" : "Mr. Anthony."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Dryden, John,"
+                     },
+                     {
+                        "d" : "1631-1700."
+                     },
+                     {
+                        "t" : "Duke of Guise."
+                     },
+                     {
+                        "p" : "Prologue."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n85056911"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Lee, Nathaniel,"
+                     },
+                     {
+                        "d" : "1653?-1692."
+                     },
+                     {
+                        "t" : "Duke of Guise."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Mountfort, William,"
+                     },
+                     {
+                        "d" : "1664?-1692."
+                     },
+                     {
+                        "t" : "Injur'd lovers."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Banks, John,"
+                     },
+                     {
+                        "d" : "-1706."
+                     },
+                     {
+                        "t" : "Island queens."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n2020033920"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Shadwell, Thomas,"
+                     },
+                     {
+                        "d" : "1642?-1692."
+                     },
+                     {
+                        "t" : "Epsom Wells."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n2023011440"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Shadwell, Thomas,"
+                     },
+                     {
+                        "d" : "1642?-1692."
+                     },
+                     {
+                        "t" : "Sullen lovers."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Tate, Nahum,"
+                     },
+                     {
+                        "d" : "1652-1715."
+                     },
+                     {
+                        "t" : "Ingratitude of a commonwealth."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Shadwell, Thomas,"
+                     },
+                     {
+                        "d" : "1642?-1692."
+                     },
+                     {
+                        "t" : "Squire of Alsatia."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n86074148"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Lacy, John,"
+                     },
+                     {
+                        "d" : "-1681."
+                     },
+                     {
+                        "t" : "Old troop."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Shadwell, Thomas,"
+                     },
+                     {
+                        "d" : "1642?-1692."
+                     },
+                     {
+                        "t" : "Humorists."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Crown,"
+                     },
+                     {
+                        "c" : "Mr."
+                     },
+                     {
+                        "q" : "(John),"
+                     },
+                     {
+                        "d" : "1640?-1712."
+                     },
+                     {
+                        "t" : "City politiques."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Shadwell, Thomas,"
+                     },
+                     {
+                        "d" : "1642?-1692."
+                     },
+                     {
+                        "t" : "Virtuoso."
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Ravenscroft, Edward,"
+                     },
+                     {
+                        "d" : "1654?-1707."
+                     },
+                     {
+                        "t" : "Citizen turn'd gentleman."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n85356964"
+                     }
+                  ]
+               }
+            },
+            {
+               "700" : {
+                  "ind1" : "1",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Brome, Richard,"
+                     },
+                     {
+                        "d" : "-1652?"
+                     },
+                     {
+                        "t" : "Northern lasse."
+                     },
+                     {
+                        "0" : "http://id.loc.gov/authorities/names/n79119329"
+                     }
+                  ]
+               }
+            },
+            {
+               "710" : {
+                  "ind1" : "2",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "Cornwell House,"
+                     },
+                     {
+                        "e" : "former owner."
+                     },
+                     {
+                        "5" : "CSt"
+                     },
+                     {
+                        "4" : "http://id.loc.gov/vocabulary/relators/fmo"
+                     }
+                  ]
+               }
+            },
+            {
+               "740" : {
+                  "ind1" : "0",
+                  "ind2" : "2",
+                  "subfields" : [
+                     {
+                        "a" : "Romulus and Hersilia"
+                     }
+                  ]
+               }
+            },
+            {
+               "752" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "England"
+                     },
+                     {
+                        "d" : "London,"
+                     },
+                     {
+                        "e" : "publication place."
+                     },
+                     {
+                        "4" : "http://id.loc.gov/vocabulary/relators/pup"
+                     }
+                  ]
+               }
+            },
+            {
+               "948" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "h" : "HELD BY STF - 0 OTHER HOLDINGS"
+                     }
+                  ]
+               }
+            },
+            {
+               "994" : {
+                  "ind1" : " ",
+                  "ind2" : " ",
+                  "subfields" : [
+                     {
+                        "a" : "Z0"
+                     },
+                     {
+                        "b" : "STF"
+                     }
+                  ]
+               }
+            },
+            {
+               "999" : {
+                  "ind1" : "f",
+                  "ind2" : "f",
+                  "subfields" : [
+                     {
+                        "i" : "7d747c3e-c166-4829-89d6-a5355acf098a"
+                     },
+                     {
+                        "s" : "ef682473-206d-4489-84a4-6bce4b482be8"
+                     }
+                  ]
+               }
+            }
+         ],
+         "leader" : "04834nam a2200529 i 4500"
+      }
+   ]
+}

--- a/spec/lib/folio_holding_spec.rb
+++ b/spec/lib/folio_holding_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe FolioItem do
 
     let(:item_note) { [{ 'note' => 'note 1', 'staffOnly' => false, 'itemNoteTypeId' => '', 'itemNoteTypeName' => 'Public' }] }
     let(:holding_notes) { [{ 'note' => 'note 2', 'staffOnly' => false, 'itemNoteTypeId' => '', 'holdingsNoteTypeName' => 'Public' }] }
-    subject(:public_note) { described_class.new(item:, holding:, bound_with:).public_note }
+    subject(:public_note) { described_class.new(item:, holding:, bound_with_child: bound_with.present?).public_note }
     let(:bound_with) { nil }
 
     context 'with a bound-with item' do

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -381,6 +381,17 @@ RSpec.describe FolioRecord do
         end
       end
 
+      context 'for a record with multiple bound-with principals' do
+        let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('in00000064624.json'))), client) }
+
+        it 'includes all bound-with principals' do
+          expect(index_items.select(&:bound_with_principal?)).to contain_exactly(
+            have_attributes(id: '4ab67ace-b7d1-4a49-8405-5b464c42e27e'),
+            have_attributes(id: '8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8')
+          )
+        end
+      end
+
       context 'with Symphony migrated data without the right linkages between the bound-with holding and item' do
         let(:record) do
           {

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -268,8 +268,8 @@ RSpec.describe 'Browse nearby' do
 
     let(:index_items) do
       [
-        build(:dewey_holding, bound_with: true, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.5')),
-        build(:dewey_holding, bound_with: true, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.6'))
+        build(:dewey_holding, bound_with_child: true, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.5')),
+        build(:dewey_holding, bound_with_child: true, call_number: '630.654 .I39M', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => '630.654 .I39M V.5:NO.6'))
       ]
     end
 
@@ -302,7 +302,7 @@ RSpec.describe 'Browse nearby' do
 
     let(:index_items) do
       [
-        build(:dewey_holding, bound_with: true, call_number: 'AB1234', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => 'QA987 V.5:NO.5'))
+        build(:dewey_holding, bound_with_child: true, call_number: 'AB1234', enumeration: 'V.5:NO.1', holding: holding.merge('callNumber' => 'QA987 V.5:NO.5'))
       ]
     end
 

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe 'ItemInfo config' do
 
         before do
           allow(folio_record).to receive(:item_holdings).and_return([])
-          allow(folio_record).to receive(:bound_with_holdings).and_return(holdings)
+          allow(folio_record).to receive(:bound_with_holdings_stub_items).and_return(holdings)
         end
 
         it 'contains a bound_with parent' do


### PR DESCRIPTION
We've had a couple bug reports (SW-4620, SW-4686, SW-4687) recently about missing bound-with information, and I hope it all boils down to a mistake in how we're figuring out if an item is a bound-with parent. We've assumed a holdings record only has one bound-with (which is true for the bound-with child), but bound-with parents have a bound-with entry for each item.

I suspect there may be a better SQL query, but the internet seemed to think we'd have to add new, complex joins to get the right behavior... at least until we care to do more than flag the bound-with-ness of the principal, maybe this will do.