### PR TITLE
Extract bound-with query to get it out of holding

### DIFF
--- a/lib/folio/holding.rb
+++ b/lib/folio/holding.rb
@@ -2,21 +2,26 @@
 
 module Folio
   class Holding
-    attr_reader :data, :pieces, :items
+    attr_reader :data, :pieces, :items, :bound_with_principal
 
     delegate :[], :fetch, :dig, :as_json, :to_json, to: :data
 
-    def self.from_dynamic(holding, items: [], pieces: [])
+    def self.from_dynamic(holding, items: [], pieces: [], bound_with_principals: [], bound_with_parts: [])
       this_pieces = pieces.select { |p| p['holdingId'] == holding['id'] }
       this_items = items.select { |i| i['holdingsRecordId'] == holding['id'] }
+      bound_with_link = bound_with_parts.find { |p| p['holdingsRecordId'] == holding['id'] }
+      bound_with_principal = bound_with_principals.find { |p| p.dig('item', 'id') == bound_with_link['itemId'] } if bound_with_link
 
-      new(holding, pieces: this_pieces, items: this_items)
+      new(holding, pieces: this_pieces, items: this_items, bound_with_principal: bound_with_principal)
     end
 
-    def initialize(data, pieces: [], items: [])
+    def initialize(data, pieces: [], items: [], bound_with_principal: nil)
       @data = data
+      # keep the bound-with data in the original data structure (for now) to avoid breaking existings tests + code
+      @data = @data.merge('boundWith' => bound_with_principal) if bound_with_principal
       @pieces = pieces
       @items = items
+      @bound_with_principal = bound_with_principal
     end
 
     def electronic?
@@ -40,6 +45,7 @@ module Folio
 
     def bound_with_parent_exists?
       return false unless data.dig('boundWith', 'item', 'id')
+      return false if data.dig('boundWith', 'item', 'suppressFromDiscovery')
 
       # bound-with "principals" appear as if they're bound-with themselves. See SW-4330.
       !data.dig('boundWith', 'item', 'id').in?(items.map { |item| item['id'] })

--- a/lib/folio_record.rb
+++ b/lib/folio_record.rb
@@ -198,11 +198,15 @@ class FolioRecord
   end
 
   def all_holdings
-    @all_holdings ||= load('holdings').uniq { |x| x['id'] }.map { |x| Folio::Holding.from_dynamic(x, items: all_items, pieces: pieces) }
+    @all_holdings ||= load('holdings').map { |x| Folio::Holding.from_dynamic(x, items: all_items, bound_with_principals: bound_with_principals, bound_with_parts: bound_with_parts, pieces: pieces) }
   end
 
   def bound_with_parts
     @bound_with_parts ||= record['bound_with_parts'] || []
+  end
+
+  def bound_with_principals
+    @bound_with_principals ||= record['bound_with_principals'] || []
   end
 
   def items_and_holdings

--- a/lib/traject/readers/folio_postgres_reader.rb
+++ b/lib/traject/readers/folio_postgres_reader.rb
@@ -128,14 +128,16 @@ module Traject
           'permanentLocation' => locations[holding['permanentLocationId']],
           'temporaryLocation' => locations[holding['temporaryLocationId']]
         }.compact
+      end
 
-        holding['boundWith']['holding']['location'] = {
-          'effectiveLocation' => locations[holding['boundWith']['holding']['effectiveLocationId']]
-        } if holding.dig('boundWith', 'holding', 'effectiveLocationId')
+      data['bound_with_principals'].each do |bw|
+        bw['holding']['location'] = {
+          'effectiveLocation' => locations[bw['holding']['effectiveLocationId']]
+        } if bw.dig('holding', 'effectiveLocationId')
 
-        holding['boundWith']['item']['location'] = {
-          'effectiveLocation' => locations[holding['boundWith']['item']['effectiveLocationId']]
-        } if holding.dig('boundWith', 'item', 'effectiveLocationId')
+        bw['item']['location'] = {
+          'effectiveLocation' => locations[bw['item']['effectiveLocationId']]
+        } if bw.dig('item', 'effectiveLocationId')
       end
     end
 
