### PR TITLE
Display volume-only items without indexing them as call numbers

### DIFF
--- a/lib/folio_item.rb
+++ b/lib/folio_item.rb
@@ -198,14 +198,16 @@ class FolioItem
                          @holding&.dig('callNumber') ||
                          bound_with&.dig('holding', 'callNumber')
 
-    return CallNumber.new('', '') unless base_call_number.present?
-
     if @item
-      volume_info_parts = [@item['volume'], @item['enumeration'], @item['chronology']].compact
+      volume_info_parts = [@item['volume'], @item['enumeration'], @item['chronology']].filter_map(&:presence)
       # For SUDOCs, the volume/enumeration/chronology fields are sometimes duplicated in the call number itself
-      volume_info_parts = volume_info_parts.reject { |part| base_call_number.include?(part) } if call_number_type == 'SUDOC'
+      volume_info_parts = volume_info_parts.reject { |part| base_call_number.include?(part) } if call_number_type == 'SUDOC' && base_call_number.present?
       volume_info = normalize_call_number(volume_info_parts.join(' ').presence)
     end
+
+    base_call_number = nil if volume_info.present? && CallNumber::SKIPPED_CALL_NUMS.include?(base_call_number.to_s)
+
+    return CallNumber.new('', '', volume_info:, library:) unless base_call_number.present?
 
     if bound_with?
       # bound-withs are a special case; the call number for the holding includes the base call number and any volume information. We can try
@@ -308,11 +310,23 @@ class FolioItem
     def call_number
       separator = volume_info.present? && volume_info.start_with?(/(\s|[[:punct:]])/) ? '' : ' '
 
-      [base_call_number.to_s, volume_info].compact.join(separator)
+      [base_call_number.presence, volume_info.presence].compact.join(separator)
     end
 
+    def volume_only?
+      base_call_number.blank? && volume_info.present?
+    end
+
+    def volume_sort_key(serial: false)
+      return unless volume_only?
+
+      CallNumbers::OtherShelfkey.new('', volume_info, serial:).forward
+    end
+
+    # The call number may be displayed, but it must not be treated as a real base call number for derived behavior
     def ignored_call_number?
-      SKIPPED_CALL_NUMS.include?(call_number.to_s) ||
+      base_call_number.blank? ||
+        SKIPPED_CALL_NUMS.include?(call_number.to_s) ||
         temp_call_number?
     end
 

--- a/lib/traject/config/folio_config.rb
+++ b/lib/traject/config/folio_config.rb
@@ -1063,7 +1063,7 @@ end
 #   the call number type in the 999w == ALPHANUM and the library in the 999m == SPEC-COLL.
 #  */
 def spec_coll_item?(item)
-  item.library == 'SPEC-COLL' && item.call_number_type == 'ALPHANUM' && item.call_number.to_s =~ /^(A\d|F\d|M\d|MISC \d|(MSS (CODEX|MEDIA|PHOTO|PRINTS))|PC\d|SC[\d|DM]|V\d)/i
+  !item.call_number.ignored_call_number? && item.library == 'SPEC-COLL' && item.call_number_type == 'ALPHANUM' && item.call_number.to_s =~ /^(A\d|F\d|M\d|MISC \d|(MSS (CODEX|MEDIA|PHOTO|PRINTS))|PC\d|SC[\d|DM]|V\d)/i
 end
 
 to_field 'format_main_ssim' do |record, accumulator, context|
@@ -1168,6 +1168,8 @@ end
 # * INDEX-89 - Add video physical formats
 to_field 'format_physical_ssim' do |record, accumulator, context|
   items(record, context).each do |item|
+    next if item.call_number.ignored_call_number?
+
     call_number = item.call_number.to_s
 
     accumulator << 'Blu-ray' if call_number.include?('BLU-RAY')