@@ -418,50 +420,48 @@ module Traject
                         'callNumberType', hrcnt.jsonb - 'metadata',
                         'electronicAccess', COALESCE(sul_mod_inventory_storage.getElectronicAccessName(COALESCE(hr.jsonb #> '{electronicAccess}', '[]'::jsonb)), '[]'::jsonb),
                         'notes', COALESCE((SELECT jsonb_agg(e || jsonb_build_object('holdingsNoteTypeName', ( SELECT jsonb ->> 'name' FROM sul_mod_inventory_storage.holdings_note_type WHERE id = nullif(e ->> 'holdingsNoteTypeId','')::uuid ))) FROM jsonb_array_elements(hr.jsonb -> 'notes') AS e WHERE NOT COALESCE((e ->> 'staffOnly')::bool, false)), '[]'::jsonb),
-                        'illPolicy', ilp.jsonb - 'metadata',
-                        'boundWith',
-                          CASE WHEN parentItem.id IS NOT NULL THEN
-                            jsonb_build_object(
-                              'instance', jsonb_build_object(
-                                'id', parentInstance.id,
-                                'hrid', parentInstance.jsonb ->> 'hrid',
-                                'title', parentInstance.jsonb ->> 'title',
-                                'suppressFromDiscovery', COALESCE((parentInstance.jsonb ->> 'discoverySuppress')::bool, false)
-                              ),
-                              'holding', jsonb_build_object(
-                                'effectiveLocationId', parentHolding.jsonb ->> 'effectiveLocationId',
-                                'suppressFromDiscovery',
-                                CASE WHEN parentHolding.id IS NOT NULL THEN
-                                  COALESCE((parentInstance.jsonb ->> 'discoverySuppress')::bool, false) OR
-                                  COALESCE((parentHolding.jsonb ->> 'discoverySuppress')::bool, false)
-                                ELSE NULL END::bool
-                              ),
-                              'item', jsonb_build_object(
-                                'id', parentItem.id,
-                                'hrid', parentItem.jsonb ->> 'hrid',
-                                'barcode', parentItem.jsonb ->> 'barcode',
-                                'callNumber', parentItem.jsonb -> 'effectiveCallNumberComponents',
-                                'status', parentItem.jsonb #>> '{status, name}',
-                                'enumeration', parentItem.jsonb->>'enumeration',
-                                'volume', parentItem.jsonb->>'volume',
-                                'chronology', parentItem.jsonb->>'chronology',
-                                'effectiveLocationId', parentItem.jsonb ->> 'effectiveLocationId',
-                                'materialTypeId', parentItem.jsonb ->> 'materialTypeId',
-                                'permanentLoanTypeId', parentItem.jsonb ->> 'permanentLoanTypeId',
-                                'temporaryLoanTypeId', parentItem.jsonb ->> 'temporaryLoanTypeId',
-                                'suppressFromDiscovery',
-                                CASE WHEN parentItem.id IS NOT NULL THEN
-                                  COALESCE((parentInstance.jsonb ->> 'discoverySuppress')::bool, false) OR
-                                  COALESCE((parentHolding.jsonb ->> 'discoverySuppress')::bool, false) OR
-                                  COALESCE((parentItem.jsonb ->> 'discoverySuppress')::bool, false)
-                                ELSE NULL END::bool
-                              )
-                            )
-                          ELSE NULL END::jsonb
+                        'illPolicy', ilp.jsonb - 'metadata'
                   )
                 ) FILTER (WHERE hr.id IS NOT NULL), '[]'::jsonb
               ),
             'po_lines', COUNT(po_line.id),
+            'bound_with_principals', jsonb_agg(DISTINCT jsonb_build_object(
+              'instance', jsonb_build_object(
+                'id', parentInstance.id,
+                'hrid', parentInstance.jsonb ->> 'hrid',
+                'title', parentInstance.jsonb ->> 'title',
+                'suppressFromDiscovery', COALESCE((parentInstance.jsonb ->> 'discoverySuppress')::bool, false)
+              ),
+              'holding', jsonb_build_object(
+                'id', parentHolding.id,
+                'effectiveLocationId', parentHolding.jsonb ->> 'effectiveLocationId',
+                'suppressFromDiscovery',
+                CASE WHEN parentHolding.id IS NOT NULL THEN
+                  COALESCE((parentInstance.jsonb ->> 'discoverySuppress')::bool, false) OR
+                  COALESCE((parentHolding.jsonb ->> 'discoverySuppress')::bool, false)
+                ELSE NULL END::bool
+              ),
+              'item', jsonb_build_object(
+                'id', parentItem.id,
+                'hrid', parentItem.jsonb ->> 'hrid',
+                'barcode', parentItem.jsonb ->> 'barcode',
+                'callNumber', parentItem.jsonb -> 'effectiveCallNumberComponents',
+                'status', parentItem.jsonb #>> '{status, name}',
+                'enumeration', parentItem.jsonb->>'enumeration',
+                'volume', parentItem.jsonb->>'volume',
+                'chronology', parentItem.jsonb->>'chronology',
+                'effectiveLocationId', parentItem.jsonb ->> 'effectiveLocationId',
+                'materialTypeId', parentItem.jsonb ->> 'materialTypeId',
+                'permanentLoanTypeId', parentItem.jsonb ->> 'permanentLoanTypeId',
+                'temporaryLoanTypeId', parentItem.jsonb ->> 'temporaryLoanTypeId',
+                'suppressFromDiscovery',
+                CASE WHEN parentItem.id IS NOT NULL THEN
+                  COALESCE((parentInstance.jsonb ->> 'discoverySuppress')::bool, false) OR
+                  COALESCE((parentHolding.jsonb ->> 'discoverySuppress')::bool, false) OR
+                  COALESCE((parentItem.jsonb ->> 'discoverySuppress')::bool, false)
+                ELSE NULL END::bool
+              )
+            )) FILTER (WHERE parentItem.id IS NOT NULL),
             'bound_with_parts', jsonb_agg(DISTINCT bw.jsonb || jsonb_build_object('instanceId', parentInstance.id)) FILTER (WHERE bw.id IS NOT NULL)
             )
       FROM sul_mod_inventory_storage.instance vi

--- a/spec/fixtures/files/in00000064624.json
+++ b/spec/fixtures/files/in00000064624.json
@@ -21,6 +21,68 @@
          }
       }
    ],