@@ -1284,10 +1286,10 @@ to_field 'format_physical_ssim', extract_marc('300a:338a', alternate_script: fal
 end
 
 to_field 'format_physical_ssim' do |record, accumulator, context|
-  if items(record, context).any? { |item| item.call_number.to_s.start_with? 'MFICHE' }
+  if items(record, context).any? { |item| !item.call_number.ignored_call_number? && item.call_number.to_s.start_with?('MFICHE') }
     accumulator << 'Microfiche'
   end
-  if items(record, context).any? { |item| item.call_number.to_s.start_with? 'MFILM' }
+  if items(record, context).any? { |item| !item.call_number.ignored_call_number? && item.call_number.to_s.start_with?('MFILM') }
     accumulator << 'Microfilm'
   end
 end
@@ -2159,24 +2161,27 @@ to_field 'item_display_struct' do |record, accumulator, context|
     next if item.skipped?
 
     call_number = item.call_number.to_s
-    volume_sort = item.call_number.shelfkey(serial:).forward
-    lopped_call_number = item.call_number.base_call_number
 
     if item.shelved_by_text
       shelved_by_text = item.shelved_by_text
 
-      call_number = [shelved_by_text, item.call_number.volume_info].compact.join(' ')
+      call_number = [shelved_by_text, item.call_number.volume_info].filter_map(&:presence).join(' ')
     end
 
-    call_number_data = if item.call_number.ignored_call_number?
+    call_number_data = if item.call_number.volume_only?
+                         {
+                           callnumber: call_number,
+                           full_shelfkey: item.call_number.volume_sort_key(serial:)
+                         }
+                       elsif item.call_number.ignored_call_number?
                          {
                            callnumber: call_number
                          }
                        else
                          {
-                           lopped_callnumber: lopped_call_number,
+                           lopped_callnumber: item.call_number.base_call_number,
                            callnumber: call_number,
-                           full_shelfkey: volume_sort
+                           full_shelfkey: item.call_number.shelfkey(serial:).forward
                          }
                        end
 
@@ -2197,6 +2202,7 @@ to_field 'browse_nearby_struct' do |record, accumulator, context|
   serial = (context.output_hash['format_main_ssim'] || []).include?('Journal/Periodical')
   grouped_items = items(record, context)
                   .reject(&:skipped?)
+                  .reject { |item| item.call_number.ignored_call_number? }
                   .select { |item| item.call_number.to_s.present? && CALL_TYPE.include?(item.call_number.type) }
                   .group_by { |item| item.call_number.base_call_number }
 
@@ -2231,6 +2237,7 @@ to_field 'browse_nearby_struct' do |record, accumulator, context|
   # weren't the right type (e.g. SUDOC)
   next if items(record, context)
           .reject(&:skipped?)
+          .reject { |item| item.call_number.ignored_call_number? }
           .any? { |item| item.call_number.to_s.present? && !ERESOURCE_CALL_TYPE.include?(item.call_number.type) }
 
   callnumber = begin

--- a/spec/lib/folio_holding_spec.rb
+++ b/spec/lib/folio_holding_spec.rb
@@ -100,16 +100,82 @@ RSpec.describe FolioItem do
   end
 
   describe '#call_number' do
-    subject(:call_number) { described_class.new(item:, holding: {}).call_number }
+    subject(:call_number) { described_class.new(item:, holding:).call_number }
 
-    let(:item) do
-      {
-        call_number: ''
-      }.with_indifferent_access
+    let(:holding) { {}.with_indifferent_access }
+    let(:item) { { call_number: '' }.with_indifferent_access }
+
+    it 'is blank when there is no base call number or volume information' do
+      expect(call_number.to_s).to eq ''
+      expect(call_number).to be_temp_call_number
+      expect(call_number).to be_ignored_call_number
     end
 
-    it 'is the effective location library code' do
-      expect(call_number.to_s).to eq ''
+    context 'with volume information but no base call number' do
+      let(:holding) { { callNumber: '' }.with_indifferent_access }
+      let(:item) do
+        {
+          callNumber: { typeName: 'Title' },
+          callNumberType: { name: 'Title' },
+          volume: '',
+          enumeration: 'v. 20',
+          chronology: '2004 JA-JE'
+        }.with_indifferent_access
+      end
+
+      it 'uses the volume information as the display call number' do
+        expect(call_number).to have_attributes(
+          base_call_number: '',
+          volume_info: 'v. 20 2004 JA-JE'
+        )
+        expect(call_number.to_s).to eq 'v. 20 2004 JA-JE'
+        expect(call_number).to be_volume_only
+        expect(call_number).not_to be_temp_call_number
+        expect(call_number).to be_ignored_call_number
+      end
+
+      it 'sorts newer serial volume information first' do
+        newer_call_number = described_class.new(
+          item: item.merge(enumeration: 'v. 21', chronology: '2005 JA-JE'),
+          holding:
+        ).call_number
+
+        expect(newer_call_number.volume_sort_key(serial: true)).to be < call_number.volume_sort_key(serial: true)
+      end
+    end
+
+    context 'with volume information and the no-call-number sentinel' do
+      let(:item) do
+        {
+          callNumber: { callNumber: 'NO CALL NUMBER' },
+          callNumberType: { name: 'LC' },
+          enumeration: 'v. 20',
+          chronology: '2004 JA-JE'
+        }.with_indifferent_access
+      end
+
+      it 'uses the volume information as the display call number' do
+        expect(call_number).to have_attributes(
+          base_call_number: '',
+          volume_info: 'v. 20 2004 JA-JE'
+        )
+        expect(call_number.to_s).to eq 'v. 20 2004 JA-JE'
+        expect(call_number).to be_volume_only
+        expect(call_number).to be_ignored_call_number
+      end
+    end
+
+    context 'with a base call number and punctuation-prefixed volume information' do
+      let(:item) do
+        {
+          callNumber: { callNumber: 'ABC 123' },
+          enumeration: '.V.2'
+        }.with_indifferent_access
+      end
+
+      it 'preserves the existing separator behavior' do
+        expect(call_number.to_s).to eq 'ABC 123.V.2'
+      end
     end
   end
 

--- a/spec/lib/traject/config/browse_nearby_spec.rb
+++ b/spec/lib/traject/config/browse_nearby_spec.rb
@@ -79,6 +79,48 @@ RSpec.describe 'Browse nearby' do
     end
   end
 
+  context 'when the item has volume information but no base call number' do
+    before do
+      allow(folio_record).to receive(:index_items).and_return([
+                                                                build(:alphanum_holding,
+                                                                      call_number: nil,
+                                                                      holding: { 'callNumber' => '' },
+                                                                      additional_item_attributes: {
+                                                                        'enumeration' => 'v. 20',
+                                                                        'chronology' => '2004 JA-JE'
+                                                                      })
+                                                              ])
+    end
+
+    it { is_expected.to be_blank }
+  end
+
+  context 'when an e-resource also has an item with volume information but no base call number' do
+    let(:record) do
+      MARC::Record.new.tap do |r|
+        r.leader = '15069nam a2200409 a 4500'
+        r.append(MARC::DataField.new('050', ' ', '0',
+                                     MARC::Subfield.new('a', 'F1356'),
+                                     MARC::Subfield.new('b', '.M464 2005')))
+      end
+    end
+
+    before do
+      allow(folio_record).to receive_messages(
+        eresource?: true,
+        electronic_holdings: [],
+        index_items: [build(:alphanum_holding,
+                            call_number: nil,
+                            holding: { 'callNumber' => '' },
+                            additional_item_attributes: { 'enumeration' => 'v. 20' })]
+      )
+    end
+
+    it 'retains the MARC call-number fallback' do
+      expect(result).to contain_exactly(hash_including('lopped_callnumber' => 'F1356 .M464 2005'))
+    end
+  end
+
   context 'with some Dewey call numbers of a multi-volume monograph' do
     before do
       allow(folio_record).to receive(:index_items).and_return(index_items)

--- a/spec/lib/traject/config/callnum_facet_spec.rb
+++ b/spec/lib/traject/config/callnum_facet_spec.rb
@@ -78,6 +78,15 @@ RSpec.describe 'Call Number Facet' do
       expect(record_with_holdings(item: { 'callNumberType' => { 'name' => 'DEWEY' }, 'callNumber' => { 'callNumber' => '. . ' } }, indexer:)[field]).to be_nil
     end
 
+    it 'does not classify volume information without a base call number' do
+      expect(record_with_holdings(item: {
+                                    'callNumberType' => { 'name' => 'LC' },
+                                    'callNumber' => { 'callNumber' => nil },
+                                    'enumeration' => 'v. 20',
+                                    'chronology' => '2004 JA-JE'
+                                  }, indexer:)[field]).to be_nil
+    end
+
     it 'does not return call nubmers typed as Alphanum, and clearly not LC or Dewey' do
       expect(record_with_holdings(item: { 'callNumberType' => { 'name' => 'Shelving control number' }, 'callNumber' => { 'callNumber' => '71 15446 V.1' } }, indexer:)[field]).to be_nil
       expect(record_with_holdings(item: { 'callNumberType' => { 'name' => 'Shelving control number' }, 'callNumber' => { 'callNumber' => '4488.301 0300 2001 CD-ROM' } },

--- a/spec/lib/traject/config/callnumber_spec.rb
+++ b/spec/lib/traject/config/callnumber_spec.rb
@@ -150,6 +150,27 @@ RSpec.describe 'Call Numbers' do
 
       it { is_expected.to be_nil }
     end
+
+    context 'when call number is NO CALL NUMBER with volume information' do
+      let(:holdings) do
+        [build(:lc_holding,
+               call_number: 'NO CALL NUMBER',
+               additional_item_attributes: { 'enumeration' => 'v. 20', 'chronology' => '2004 JA-JE' })]
+      end
+
+      it { is_expected.to be_nil }
+    end
+
+    context 'when there is volume information but no base call number' do
+      let(:holdings) do
+        [build(:lc_holding,
+               call_number: nil,
+               holding: { 'callNumber' => '' },
+               additional_item_attributes: { 'enumeration' => 'v. 20', 'chronology' => '2004 JA-JE' })]
+      end
+
+      it { is_expected.to be_nil }
+    end
   end
 
   describe 'alphanum_callnum_search' do
@@ -242,6 +263,17 @@ RSpec.describe 'Call Numbers' do
       end
 
       it { is_expected.to include('ISHII SPRING 2009', 'ISHII') }
+    end
+
+    context 'with volume information but no base call number' do
+      let(:holdings) do
+        [build(:alphanum_holding,
+               call_number: nil,
+               holding: { 'callNumber' => '' },
+               additional_item_attributes: { 'enumeration' => 'v. 20', 'chronology' => '2004 JA-JE' })]
+      end
+
+      it { is_expected.to be_nil }
     end
   end
 

--- a/spec/lib/traject/config/format_physical_spec.rb
+++ b/spec/lib/traject/config/format_physical_spec.rb
@@ -10,6 +10,34 @@ RSpec.describe 'Format physical config' do
   let(:folio_record) { marc_to_folio(record) }
   let(:field) { 'format_physical_ssim' }
 
+  context 'when a format-like call number is ignored' do
+    let(:record) { MARC::Record.new }
+
+    %w[ZDVD MFILM].each do |call_number|
+      it "skips an ignored #{call_number} call number" do
+        item = build(:alphanum_holding, call_number:)
+        allow(item.call_number).to receive(:ignored_call_number?).and_return(true)
+        allow(folio_record).to receive(:index_items).and_return([item])
+
+        expect(result[field]).to be_nil
+      end
+    end
+  end
+
+  context 'when volume information is attached to the no-call-number sentinel' do
+    let(:record) { MARC::Record.new }
+
+    it 'does not infer a format from the volume information' do
+      allow(folio_record).to receive(:index_items).and_return([
+                                                                build(:alphanum_holding,
+                                                                      call_number: 'NO CALL NUMBER',
+                                                                      additional_item_attributes: { 'enumeration' => 'ZDVD' })
+                                                              ])
+
+      expect(result[field]).to be_nil
+    end
+  end
+
   context 'with 007/00 = m (Film)' do
     let(:record) do
       MARC::Record.new.tap do |r|

--- a/spec/lib/traject/config/item_info_spec.rb
+++ b/spec/lib/traject/config/item_info_spec.rb
@@ -485,6 +485,47 @@ RSpec.describe 'ItemInfo config' do
       }
     end
 
+    describe 'volume information without a base call number' do
+      let(:record) do
+        MARC::Record.new.tap do |r|
+          r.leader = '02334cas a2200625Ei 4500'
+          r.append(MARC::ControlField.new('008', '860725c19859999nyumr p       0   a0eng d'))
+        end
+      end
+      let(:holdings) do
+        [
+          build(:alphanum_holding,
+                barcode: 'older',
+                call_number: nil,
+                holding: { 'callNumber' => '' },
+                additional_item_attributes: {
+                  'callNumber' => { 'typeName' => 'Title' },
+                  'enumeration' => 'v. 20',
+                  'chronology' => '2004 JA-JE'
+                }),
+          build(:alphanum_holding,
+                barcode: 'newer',
+                call_number: nil,
+                holding: { 'callNumber' => '' },
+                additional_item_attributes: {
+                  'callNumber' => { 'typeName' => 'Title' },
+                  'enumeration' => 'v. 21',
+                  'chronology' => '2005 JA-JE'
+                })
+        ]
+      end
+
+      it 'emits display call numbers and sort keys without browseable base call-number data' do
+        items_by_barcode = value.index_by { |item| item.fetch('barcode') }
+
+        expect(items_by_barcode.fetch('older')).to include('callnumber' => 'v. 20 2004 JA-JE')
+        expect(items_by_barcode.fetch('newer')).to include('callnumber' => 'v. 21 2005 JA-JE')
+        expect(items_by_barcode.values).to all(include('full_shelfkey'))
+        expect(items_by_barcode.values).to all(satisfy { |item| !item.key?('lopped_callnumber') })
+        expect(items_by_barcode.fetch('newer').fetch('full_shelfkey')).to be < items_by_barcode.fetch('older').fetch('full_shelfkey')
+      end
+    end
+
     describe 'volsort/full shelfkey' do
       context 'LC' do
         let(:record) do

--- a/spec/lib/traject/config/preferred_barcode_spec.rb
+++ b/spec/lib/traject/config/preferred_barcode_spec.rb
@@ -395,6 +395,18 @@ RSpec.describe 'All_search config' do
     it { is_expected.to eq nil }
   end
 
+  context 'with volume information but no base call number' do
+    let(:index_items) do
+      [build(:alphanum_holding,
+             barcode: 'volume-only',
+             call_number: nil,
+             holding: { 'callNumber' => '' },
+             additional_item_attributes: { 'enumeration' => 'v. 20', 'chronology' => '2004 JA-JE' })]
+    end
+
+    it { is_expected.to be_nil }
+  end
+
   context 'with a shelby location' do
     let(:index_items) do
       [


### PR DESCRIPTION
For items like https://searchworks.stanford.edu/view/L222 that currently display `(no call number)`, we noticed Requests uses the volume information which seems like nicer behavior for the user.

Before:
<img width="312" height="389" alt="Screenshot 2026-08-06 at 10 08 32 AM" src="https://github.com/user-attachments/assets/c58c0087-d424-4814-849e-1dc677ca77b2" />

After:
<img width="319" height="412" alt="Screenshot 2026-08-06 at 10 08 16 AM" src="https://github.com/user-attachments/assets/2d491873-9a70-4c34-8061-c0a631ab7daa" />

This requires a fair number of spec guards to protect ourselves. I think it's okay-ish, but wouldn't be upset if folks thought we needed to explore refactors first (e.g., split out some concept of `indexable?`, `browseable?`, `displayable?` rather than leaning on ignored).