+   "bound_with_principals" : [
+      {
+         "holding" : {
+            "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+            "suppressFromDiscovery" : false
+         },
+         "instance" : {
+            "hrid" : "in00000064624",
+            "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+            "suppressFromDiscovery" : false,
+            "title" : "[Collection of Restoration plays]"
+         },
+         "item" : {
+            "barcode" : "36105244284563",
+            "callNumber" : {
+               "callNumber" : "PR1266.C65 1670",
+               "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
+            },
+            "chronology" : null,
+            "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+            "enumeration" : "v.2",
+            "hrid" : "it00000479304",
+            "id" : "4ab67ace-b7d1-4a49-8405-5b464c42e27e",
+            "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+            "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+            "status" : "In process (non-requestable)",
+            "suppressFromDiscovery" : false,
+            "temporaryLoanTypeId" : null,
+            "volume" : null
+         }
+      },
+      {
+         "holding" : {
+            "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
+            "suppressFromDiscovery" : false
+         },
+         "instance" : {
+            "hrid" : "in00000064624",
+            "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
+            "suppressFromDiscovery" : false,
+            "title" : "[Collection of Restoration plays]"
+         },
+         "item" : {
+            "barcode" : "36105236764440",
+            "callNumber" : {
+               "callNumber" : "PR1266.C65 1670",
+               "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
+            },
+            "chronology" : null,
+            "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
+            "enumeration" : "v.1",
+            "hrid" : "it00000080179",
+            "id" : "8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8",
+            "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+            "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
+            "status" : "In process (non-requestable)",
+            "suppressFromDiscovery" : false,
+            "temporaryLoanTypeId" : null,
+            "volume" : null
+         }
+      }
+   ],
    "holdingSummaries" : [
       {
          "orderCloseReason" : {
@@ -38,258 +100,6 @@
       {
          "_version" : 2,
          "administrativeNotes" : [],
-         "boundWith" : {
-            "holding" : {
-               "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-               "location" : {
-                  "effectiveLocation" : {
-                     "campus" : {
-                        "code" : "SUL",
-                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
-                        "name" : "Stanford Libraries"
-                     },
-                     "code" : "SPEC-RARE-BOOKS",
-                     "details" : {
-                        "pageAeonSite" : "SPECUA"
-                     },
-                     "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-                     "institution" : {
-                        "code" : "SU",
-                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                        "name" : "Stanford University"
-                     },
-                     "isActive" : true,
-                     "library" : {
-                        "code" : "SPEC-COLL",
-                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
-                        "name" : "Special Collections"
-                     },
-                     "name" : "Rare Books Collection"
-                  }
-               },
-               "suppressFromDiscovery" : false
-            },
-            "instance" : {
-               "hrid" : "in00000064624",
-               "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
-               "suppressFromDiscovery" : false,
-               "title" : "[Collection of Restoration plays]"
-            },
-            "item" : {
-               "barcode" : "36105244284563",
-               "callNumber" : {
-                  "callNumber" : "PR1266.C65 1670",
-                  "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
-               },
-               "chronology" : null,
-               "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
-               "enumeration" : "v.2",
-               "hrid" : "it00000479304",
-               "id" : "4ab67ace-b7d1-4a49-8405-5b464c42e27e",
-               "location" : {
-                  "effectiveLocation" : {
-                     "campus" : {
-                        "code" : "SUL",
-                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
-                        "name" : "Stanford Libraries"
-                     },
-                     "code" : "SPEC-INPROCESS-RWC",
-                     "details" : {
-                        "availabilityClass" : "In_process_non_requestable"
-                     },
-                     "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
-                     "institution" : {
-                        "code" : "SU",
-                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                        "name" : "Stanford University"
-                     },
-                     "isActive" : true,
-                     "library" : {
-                        "code" : "SPEC-COLL",
-                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
-                        "name" : "Special Collections"
-                     },
-                     "name" : "In process"
-                  }
-               },
-               "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
-               "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-               "status" : "In process (non-requestable)",
-               "suppressFromDiscovery" : false,
-               "temporaryLoanTypeId" : null,
-               "volume" : null
-            }
-         },
-         "callNumber" : "PR1266.C65 1670",
-         "callNumberType" : {
-            "id" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
-            "name" : "Library of Congress classification",
-            "source" : "system"
-         },
-         "callNumberTypeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d",
-         "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-         "electronicAccess" : [],
-         "formerIds" : [],
-         "holdingsStatements" : [],
-         "holdingsStatementsForIndexes" : [],
-         "holdingsStatementsForSupplements" : [],
-         "holdingsType" : {
-            "id" : "5684e4a3-9279-4463-b6ee-20ae21bbec07",
-            "name" : "Book",
-            "source" : "local"
-         },
-         "holdingsTypeId" : "5684e4a3-9279-4463-b6ee-20ae21bbec07",
-         "hrid" : "ho00000079375",
-         "id" : "212b61ac-a336-4b07-a780-01a49c878f04",
-         "illPolicy" : null,
-         "instanceId" : "7d747c3e-c166-4829-89d6-a5355acf098a",
-         "location" : {
-            "effectiveLocation" : {
-               "campus" : {
-                  "code" : "SUL",
-                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
-                  "name" : "Stanford Libraries"
-               },
-               "code" : "SPEC-RARE-BOOKS",
-               "details" : {
-                  "pageAeonSite" : "SPECUA"
-               },
-               "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-               "institution" : {
-                  "code" : "SU",
-                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                  "name" : "Stanford University"
-               },
-               "isActive" : true,
-               "library" : {
-                  "code" : "SPEC-COLL",
-                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
-                  "name" : "Special Collections"
-               },
-               "name" : "Rare Books Collection"
-            },
-            "permanentLocation" : {
-               "campus" : {
-                  "code" : "SUL",
-                  "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
-                  "name" : "Stanford Libraries"
-               },
-               "code" : "SPEC-RARE-BOOKS",
-               "details" : {
-                  "pageAeonSite" : "SPECUA"
-               },
-               "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-               "institution" : {
-                  "code" : "SU",
-                  "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                  "name" : "Stanford University"
-               },
-               "isActive" : true,
-               "library" : {
-                  "code" : "SPEC-COLL",
-                  "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
-                  "name" : "Special Collections"
-               },
-               "name" : "Rare Books Collection"
-            }
-         },
-         "metadata" : {
-            "createdByUserId" : "7ced6673-ff0d-4619-997d-34c41d17baec",
-            "createdDate" : "2024-03-05T17:08:19.509Z",
-            "updatedByUserId" : "b8585498-1d18-4269-8044-1a44fb8bcaa6",
-            "updatedDate" : "2026-07-24T18:55:53.902Z"
-         },
-         "notes" : [],
-         "permanentLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-         "sourceId" : "f32d531e-df79-46b3-8932-cdd35f7a2264",
-         "statisticalCodeIds" : [],
-         "suppressFromDiscovery" : false
-      },
-      {
-         "_version" : 2,
-         "administrativeNotes" : [],
-         "boundWith" : {
-            "holding" : {
-               "effectiveLocationId" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-               "location" : {
-                  "effectiveLocation" : {
-                     "campus" : {
-                        "code" : "SUL",
-                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
-                        "name" : "Stanford Libraries"
-                     },
-                     "code" : "SPEC-RARE-BOOKS",
-                     "details" : {
-                        "pageAeonSite" : "SPECUA"
-                     },
-                     "id" : "271f84ab-47aa-40cc-b8a1-18a992bb6b88",
-                     "institution" : {
-                        "code" : "SU",
-                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                        "name" : "Stanford University"
-                     },
-                     "isActive" : true,
-                     "library" : {
-                        "code" : "SPEC-COLL",
-                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
-                        "name" : "Special Collections"
-                     },
-                     "name" : "Rare Books Collection"
-                  }
-               },
-               "suppressFromDiscovery" : false
-            },
-            "instance" : {
-               "hrid" : "in00000064624",
-               "id" : "7d747c3e-c166-4829-89d6-a5355acf098a",
-               "suppressFromDiscovery" : false,
-               "title" : "[Collection of Restoration plays]"
-            },
-            "item" : {
-               "barcode" : "36105236764440",
-               "callNumber" : {
-                  "callNumber" : "PR1266.C65 1670",
-                  "typeId" : "95467209-6d7b-468b-94df-0f5d7ad2747d"
-               },
-               "chronology" : null,
-               "effectiveLocationId" : "2065af65-904d-41bb-8db8-35bff753cf64",
-               "enumeration" : "v.1",
-               "hrid" : "it00000080179",
-               "id" : "8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8",
-               "location" : {
-                  "effectiveLocation" : {
-                     "campus" : {
-                        "code" : "SUL",
-                        "id" : "c365047a-51f2-45ce-8601-e421ca3615c5",
-                        "name" : "Stanford Libraries"
-                     },
-                     "code" : "SPEC-INPROCESS-RWC",
-                     "details" : {
-                        "availabilityClass" : "In_process_non_requestable"
-                     },
-                     "id" : "2065af65-904d-41bb-8db8-35bff753cf64",
-                     "institution" : {
-                        "code" : "SU",
-                        "id" : "8d433cdd-4e8f-4dc1-aa24-8a4ddb7dc929",
-                        "name" : "Stanford University"
-                     },
-                     "isActive" : true,
-                     "library" : {
-                        "code" : "SPEC-COLL",
-                        "id" : "5b61a365-6b39-408c-947d-f8861a7ba8ae",
-                        "name" : "Special Collections"
-                     },
-                     "name" : "In process"
-                  }
-               },
-               "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
-               "permanentLoanTypeId" : "52d7b849-b6d8-4fb3-b2ab-a9b0eb41b6fd",
-               "status" : "In process (non-requestable)",
-               "suppressFromDiscovery" : false,
-               "temporaryLoanTypeId" : null,
-               "volume" : null
-            }
-         },
          "callNumber" : "PR1266.C65 1670",
          "callNumberType" : {
             "id" : "95467209-6d7b-468b-94df-0f5d7ad2747d",

--- a/spec/lib/folio_record_spec.rb
+++ b/spec/lib/folio_record_spec.rb
@@ -355,9 +355,9 @@ RSpec.describe FolioRecord do
         let(:folio_record) { described_class.new(JSON.parse(File.read(file_fixture('in00000064624.json'))), client) }
 
         it 'includes all bound-with principals' do
-          expect(index_items.select(&:bound_with_principal?)).to contain_exactly(
-            have_attributes(id: '4ab67ace-b7d1-4a49-8405-5b464c42e27e'),
-            have_attributes(id: '8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8')
+          expect(index_items.select(&:bound_with_principal?).map(&:id)).to contain_exactly(
+            '4ab67ace-b7d1-4a49-8405-5b464c42e27e',
+            '8f15d3c4-985b-49ef-9a9c-bcc7c7ed4da8'
           )
         end
       end


### PR DESCRIPTION
We're currently  getting duplicate holdings records when there are multiple bound-with principals associated with a holdings record.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>